### PR TITLE
Release all codama packages as v1

### DIFF
--- a/.changeset/popular-cooks-dance.md
+++ b/.changeset/popular-cooks-dance.md
@@ -1,0 +1,17 @@
+---
+'@codama/errors': major
+'codama': major
+'@codama/node-types': major
+'@codama/nodes': major
+'@codama/nodes-from-anchor': major
+'@codama/renderers': major
+'@codama/renderers-core': major
+'@codama/renderers-js': major
+'@codama/renderers-js-umi': major
+'@codama/renderers-rust': major
+'@codama/validators': major
+'@codama/visitors': major
+'@codama/visitors-core': major
+---
+
+Publish codama v1 packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ env:
   # Among other things, opts out of Turborepo telemetry. See https://consoledonottrack.com/.
   DO_NOT_TRACK: '1'
   NODE_VERSION: 18
-  CODAMA_VERSION: 0.22
+  CODAMA_VERSION: 1.x
   SOLANA_VERSION: 1.18.12
 
 jobs:


### PR DESCRIPTION
This PR adds a **major** changeset for all packages such that the "Publish packages" publishes all codama packages as version `1.0.0`.