### PR TITLE
Fix missing semicolon in generated Rust code

### DIFF
--- a/.changeset/many-rules-peel.md
+++ b/.changeset/many-rules-peel.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-rust': patch
+---
+
+Fix missing semicolon in generated Rust code

--- a/packages/renderers-rust/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-rust/src/getTypeManifestVisitor.ts
@@ -163,7 +163,7 @@ export function getTypeManifestVisitor(options: {
                         return {
                             ...manifest,
                             nestedStructs,
-                            type: `pub type ${pascalCase(definedType.name)} = ${manifest.type}`,
+                            type: `pub type ${pascalCase(definedType.name)} = ${manifest.type};`,
                         };
                     }
 

--- a/packages/renderers-rust/test/types/array.test.ts
+++ b/packages/renderers-rust/test/types/array.test.ts
@@ -25,7 +25,7 @@ test('it exports short vecs', () => {
 
     // Then we expect a short vec to be exported.
     codeContains(renderMap.get('types/my_short_vec.rs'), [
-        /pub type MyShortVec = ShortVec<Pubkey>/,
+        /pub type MyShortVec = ShortVec<Pubkey>;/,
         /use solana_program::pubkey::Pubkey/,
         /use solana_program::short_vec::ShortVec/,
     ]);
@@ -52,7 +52,7 @@ test('it exports short vecs as struct fields', () => {
 
     // Then we expect a short vec to be exported as a struct field.
     codeContains(renderMap.get('types/my_short_vec.rs'), [
-        /pub value: ShortVec<Pubkey>/,
+        /pub value: ShortVec<Pubkey>,/,
         /use solana_program::pubkey::Pubkey/,
         /use solana_program::short_vec::ShortVec/,
     ]);


### PR DESCRIPTION
Currently, when generating Rust types that are not enums or structs, the semicolon at the end of the statement is missing. This PR fixes this.

```rs
// Before.
pub type MyShortVec = ShortVec<Pubkey>

// After.
pub type MyShortVec = ShortVec<Pubkey>;
```