### PR TITLE
Add support for verbatimModuleSyntax with the umi renderer

### DIFF
--- a/packages/renderers-js-umi/public/templates/sharedPage.njk
+++ b/packages/renderers-js-umi/public/templates/sharedPage.njk
@@ -2,7 +2,7 @@
 {% import "macros.njk" as macros %}
 
 {% block main %}
-import { AccountMeta, isSigner, Pda, publicKey, PublicKey, Signer, isPda } from '@metaplex-foundation/umi';
+import { type AccountMeta, isSigner, type Pda, publicKey, type PublicKey, type Signer, isPda } from '@metaplex-foundation/umi';
 
 /**
  * Transforms the given object such that the given keys are optional.


### PR DESCRIPTION
This adds a "fixer" for all imports so if they are PascalCase they get a type prefix which makes the renderer compatible with verbatimModuleSyntax