### PR TITLE
Add options to configure how traits are rendered in Rust

### DIFF
--- a/.changeset/spicy-spoons-worry.md
+++ b/.changeset/spicy-spoons-worry.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-rust': patch
+---
+
+Add options to configure how traits are rendered in Rust

--- a/packages/renderers-rust/README.md
+++ b/packages/renderers-rust/README.md
@@ -65,10 +65,19 @@ Note that you must provide the fully qualified name of the traits you provide (e
 
 ```ts
 const traitOptions = {
-    baseDefaults: ['borsh::BorshSerialize', 'borsh::BorshDeserialize', 'Clone', 'Debug', 'Eq', 'PartialEq'],
+    baseDefaults: [
+        'borsh::BorshSerialize',
+        'borsh::BorshDeserialize',
+        'serde::Serialize',
+        'serde::Deserialize',
+        'Clone',
+        'Debug',
+        'Eq',
+        'PartialEq',
+    ],
     dataEnumDefaults: [],
     scalarEnumDefaults: ['Copy', 'PartialOrd', 'Hash', 'num_derive::FromPrimitive'],
-    structDefaults: ['serde::Serialize', 'serde::Deserialize'],
+    structDefaults: [],
 };
 ```
 
@@ -135,3 +144,5 @@ use serde::Deserialize;
 // With `useFullyQualifiedName` set to `true`.
 #[derive(serde::Serialize, serde::Deserialize)]
 ```
+
+Note that any trait rendered under a feature flag will always use the Fully Qualified Name in order to ensure we only reference the trait when the feature is enabled.

--- a/packages/renderers-rust/README.md
+++ b/packages/renderers-rust/README.md
@@ -86,3 +86,52 @@ const traitOptions = {
     },
 };
 ```
+
+### Feature Flags
+
+You may also configure which traits should be rendered under a feature flag by using the `featureFlags` attribute. This attribute is a map where the keys are feature flag names and the values are the traits that should be rendered under that feature flag. Here is an example:
+
+```ts
+const traitOptions = {
+    featureFlags: { fruits: ['fruits::Apple', 'fruits::Banana'] },
+};
+```
+
+Now, if at any point, we encounter a `fruits::Apple` or `fruits::Banana` trait to be rendered (either as default traits or as overridden traits), they will be rendered under the `fruits` feature flag. For instance:
+
+```rust
+#[cfg(feature = "fruits", derive(fruits::Apple, fruits::Banana))]
+```
+
+By default, the `featureFlags` option is set to the following:
+
+```ts
+const traitOptions = {
+    featureFlags: { serde: ['serde::Serialize', 'serde::Deserialize'] },
+};
+```
+
+### Using the Fully Qualified Name
+
+By default, all traits are imported using the provided Fully Qualified Name which means their short name will be used within the `derive` attributes.
+
+However, you may want to avoid importing these traits and use the Fully Qualified Name directly in the generated code. To do so, you may use the `useFullyQualifiedName` attribute of the `traitOptions` object by setting it to `true`:
+
+```ts
+const traitOptions = {
+    useFullyQualifiedName: true,
+};
+```
+
+Here is an example of rendered traits with this option set to `true` and `false` (which is the default):
+
+```rust
+// With `useFullyQualifiedName` set to `false` (default).
+use serde::Serialize;
+use serde::Deserialize;
+// ...
+#[derive(Serialize, Deserialize)]
+
+// With `useFullyQualifiedName` set to `true`.
+#[derive(serde::Serialize, serde::Deserialize)]
+```

--- a/packages/renderers-rust/README.md
+++ b/packages/renderers-rust/README.md
@@ -109,7 +109,7 @@ const traitOptions = {
 Now, if at any point, we encounter a `fruits::Apple` or `fruits::Banana` trait to be rendered (either as default traits or as overridden traits), they will be rendered under the `fruits` feature flag. For instance:
 
 ```rust
-#[cfg(feature = "fruits", derive(fruits::Apple, fruits::Banana))]
+#[cfg_attr(feature = "fruits", derive(fruits::Apple, fruits::Banana))]
 ```
 
 By default, the `featureFlags` option is set to the following:
@@ -119,6 +119,8 @@ const traitOptions = {
     featureFlags: { serde: ['serde::Serialize', 'serde::Deserialize'] },
 };
 ```
+
+Note that for feature flags to be effective, they must be added to the `Cargo.toml` file of the generated Rust client.
 
 ### Using the Fully Qualified Name
 

--- a/packages/renderers-rust/README.md
+++ b/packages/renderers-rust/README.md
@@ -60,13 +60,11 @@ Using the `traitOptions` attribute, you may configure the default traits that wi
 -   `dataEnumDefaults`: The default traits to implement for all data enum types, in addition to the `baseDefaults` traits. Data enums are enums with at least one non-unit variant — e.g. `pub enum Command { Write(String), Quit }`.
 -   `scalarEnumDefaults`: The default traits to implement for all scalar enum types, in addition to the `baseDefaults` traits. Scalar enums are enums with unit variants only — e.g. `pub enum Feedback { Good, Bad }`.
 -   `structDefaults`: The default traits to implement for all struct types, in addition to the `baseDefaults` traits.
--   `aliasDefaults`: The default traits to implement for all type aliases, in addition to the `baseDefaults` traits.
 
 Note that you must provide the fully qualified name of the traits you provide (e.g. `serde::Serialize`). Here are the default values for these attributes:
 
 ```ts
 const traitOptions = {
-    aliasDefaults: [],
     baseDefaults: ['borsh::BorshSerialize', 'borsh::BorshDeserialize', 'Clone', 'Debug', 'Eq', 'PartialEq'],
     dataEnumDefaults: [],
     scalarEnumDefaults: ['Copy', 'PartialOrd', 'Hash', 'num_derive::FromPrimitive'],

--- a/packages/renderers-rust/README.md
+++ b/packages/renderers-rust/README.md
@@ -57,7 +57,8 @@ The Rust renderer provides sensible default traits when generating the various R
 Using the `traitOptions` attribute, you may configure the default traits that will be applied to every Rust type. These default traits can be configured using 4 different attributes:
 
 -   `baseDefaults`: The default traits to implement for all types.
--   `enumDefaults`: The default traits to implement for all enum types, in addition to the `baseDefaults` traits.
+-   `dataEnumDefaults`: The default traits to implement for all data enum types, in addition to the `baseDefaults` traits. Data enums are enums with at least one non-unit variant — e.g. `pub enum Command { Write(String), Quit }`.
+-   `scalarEnumDefaults`: The default traits to implement for all scalar enum types, in addition to the `baseDefaults` traits. Scalar enums are enums with unit variants only — e.g. `pub enum Feedback { Good, Bad }`.
 -   `structDefaults`: The default traits to implement for all struct types, in addition to the `baseDefaults` traits.
 -   `aliasDefaults`: The default traits to implement for all type aliases, in addition to the `baseDefaults` traits.
 
@@ -67,7 +68,8 @@ Note that you must provide the fully qualified name of the traits you provide (e
 const traitOptions = {
     aliasDefaults: [],
     baseDefaults: ['borsh::BorshSerialize', 'borsh::BorshDeserialize', 'Clone', 'Debug', 'Eq', 'PartialEq'],
-    enumDefaults: ['Copy', 'PartialOrd', 'Hash', 'num_derive::FromPrimitive'],
+    dataEnumDefaults: [],
+    scalarEnumDefaults: ['Copy', 'PartialOrd', 'Hash', 'num_derive::FromPrimitive'],
     structDefaults: ['serde::Serialize', 'serde::Deserialize'],
 };
 ```

--- a/packages/renderers-rust/README.md
+++ b/packages/renderers-rust/README.md
@@ -37,12 +37,52 @@ codama.accept(renderVisitor(pathToGeneratedFolder, options));
 
 The `renderVisitor` accepts the following options.
 
-| Name                          | Type                                                                                                                    | Default     | Description                                                                                                                                                                                      |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `deleteFolderBeforeRendering` | `boolean`                                                                                                               | `true`      | Whether the base directory should be cleaned before generating new files.                                                                                                                        |
-| `formatCode`                  | `boolean`                                                                                                               | `false`     | Whether we should use `cargo fmt` to format the generated code. When set to `true`, the `crateFolder` option must be provided.                                                                   |
-| `toolchain`                   | `string`                                                                                                                | `"+stable"` | The toolchain to use when formatting the generated code.                                                                                                                                         |
-| `crateFolder`                 | `string`                                                                                                                | none        | The path to the root folder of the Rust crate. This option is required when `formatCode` is set to `true`.                                                                                       |
-| `linkOverrides`               | `Record<'accounts' \| 'definedTypes' \| 'instructions' \| 'pdas' \| 'programs' \| 'resolvers', Record<string, string>>` | `{}`        | A object that overrides the import path of link nodes. For instance, `{ definedTypes: { counter: 'hooked' } }` uses the `hooked` folder to import any link node referring to the `counter` type. |
-| `dependencyMap`               | `Record<string, string>`                                                                                                | `{}`        | A mapping between import aliases and their actual crate name or path in Rust.                                                                                                                    |
-| `renderParentInstructions`    | `boolean`                                                                                                               | `false`     | When using nested instructions, whether the parent instructions should also be rendered. When set to `false` (default), only the instruction leaves are being rendered.                          |
+| Name                          | Type                                                                                                                    | Default                 | Description                                                                                                                                                                                      |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `deleteFolderBeforeRendering` | `boolean`                                                                                                               | `true`                  | Whether the base directory should be cleaned before generating new files.                                                                                                                        |
+| `formatCode`                  | `boolean`                                                                                                               | `false`                 | Whether we should use `cargo fmt` to format the generated code. When set to `true`, the `crateFolder` option must be provided.                                                                   |
+| `toolchain`                   | `string`                                                                                                                | `"+stable"`             | The toolchain to use when formatting the generated code.                                                                                                                                         |
+| `crateFolder`                 | `string`                                                                                                                | none                    | The path to the root folder of the Rust crate. This option is required when `formatCode` is set to `true`.                                                                                       |
+| `linkOverrides`               | `Record<'accounts' \| 'definedTypes' \| 'instructions' \| 'pdas' \| 'programs' \| 'resolvers', Record<string, string>>` | `{}`                    | A object that overrides the import path of link nodes. For instance, `{ definedTypes: { counter: 'hooked' } }` uses the `hooked` folder to import any link node referring to the `counter` type. |
+| `dependencyMap`               | `Record<string, string>`                                                                                                | `{}`                    | A mapping between import aliases and their actual crate name or path in Rust.                                                                                                                    |
+| `renderParentInstructions`    | `boolean`                                                                                                               | `false`                 | When using nested instructions, whether the parent instructions should also be rendered. When set to `false` (default), only the instruction leaves are being rendered.                          |
+| `traitOptions`                | [`TraitOptions`](#trait-options)                                                                                        | `DEFAULT_TRAIT_OPTIONS` | A set of options that can be used to configure how traits are rendered for every Rust types. See [documentation below](#trait-options) for more information.                                     |
+
+## Trait Options
+
+The Rust renderer provides sensible default traits when generating the various Rust types you client will use. However, you may wish to configure these traits to better suit your needs. The `traitOptions` attribute is here to help you with that. Let's see the various settings it provides.
+
+### Default traits
+
+Using the `traitOptions` attribute, you may configure the default traits that will be applied to every Rust type. These default traits can be configured using 4 different attributes:
+
+-   `baseDefaults`: The default traits to implement for all types.
+-   `enumDefaults`: The default traits to implement for all enum types, in addition to the `baseDefaults` traits.
+-   `structDefaults`: The default traits to implement for all struct types, in addition to the `baseDefaults` traits.
+-   `aliasDefaults`: The default traits to implement for all type aliases, in addition to the `baseDefaults` traits.
+
+Note that you must provide the fully qualified name of the traits you provide (e.g. `serde::Serialize`). Here are the default values for these attributes:
+
+```ts
+const traitOptions = {
+    aliasDefaults: [],
+    baseDefaults: ['borsh::BorshSerialize', 'borsh::BorshDeserialize', 'Clone', 'Debug', 'Eq', 'PartialEq'],
+    enumDefaults: ['Copy', 'PartialOrd', 'Hash', 'num_derive::FromPrimitive'],
+    structDefaults: ['serde::Serialize', 'serde::Deserialize'],
+};
+```
+
+### Overridden traits
+
+In addition to configure the default traits, you may also override the traits for specific types. This will completely replace the default traits for the given type. To do so, you may use the `overrides` attribute of the `traitOptions` object.
+
+This attribute is a map where the keys are the names of the types you want to override, and the values are the traits you want to apply to these types. Here is an example:
+
+```ts
+const traitOptions = {
+    overrides: {
+        myCustomType: ['Clone', 'my::custom::Trait', 'my::custom::OtherTrait'],
+        myTypeWithNoTraits: [],
+    },
+};
+```

--- a/packages/renderers-rust/src/getRenderMapVisitor.ts
+++ b/packages/renderers-rust/src/getRenderMapVisitor.ts
@@ -27,12 +27,14 @@ import {
 import { getTypeManifestVisitor } from './getTypeManifestVisitor';
 import { ImportMap } from './ImportMap';
 import { renderValueNode } from './renderValueNodeVisitor';
-import { getImportFromFactory, LinkOverrides, render } from './utils';
+import { getImportFromFactory, LinkOverrides, render, TraitOptions } from './utils';
 
 export type GetRenderMapOptions = {
+    defaultTraitOverrides?: string[];
     dependencyMap?: Record<string, string>;
     linkOverrides?: LinkOverrides;
     renderParentInstructions?: boolean;
+    traitOverrides?: TraitOptions;
 };
 
 export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {

--- a/packages/renderers-rust/src/getRenderMapVisitor.ts
+++ b/packages/renderers-rust/src/getRenderMapVisitor.ts
@@ -27,14 +27,14 @@ import {
 import { getTypeManifestVisitor } from './getTypeManifestVisitor';
 import { ImportMap } from './ImportMap';
 import { renderValueNode } from './renderValueNodeVisitor';
-import { getImportFromFactory, LinkOverrides, render, TraitOptions } from './utils';
+import { getImportFromFactory, getTraitsFromNodeFactory, LinkOverrides, render, TraitOptions } from './utils';
 
 export type GetRenderMapOptions = {
     defaultTraitOverrides?: string[];
     dependencyMap?: Record<string, string>;
     linkOverrides?: LinkOverrides;
     renderParentInstructions?: boolean;
-    traitOverrides?: TraitOptions;
+    traitOptions?: TraitOptions;
 };
 
 export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
@@ -44,7 +44,8 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
     const renderParentInstructions = options.renderParentInstructions ?? false;
     const dependencyMap = options.dependencyMap ?? {};
     const getImportFrom = getImportFromFactory(options.linkOverrides ?? {});
-    const typeManifestVisitor = getTypeManifestVisitor({ getImportFrom });
+    const getTraitsFromNode = getTraitsFromNodeFactory(options.traitOptions);
+    const typeManifestVisitor = getTypeManifestVisitor({ getImportFrom, getTraitsFromNode });
 
     return pipe(
         staticVisitor(
@@ -149,6 +150,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                     node.arguments.forEach(argument => {
                         const argumentVisitor = getTypeManifestVisitor({
                             getImportFrom,
+                            getTraitsFromNode,
                             nestedStruct: true,
                             parentName: `${pascalCase(node.name)}InstructionData`,
                         });
@@ -189,6 +191,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                     const struct = structTypeNodeFromInstructionArgumentNodes(node.arguments);
                     const structVisitor = getTypeManifestVisitor({
                         getImportFrom,
+                        getTraitsFromNode,
                         parentName: `${pascalCase(node.name)}InstructionData`,
                     });
                     const typeManifest = visit(struct, structVisitor);

--- a/packages/renderers-rust/src/utils/index.ts
+++ b/packages/renderers-rust/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './codecs';
 export * from './linkOverrides';
 export * from './render';
+export * from './traitOptions';

--- a/packages/renderers-rust/src/utils/traitOptions.ts
+++ b/packages/renderers-rust/src/utils/traitOptions.ts
@@ -1,0 +1,130 @@
+import { AccountNode, assertIsNode, DefinedTypeNode, isNode, isScalarEnum } from '@codama/nodes';
+
+import { ImportMap } from '../ImportMap';
+
+export type TraitOptions = {
+    /** The default traits to implement for type aliases only — on top of the base defaults. */
+    aliasDefaults?: string[];
+    /** The default traits to implement for all types. */
+    baseDefaults?: string[];
+    /** The default traits to implement for enums only — on top of the base defaults. */
+    enumDefaults?: string[];
+    /**
+     * The mapping of feature flags to traits.
+     * For each entry, the traits will be rendered within a
+     * `#[cfg(feature = "feature_name", derive(Traits))]` attribute.
+     */
+    featureFlags?: Record<string, string[]>;
+    /** The complete trait overrides of specific types. */
+    overrides?: Record<string, string[]>;
+    /** The default traits to implement for structs only — on top of the base defaults. */
+    structDefaults?: string[];
+    /** Whether or not to use the fully qualified name for traits, instead of importing them. */
+    useFullyQualifiedName?: boolean;
+};
+
+export const DEFAULT_TRAIT_OPTIONS: Required<TraitOptions> = {
+    aliasDefaults: [],
+    baseDefaults: ['borsh::BorshSerialize', 'borsh::BorshDeserialize', 'Clone', 'Debug', 'Eq', 'PartialEq'],
+    enumDefaults: ['Copy', 'PartialOrd', 'Hash', 'num_derive::FromPrimitive'],
+    featureFlags: { serde: ['serde::Serialize', 'serde::Deserialize'] },
+    overrides: {},
+    structDefaults: ['serde::Serialize', 'serde::Deserialize'],
+    useFullyQualifiedName: false,
+};
+
+export function getTraitsFromNode(
+    node: AccountNode | DefinedTypeNode,
+    userOptions: TraitOptions = {},
+): { imports: ImportMap; render: string } {
+    assertIsNode(node, ['accountNode', 'definedTypeNode']);
+    const options: Required<TraitOptions> = { ...DEFAULT_TRAIT_OPTIONS, ...userOptions };
+
+    // Find all the FQN traits for the node.
+    const nodeType = getNodeType(node);
+    const nodeOverrides: string[] | undefined = options.overrides[node.name];
+    const allTraits = nodeOverrides === undefined ? getDefaultTraits(nodeType, options) : nodeOverrides;
+
+    // Wrap the traits in feature flags if necessary.
+    let [unfeaturedTraits, featuredTraits] = partitionTraitsInFeatures(allTraits, options.featureFlags);
+
+    // Import the traits if necessary.
+    const imports = new ImportMap();
+    if (!options.useFullyQualifiedName) {
+        unfeaturedTraits = extractFullyQualifiedNames(unfeaturedTraits, imports);
+        featuredTraits = Object.fromEntries(
+            Object.entries(featuredTraits).map(([feature, traits]) => {
+                return [feature, extractFullyQualifiedNames(traits, imports)];
+            }),
+        );
+    }
+
+    // Render the trait lines.
+    const traitLines: string[] = [
+        `#[derive(${unfeaturedTraits.join(', ')})]`,
+        ...Object.entries(featuredTraits).map(([feature, traits]) => {
+            return `#[cfg(feature = "${feature}", derive(${traits.join(', ')}))]`;
+        }),
+    ];
+
+    return { imports, render: traitLines.join('\n') };
+}
+
+function getNodeType(node: AccountNode | DefinedTypeNode): 'alias' | 'enum' | 'struct' {
+    if (isNode(node, 'accountNode')) return 'struct';
+    if (isNode(node.type, 'structTypeNode')) return 'struct';
+    if (isNode(node.type, 'enumTypeNode') && isScalarEnum(node.type)) return 'enum';
+    return 'alias';
+}
+
+function getDefaultTraits(
+    nodeType: 'alias' | 'enum' | 'struct',
+    options: Pick<Required<TraitOptions>, 'aliasDefaults' | 'baseDefaults' | 'enumDefaults' | 'structDefaults'>,
+): string[] {
+    switch (nodeType) {
+        case 'alias':
+            return [...options.baseDefaults, ...options.aliasDefaults];
+        case 'enum':
+            return [...options.baseDefaults, ...options.enumDefaults];
+        case 'struct':
+        default:
+            return [...options.baseDefaults, ...options.structDefaults];
+    }
+}
+
+function partitionTraitsInFeatures(
+    traits: string[],
+    featureFlags: Record<string, string[]>,
+): [string[], Record<string, string[]>] {
+    // Reverse the feature flags option for quick lookup.
+    // If there are any duplicate traits, the first one encountered will be used.
+    const reverseFeatureFlags = Object.entries(featureFlags).reduce(
+        (acc, [feature, traits]) => {
+            for (const trait of traits) {
+                if (!acc[trait]) acc[trait] = feature;
+            }
+            return acc;
+        },
+        {} as Record<string, string>,
+    );
+
+    const unfeaturedTraits: string[] = [];
+    const featuredTraits: Record<string, string[]> = {};
+    for (const trait of traits) {
+        const feature: string | undefined = reverseFeatureFlags[trait];
+        if (feature !== undefined) unfeaturedTraits.push(trait);
+        if (!featuredTraits[feature]) featuredTraits[feature] = [];
+        featuredTraits[feature].push(trait);
+    }
+
+    return [unfeaturedTraits, featuredTraits];
+}
+
+function extractFullyQualifiedNames(traits: string[], imports: ImportMap): string[] {
+    return traits.map(trait => {
+        const index = trait.lastIndexOf('::');
+        if (index === -1) return trait;
+        imports.add(trait);
+        return trait.slice(index + 2);
+    });
+}

--- a/packages/renderers-rust/src/utils/traitOptions.ts
+++ b/packages/renderers-rust/src/utils/traitOptions.ts
@@ -76,13 +76,14 @@ export function getTraitsFromNode(
 
     // Wrap the traits in feature flags if necessary.
     const partitionedTraits = partitionTraitsInFeatures(allTraits, options.featureFlags);
+    let unfeaturedTraits = partitionedTraits[0];
+    const featuredTraits = partitionedTraits[1];
 
     // Import the traits if necessary.
     const imports = new ImportMap();
     if (!options.useFullyQualifiedName) {
-        partitionedTraits[0] = extractFullyQualifiedNames(partitionedTraits[0], imports);
+        unfeaturedTraits = extractFullyQualifiedNames(unfeaturedTraits, imports);
     }
-    const [unfeaturedTraits, featuredTraits] = partitionedTraits;
 
     // Render the trait lines.
     const traitLines: string[] = [

--- a/packages/renderers-rust/src/utils/traitOptions.ts
+++ b/packages/renderers-rust/src/utils/traitOptions.ts
@@ -1,4 +1,4 @@
-import { AccountNode, assertIsNode, DefinedTypeNode, isNode, isScalarEnum } from '@codama/nodes';
+import { AccountNode, assertIsNode, camelCase, DefinedTypeNode, isNode, isScalarEnum } from '@codama/nodes';
 
 import { ImportMap } from '../ImportMap';
 
@@ -42,7 +42,10 @@ export function getTraitsFromNode(
 
     // Find all the FQN traits for the node.
     const nodeType = getNodeType(node);
-    const nodeOverrides: string[] | undefined = options.overrides[node.name];
+    const sanitizedOverrides = Object.fromEntries(
+        Object.entries(options.overrides).map(([key, value]) => [camelCase(key), value]),
+    );
+    const nodeOverrides: string[] | undefined = sanitizedOverrides[node.name];
     const allTraits = nodeOverrides === undefined ? getDefaultTraits(nodeType, options) : nodeOverrides;
 
     // Wrap the traits in feature flags if necessary.

--- a/packages/renderers-rust/src/utils/traitOptions.ts
+++ b/packages/renderers-rust/src/utils/traitOptions.ts
@@ -33,6 +33,12 @@ export const DEFAULT_TRAIT_OPTIONS: Required<TraitOptions> = {
     useFullyQualifiedName: false,
 };
 
+export type GetTraitsFromNodeFunction = (node: AccountNode | DefinedTypeNode) => { imports: ImportMap; render: string };
+
+export function getTraitsFromNodeFactory(options: TraitOptions = {}): GetTraitsFromNodeFunction {
+    return node => getTraitsFromNode(node, options);
+}
+
 export function getTraitsFromNode(
     node: AccountNode | DefinedTypeNode,
     userOptions: TraitOptions = {},
@@ -64,13 +70,13 @@ export function getTraitsFromNode(
 
     // Render the trait lines.
     const traitLines: string[] = [
-        ...(unfeaturedTraits.length > 0 ? [`#[derive(${unfeaturedTraits.join(', ')})]`] : []),
+        ...(unfeaturedTraits.length > 0 ? [`#[derive(${unfeaturedTraits.join(', ')})]\n`] : []),
         ...Object.entries(featuredTraits).map(([feature, traits]) => {
-            return `#[cfg(feature = "${feature}", derive(${traits.join(', ')}))]`;
+            return `#[cfg(feature = "${feature}", derive(${traits.join(', ')}))]\n`;
         }),
     ];
 
-    return { imports, render: traitLines.join('\n') };
+    return { imports, render: traitLines.join('') };
 }
 
 function getNodeType(node: AccountNode | DefinedTypeNode): 'alias' | 'enum' | 'struct' {

--- a/packages/renderers-rust/src/utils/traitOptions.ts
+++ b/packages/renderers-rust/src/utils/traitOptions.ts
@@ -61,7 +61,7 @@ export function getTraitsFromNode(
 
     // Render the trait lines.
     const traitLines: string[] = [
-        `#[derive(${unfeaturedTraits.join(', ')})]`,
+        ...(unfeaturedTraits.length > 0 ? [`#[derive(${unfeaturedTraits.join(', ')})]`] : []),
         ...Object.entries(featuredTraits).map(([feature, traits]) => {
             return `#[cfg(feature = "${feature}", derive(${traits.join(', ')}))]`;
         }),

--- a/packages/renderers-rust/src/utils/traitOptions.ts
+++ b/packages/renderers-rust/src/utils/traitOptions.ts
@@ -1,4 +1,4 @@
-import { AccountNode, assertIsNode, camelCase, DefinedTypeNode, isNode, isScalarEnum } from '@codama/nodes';
+import { AccountNode, assertIsNode, camelCase, DefinedTypeNode, isNode } from '@codama/nodes';
 
 import { ImportMap } from '../ImportMap';
 
@@ -82,7 +82,7 @@ export function getTraitsFromNode(
 function getNodeType(node: AccountNode | DefinedTypeNode): 'alias' | 'enum' | 'struct' {
     if (isNode(node, 'accountNode')) return 'struct';
     if (isNode(node.type, 'structTypeNode')) return 'struct';
-    if (isNode(node.type, 'enumTypeNode') && isScalarEnum(node.type)) return 'enum';
+    if (isNode(node.type, 'enumTypeNode')) return 'enum';
     return 'alias';
 }
 

--- a/packages/renderers-rust/src/utils/traitOptions.ts
+++ b/packages/renderers-rust/src/utils/traitOptions.ts
@@ -112,9 +112,12 @@ function partitionTraitsInFeatures(
     const featuredTraits: Record<string, string[]> = {};
     for (const trait of traits) {
         const feature: string | undefined = reverseFeatureFlags[trait];
-        if (feature === undefined) unfeaturedTraits.push(trait);
-        if (!featuredTraits[feature]) featuredTraits[feature] = [];
-        featuredTraits[feature].push(trait);
+        if (feature === undefined) {
+            unfeaturedTraits.push(trait);
+        } else {
+            if (!featuredTraits[feature]) featuredTraits[feature] = [];
+            featuredTraits[feature].push(trait);
+        }
     }
 
     return [unfeaturedTraits, featuredTraits];

--- a/packages/renderers-rust/src/utils/traitOptions.ts
+++ b/packages/renderers-rust/src/utils/traitOptions.ts
@@ -13,7 +13,7 @@ export type TraitOptions = {
     /**
      * The mapping of feature flags to traits.
      * For each entry, the traits will be rendered within a
-     * `#[cfg(feature = "feature_name", derive(Traits))]` attribute.
+     * `#[cfg_attr(feature = "feature_name", derive(Traits))]` attribute.
      */
     featureFlags?: Record<string, string[]>;
     /** The complete trait overrides of specific types. */

--- a/packages/renderers-rust/src/utils/traitOptions.ts
+++ b/packages/renderers-rust/src/utils/traitOptions.ts
@@ -112,7 +112,7 @@ function partitionTraitsInFeatures(
     const featuredTraits: Record<string, string[]> = {};
     for (const trait of traits) {
         const feature: string | undefined = reverseFeatureFlags[trait];
-        if (feature !== undefined) unfeaturedTraits.push(trait);
+        if (feature === undefined) unfeaturedTraits.push(trait);
         if (!featuredTraits[feature]) featuredTraits[feature] = [];
         featuredTraits[feature].push(trait);
     }

--- a/packages/renderers-rust/test/utils/traitOptions.test.ts
+++ b/packages/renderers-rust/test/utils/traitOptions.test.ts
@@ -243,7 +243,7 @@ describe('base traits', () => {
     });
 });
 
-describe('overridden  traits', () => {
+describe('overridden traits', () => {
     test('it replaces all default traits with the overridden traits', () => {
         // Given a scalar enum defined type.
         const node = definedTypeNode({
@@ -283,5 +283,28 @@ describe('overridden  traits', () => {
 
         // Then we expect some of the overridden traits to be rendered under feature flags.
         expect(render).toBe(`#[derive(MyNonFeatureTrait)]\n#[cfg(feature = "custom", derive(MyFeedbackTrait))]`);
+    });
+});
+
+describe('fully qualified name traits', () => {
+    test('it can use fully qualified names for traits instead of importing them', () => {
+        // Given a scalar enum defined type.
+        const node = definedTypeNode({
+            name: 'Feedback',
+            type: enumTypeNode([enumEmptyVariantTypeNode('Good'), enumEmptyVariantTypeNode('Bad')]),
+        });
+
+        // When we get the traits from the node such that we use fully qualified names.
+        const { render, imports } = getTraitsFromNode(node, {
+            ...RESET_OPTIONS,
+            baseDefaults: ['fruits::Apple', 'fruits::Banana', 'vegetables::Carrot'],
+            useFullyQualifiedName: true,
+        });
+
+        // Then we expect the fully qualified names to be used for the traits.
+        expect(render).toBe(`#[derive(fruits::Apple, fruits::Banana, vegetables::Carrot)]`);
+
+        // And no imports should be used.
+        expect([...imports.imports]).toStrictEqual([]);
     });
 });

--- a/packages/renderers-rust/test/utils/traitOptions.test.ts
+++ b/packages/renderers-rust/test/utils/traitOptions.test.ts
@@ -1,0 +1,45 @@
+import { definedTypeNode, enumEmptyVariantTypeNode, enumTypeNode } from '@codama/nodes';
+import { describe, expect, test } from 'vitest';
+
+import { getTraitsFromNode, TraitOptions } from '../../src/utils';
+
+describe('default values', () => {
+    test('it defaults to a set of traits for enums', () => {
+        // Given a scalar enum defined type.
+        const node = definedTypeNode({
+            name: 'Feedback',
+            type: enumTypeNode([enumEmptyVariantTypeNode('Good'), enumEmptyVariantTypeNode('Bad')]),
+        });
+
+        // When we get the traits from the node using the default options.
+        const { render, imports } = getTraitsFromNode(node);
+
+        // Then we expect the following traits to be rendered.
+        expect(render).toBe(
+            `#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, Copy, PartialOrd, Hash, FromPrimitive)]`,
+        );
+
+        // And the following imports to be used.
+        expect([...imports.imports]).toStrictEqual([
+            'borsh::BorshSerialize',
+            'borsh::BorshDeserialize',
+            'num_derive::FromPrimitive',
+        ]);
+    });
+
+    test.todo('it defaults to a set of traits for structs');
+    test.todo('it defaults to a set of traits for aliases');
+    test.todo('it defaults to not using fully qualified names');
+    test.todo('it defaults to a set of feature flags for traits');
+});
+
+const RESET_OPTIONS: Required<TraitOptions> = {
+    aliasDefaults: [],
+    baseDefaults: [],
+    enumDefaults: [],
+    featureFlags: {},
+    overrides: {},
+    structDefaults: [],
+    useFullyQualifiedName: false,
+};
+console.log({ RESET_OPTIONS });

--- a/packages/renderers-rust/test/utils/traitOptions.test.ts
+++ b/packages/renderers-rust/test/utils/traitOptions.test.ts
@@ -130,4 +130,85 @@ const RESET_OPTIONS: Required<TraitOptions> = {
     structDefaults: [],
     useFullyQualifiedName: false,
 };
-console.log({ RESET_OPTIONS });
+
+describe('base traits', () => {
+    test('it uses both the base and enum traits', () => {
+        // Given a scalar enum defined type.
+        const node = definedTypeNode({
+            name: 'Feedback',
+            type: enumTypeNode([enumEmptyVariantTypeNode('Good'), enumEmptyVariantTypeNode('Bad')]),
+        });
+
+        // When we get the traits from the node using custom base and enum defaults.
+        const { render } = getTraitsFromNode(node, {
+            ...RESET_OPTIONS,
+            baseDefaults: ['MyBaseTrait'],
+            enumDefaults: ['MyEnumTrait'],
+        });
+
+        // Then we expect both the base and enum traits to be rendered.
+        expect(render).toBe(`#[derive(MyBaseTrait, MyEnumTrait)]`);
+    });
+
+    test('it uses both the base and struct traits', () => {
+        // Given an account node.
+        const node = accountNode({
+            data: structTypeNode([
+                structFieldTypeNode({ name: 'x', type: numberTypeNode('u64') }),
+                structFieldTypeNode({ name: 'y', type: numberTypeNode('u64') }),
+            ]),
+            name: 'Coordinates',
+        });
+
+        // When we get the traits from the node using custom base and struct defaults.
+        const { render } = getTraitsFromNode(node, {
+            ...RESET_OPTIONS,
+            baseDefaults: ['MyBaseTrait'],
+            structDefaults: ['MyStructTrait'],
+        });
+
+        // Then we expect both the base and struct traits to be rendered.
+        expect(render).toBe(`#[derive(MyBaseTrait, MyStructTrait)]`);
+    });
+
+    test('it uses both the base and alias traits', () => {
+        // Given a defined type node that is not an enum or struct.
+        const node = definedTypeNode({
+            name: 'Score',
+            type: numberTypeNode('u64'),
+        });
+
+        // When we get the traits from the node using custom base and alias defaults.
+        const { render } = getTraitsFromNode(node, {
+            ...RESET_OPTIONS,
+            aliasDefaults: ['MyAliasTrait'],
+            baseDefaults: ['MyBaseTrait'],
+        });
+
+        // Then we expect both the base and alias traits to be rendered.
+        expect(render).toBe(`#[derive(MyBaseTrait, MyAliasTrait)]`);
+    });
+});
+
+describe('overridden  traits', () => {
+    test('it replaces all default traits with the overridden traits', () => {
+        // Given a scalar enum defined type.
+        const node = definedTypeNode({
+            name: 'Feedback',
+            type: enumTypeNode([enumEmptyVariantTypeNode('Good'), enumEmptyVariantTypeNode('Bad')]),
+        });
+
+        // When we get the traits from the node such that:
+        // - We provide custom base and enum defaults.
+        // - We override the feedback type with custom traits.
+        const { render } = getTraitsFromNode(node, {
+            ...RESET_OPTIONS,
+            baseDefaults: ['MyBaseTrait'],
+            enumDefaults: ['MyEnumTrait'],
+            overrides: { feedback: ['MyFeedbackTrait'] },
+        });
+
+        // Then we expect only the feedback traits to be rendered.
+        expect(render).toBe(`#[derive(MyFeedbackTrait)]`);
+    });
+});

--- a/packages/renderers-rust/test/utils/traitOptions.test.ts
+++ b/packages/renderers-rust/test/utils/traitOptions.test.ts
@@ -80,10 +80,45 @@ describe('default values', () => {
         expect([...imports.imports]).toStrictEqual(['borsh::BorshSerialize', 'borsh::BorshDeserialize']);
     });
 
-    test.todo('it defaults to not using fully qualified names');
-    test.todo('it defaults to a set of feature flags for traits');
-    test.todo('it does not use default traits if they are overridden');
-    test.todo('it still uses feature flags for overridden traits');
+    test('it does not use default traits if they are overridden', () => {
+        // Given a defined type node that should use custom traits.
+        const node = definedTypeNode({
+            name: 'Score',
+            type: numberTypeNode('u64'),
+        });
+
+        // When we get the traits from the node using the
+        // default options with the overrides attribute.
+        const { render, imports } = getTraitsFromNode(node, {
+            overrides: { score: ['My', 'special::Traits'] },
+        });
+
+        // Then we expect the following traits to be rendered.
+        expect(render).toBe(`#[derive(My, Traits)]`);
+
+        // And the following imports to be used.
+        expect([...imports.imports]).toStrictEqual(['special::Traits']);
+    });
+
+    test('it still uses feature flags for overridden traits', () => {
+        // Given a defined type node that should use custom traits.
+        const node = definedTypeNode({
+            name: 'Score',
+            type: numberTypeNode('u64'),
+        });
+
+        // When we get the traits from the node using custom traits
+        // such that some are part of the feature flag defaults.
+        const { render, imports } = getTraitsFromNode(node, {
+            overrides: { score: ['My', 'special::Traits', 'serde::Serialize'] },
+        });
+
+        // Then we expect the following traits to be rendered.
+        expect(render).toBe(`#[derive(My, Traits)]\n#[cfg(feature = "serde", derive(Serialize))]`);
+
+        // And the following imports to be used.
+        expect([...imports.imports]).toStrictEqual(['special::Traits', 'serde::Serialize']);
+    });
 });
 
 const RESET_OPTIONS: Required<TraitOptions> = {

--- a/packages/renderers-rust/test/utils/traitOptions.test.ts
+++ b/packages/renderers-rust/test/utils/traitOptions.test.ts
@@ -1,4 +1,12 @@
-import { definedTypeNode, enumEmptyVariantTypeNode, enumTypeNode } from '@codama/nodes';
+import {
+    accountNode,
+    definedTypeNode,
+    enumEmptyVariantTypeNode,
+    enumTypeNode,
+    numberTypeNode,
+    structFieldTypeNode,
+    structTypeNode,
+} from '@codama/nodes';
 import { describe, expect, test } from 'vitest';
 
 import { getTraitsFromNode, TraitOptions } from '../../src/utils';
@@ -27,7 +35,34 @@ describe('default values', () => {
         ]);
     });
 
-    test.todo('it defaults to a set of traits for structs');
+    test('it defaults to a set of traits for structs', () => {
+        // Given an account node.
+        const node = accountNode({
+            data: structTypeNode([
+                structFieldTypeNode({ name: 'x', type: numberTypeNode('u64') }),
+                structFieldTypeNode({ name: 'y', type: numberTypeNode('u64') }),
+            ]),
+            name: 'Coordinates',
+        });
+
+        // When we get the traits from the node using the default options.
+        const { render, imports } = getTraitsFromNode(node);
+
+        // Then we expect the following traits to be rendered.
+        expect(render).toBe(
+            `#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]\n` +
+                `#[cfg(feature = "serde", derive(Serialize, Deserialize))]`,
+        );
+
+        // And the following imports to be used.
+        expect([...imports.imports]).toStrictEqual([
+            'borsh::BorshSerialize',
+            'borsh::BorshDeserialize',
+            'serde::Serialize',
+            'serde::Deserialize',
+        ]);
+    });
+
     test.todo('it defaults to a set of traits for aliases');
     test.todo('it defaults to not using fully qualified names');
     test.todo('it defaults to a set of feature flags for traits');

--- a/packages/renderers-rust/test/utils/traitOptions.test.ts
+++ b/packages/renderers-rust/test/utils/traitOptions.test.ts
@@ -30,7 +30,10 @@ describe('default values', () => {
         const { render, imports } = getTraitsFromNode(node);
 
         // Then we expect the following traits to be rendered.
-        expect(render).toBe(`#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]\n`);
+        expect(render).toBe(
+            `#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]\n` +
+                `#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n`,
+        );
 
         // And the following imports to be used.
         expect([...imports.imports]).toStrictEqual(['borsh::BorshSerialize', 'borsh::BorshDeserialize']);
@@ -48,7 +51,8 @@ describe('default values', () => {
 
         // Then we expect the following traits to be rendered.
         expect(render).toBe(
-            `#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, Copy, PartialOrd, Hash, FromPrimitive)]\n`,
+            `#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, Copy, PartialOrd, Hash, FromPrimitive)]\n` +
+                `#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n`,
         );
 
         // And the following imports to be used.
@@ -75,16 +79,11 @@ describe('default values', () => {
         // Then we expect the following traits to be rendered.
         expect(render).toBe(
             `#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]\n` +
-                `#[cfg(feature = "serde", derive(Serialize, Deserialize))]\n`,
+                `#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n`,
         );
 
         // And the following imports to be used.
-        expect([...imports.imports]).toStrictEqual([
-            'borsh::BorshSerialize',
-            'borsh::BorshDeserialize',
-            'serde::Serialize',
-            'serde::Deserialize',
-        ]);
+        expect([...imports.imports]).toStrictEqual(['borsh::BorshSerialize', 'borsh::BorshDeserialize']);
     });
 
     test('it does not use default traits if they are overridden', () => {
@@ -122,15 +121,12 @@ describe('default values', () => {
 
         // When we get the traits from the node using custom traits
         // such that some are part of the feature flag defaults.
-        const { render, imports } = getTraitsFromNode(node, {
+        const { render } = getTraitsFromNode(node, {
             overrides: { coordinates: ['My', 'special::Traits', 'serde::Serialize'] },
         });
 
         // Then we expect the following traits to be rendered.
-        expect(render).toBe(`#[derive(My, Traits)]\n#[cfg(feature = "serde", derive(Serialize))]\n`);
-
-        // And the following imports to be used.
-        expect([...imports.imports]).toStrictEqual(['special::Traits', 'serde::Serialize']);
+        expect(render).toBe(`#[derive(My, Traits)]\n#[cfg_attr(feature = "serde", derive(serde::Serialize))]\n`);
     });
 });
 
@@ -248,8 +244,8 @@ describe('base traits', () => {
         // Then we expect both the base and enum traits to be rendered as separate feature flags.
         expect(render).toBe(
             `#[derive(MyNonFeatureTrait)]\n` +
-                `#[cfg(feature = "base", derive(MyBaseTrait))]\n` +
-                `#[cfg(feature = "enum", derive(MyScalarEnumTrait))]\n`,
+                `#[cfg_attr(feature = "base", derive(MyBaseTrait))]\n` +
+                `#[cfg_attr(feature = "enum", derive(MyScalarEnumTrait))]\n`,
         );
     });
 
@@ -274,7 +270,7 @@ describe('base traits', () => {
 
         // Then we expect the following traits to be rendered.
         expect(render).toBe(
-            `#[cfg(feature = "base", derive(MyBaseTrait))]\n#[cfg(feature = "enum", derive(MyScalarEnumTrait))]\n`,
+            `#[cfg_attr(feature = "base", derive(MyBaseTrait))]\n#[cfg_attr(feature = "enum", derive(MyScalarEnumTrait))]\n`,
         );
     });
 });
@@ -336,7 +332,7 @@ describe('overridden traits', () => {
         });
 
         // Then we expect some of the overridden traits to be rendered under feature flags.
-        expect(render).toBe(`#[derive(MyNonFeatureTrait)]\n#[cfg(feature = "custom", derive(MyFeedbackTrait))]\n`);
+        expect(render).toBe(`#[derive(MyNonFeatureTrait)]\n#[cfg_attr(feature = "custom", derive(MyFeedbackTrait))]\n`);
     });
 });
 

--- a/packages/renderers-rust/test/utils/traitOptions.test.ts
+++ b/packages/renderers-rust/test/utils/traitOptions.test.ts
@@ -63,9 +63,27 @@ describe('default values', () => {
         ]);
     });
 
-    test.todo('it defaults to a set of traits for aliases');
+    test('it defaults to a set of traits for aliases', () => {
+        // Given a defined type node that is not an enum or struct.
+        const node = definedTypeNode({
+            name: 'Score',
+            type: numberTypeNode('u64'),
+        });
+
+        // When we get the traits from the node using the default options.
+        const { render, imports } = getTraitsFromNode(node);
+
+        // Then we expect the following traits to be rendered.
+        expect(render).toBe(`#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]`);
+
+        // And the following imports to be used.
+        expect([...imports.imports]).toStrictEqual(['borsh::BorshSerialize', 'borsh::BorshDeserialize']);
+    });
+
     test.todo('it defaults to not using fully qualified names');
     test.todo('it defaults to a set of feature flags for traits');
+    test.todo('it does not use default traits if they are overridden');
+    test.todo('it still uses feature flags for overridden traits');
 });
 
 const RESET_OPTIONS: Required<TraitOptions> = {

--- a/packages/renderers-rust/test/utils/traitOptions.test.ts
+++ b/packages/renderers-rust/test/utils/traitOptions.test.ts
@@ -265,6 +265,24 @@ describe('overridden traits', () => {
         expect(render).toBe(`#[derive(MyFeedbackTrait)]`);
     });
 
+    test('it finds traits to override when using pascal case', () => {
+        // Given a scalar enum defined type.
+        const node = definedTypeNode({
+            name: 'Feedback',
+            type: enumTypeNode([enumEmptyVariantTypeNode('Good'), enumEmptyVariantTypeNode('Bad')]),
+        });
+
+        // When we get the traits from the node such that
+        // we use PascalCase for the type name.
+        const { render } = getTraitsFromNode(node, {
+            ...RESET_OPTIONS,
+            overrides: { Feedback: ['MyFeedbackTrait'] },
+        });
+
+        // Then we still expect the custom feedback traits to be rendered.
+        expect(render).toBe(`#[derive(MyFeedbackTrait)]`);
+    });
+
     test('it identifies feature flags under all overridden traits', () => {
         // Given a scalar enum defined type.
         const node = definedTypeNode({

--- a/packages/renderers-rust/test/utils/traitOptions.test.ts
+++ b/packages/renderers-rust/test/utils/traitOptions.test.ts
@@ -24,7 +24,7 @@ describe('default values', () => {
 
         // Then we expect the following traits to be rendered.
         expect(render).toBe(
-            `#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, Copy, PartialOrd, Hash, FromPrimitive)]`,
+            `#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, Copy, PartialOrd, Hash, FromPrimitive)]\n`,
         );
 
         // And the following imports to be used.
@@ -51,7 +51,7 @@ describe('default values', () => {
         // Then we expect the following traits to be rendered.
         expect(render).toBe(
             `#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]\n` +
-                `#[cfg(feature = "serde", derive(Serialize, Deserialize))]`,
+                `#[cfg(feature = "serde", derive(Serialize, Deserialize))]\n`,
         );
 
         // And the following imports to be used.
@@ -74,7 +74,7 @@ describe('default values', () => {
         const { render, imports } = getTraitsFromNode(node);
 
         // Then we expect the following traits to be rendered.
-        expect(render).toBe(`#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]`);
+        expect(render).toBe(`#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]\n`);
 
         // And the following imports to be used.
         expect([...imports.imports]).toStrictEqual(['borsh::BorshSerialize', 'borsh::BorshDeserialize']);
@@ -94,7 +94,7 @@ describe('default values', () => {
         });
 
         // Then we expect the following traits to be rendered.
-        expect(render).toBe(`#[derive(My, Traits)]`);
+        expect(render).toBe(`#[derive(My, Traits)]\n`);
 
         // And the following imports to be used.
         expect([...imports.imports]).toStrictEqual(['special::Traits']);
@@ -114,7 +114,7 @@ describe('default values', () => {
         });
 
         // Then we expect the following traits to be rendered.
-        expect(render).toBe(`#[derive(My, Traits)]\n#[cfg(feature = "serde", derive(Serialize))]`);
+        expect(render).toBe(`#[derive(My, Traits)]\n#[cfg(feature = "serde", derive(Serialize))]\n`);
 
         // And the following imports to be used.
         expect([...imports.imports]).toStrictEqual(['special::Traits', 'serde::Serialize']);
@@ -147,7 +147,7 @@ describe('base traits', () => {
         });
 
         // Then we expect both the base and enum traits to be rendered.
-        expect(render).toBe(`#[derive(MyBaseTrait, MyEnumTrait)]`);
+        expect(render).toBe(`#[derive(MyBaseTrait, MyEnumTrait)]\n`);
     });
 
     test('it uses both the base and struct traits', () => {
@@ -168,7 +168,7 @@ describe('base traits', () => {
         });
 
         // Then we expect both the base and struct traits to be rendered.
-        expect(render).toBe(`#[derive(MyBaseTrait, MyStructTrait)]`);
+        expect(render).toBe(`#[derive(MyBaseTrait, MyStructTrait)]\n`);
     });
 
     test('it uses both the base and alias traits', () => {
@@ -186,7 +186,7 @@ describe('base traits', () => {
         });
 
         // Then we expect both the base and alias traits to be rendered.
-        expect(render).toBe(`#[derive(MyBaseTrait, MyAliasTrait)]`);
+        expect(render).toBe(`#[derive(MyBaseTrait, MyAliasTrait)]\n`);
     });
 
     test('it identifies feature flags under all default traits', () => {
@@ -213,7 +213,7 @@ describe('base traits', () => {
         expect(render).toBe(
             `#[derive(MyNonFeatureTrait)]\n` +
                 `#[cfg(feature = "base", derive(MyBaseTrait))]\n` +
-                `#[cfg(feature = "enum", derive(MyEnumTrait))]`,
+                `#[cfg(feature = "enum", derive(MyEnumTrait))]\n`,
         );
     });
 
@@ -238,7 +238,7 @@ describe('base traits', () => {
 
         // Then we expect the following traits to be rendered.
         expect(render).toBe(
-            `#[cfg(feature = "base", derive(MyBaseTrait))]\n#[cfg(feature = "enum", derive(MyEnumTrait))]`,
+            `#[cfg(feature = "base", derive(MyBaseTrait))]\n#[cfg(feature = "enum", derive(MyEnumTrait))]\n`,
         );
     });
 });
@@ -262,7 +262,7 @@ describe('overridden traits', () => {
         });
 
         // Then we expect only the feedback traits to be rendered.
-        expect(render).toBe(`#[derive(MyFeedbackTrait)]`);
+        expect(render).toBe(`#[derive(MyFeedbackTrait)]\n`);
     });
 
     test('it finds traits to override when using pascal case', () => {
@@ -280,7 +280,7 @@ describe('overridden traits', () => {
         });
 
         // Then we still expect the custom feedback traits to be rendered.
-        expect(render).toBe(`#[derive(MyFeedbackTrait)]`);
+        expect(render).toBe(`#[derive(MyFeedbackTrait)]\n`);
     });
 
     test('it identifies feature flags under all overridden traits', () => {
@@ -300,7 +300,7 @@ describe('overridden traits', () => {
         });
 
         // Then we expect some of the overridden traits to be rendered under feature flags.
-        expect(render).toBe(`#[derive(MyNonFeatureTrait)]\n#[cfg(feature = "custom", derive(MyFeedbackTrait))]`);
+        expect(render).toBe(`#[derive(MyNonFeatureTrait)]\n#[cfg(feature = "custom", derive(MyFeedbackTrait))]\n`);
     });
 });
 
@@ -320,7 +320,7 @@ describe('fully qualified name traits', () => {
         });
 
         // Then we expect the fully qualified names to be used for the traits.
-        expect(render).toBe(`#[derive(fruits::Apple, fruits::Banana, vegetables::Carrot)]`);
+        expect(render).toBe(`#[derive(fruits::Apple, fruits::Banana, vegetables::Carrot)]\n`);
 
         // And no imports should be used.
         expect([...imports.imports]).toStrictEqual([]);


### PR DESCRIPTION
This PR adds the following `TraitOptions` configuration object to the Rust renderer allowing users to tweak how traits are rendered in their clients.


```ts
export type TraitOptions = {
    /** The default traits to implement for all types. */
    baseDefaults?: string[];
    /**
     * The default traits to implement for data enums only — on top of the base defaults.
     * Data enums are enums with at least one non-unit variant.
     */
    dataEnumDefaults?: string[];
    /**
     * The mapping of feature flags to traits.
     * For each entry, the traits will be rendered within a
     * `#[cfg(feature = "feature_name", derive(Traits))]` attribute.
     */
    featureFlags?: Record<string, string[]>;
    /** The complete trait overrides of specific types. */
    overrides?: Record<string, string[]>;
    /**
     * The default traits to implement for scalar enums only — on top of the base defaults.
     * Scalar enums are enums with no variants or only unit variants.
     */
    scalarEnumDefaults?: string[];
    /** The default traits to implement for structs only — on top of the base defaults. */
    structDefaults?: string[];
    /** Whether or not to use the fully qualified name for traits, instead of importing them. */
    useFullyQualifiedName?: boolean;
};
```

The default values for these options are:

```ts
export const DEFAULT_TRAIT_OPTIONS: Required<TraitOptions> = {
    baseDefaults: [
        'borsh::BorshSerialize',
        'borsh::BorshDeserialize',
        'serde::Serialize',
        'serde::Deserialize',
        'Clone',
        'Debug',
        'Eq',
        'PartialEq',
    ],
    dataEnumDefaults: [],
    featureFlags: { serde: ['serde::Serialize', 'serde::Deserialize'] },
    overrides: {},
    scalarEnumDefaults: ['Copy', 'PartialOrd', 'Hash', 'num_derive::FromPrimitive'],
    structDefaults: [],
    useFullyQualifiedName: false,
};
```

See readme changes for more details.