### PR TITLE
Use NodePath in LinkableDictionary

### DIFF
--- a/.changeset/red-plants-collect.md
+++ b/.changeset/red-plants-collect.md
@@ -1,0 +1,5 @@
+---
+'@codama/visitors-core': minor
+---
+
+Record and resolve `NodePaths` instead of `Nodes` in `LinkableDictionary`

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -75,7 +75,7 @@ export type CodamaErrorContext = DefaultUnspecifiedErrorContextToUndefined<{
         kind: LinkNode['kind'];
         linkNode: LinkNode;
         name: CamelCaseString;
-        stack: Node[];
+        path: readonly Node[];
     };
     [CODAMA_ERROR__NODE_FILESYSTEM_FUNCTION_UNAVAILABLE]: {
         fsFunction: string;
@@ -169,7 +169,7 @@ type ValidationItem = {
     level: 'debug' | 'error' | 'info' | 'trace' | 'warn';
     message: string;
     node: Node;
-    stack: Node[];
+    path: Node[];
 };
 
 export function decodeEncodedContext(encodedContext: string): object {

--- a/packages/renderers-js-umi/src/getRenderMapVisitor.ts
+++ b/packages/renderers-js-umi/src/getRenderMapVisitor.ts
@@ -204,7 +204,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}): Visitor<
                     }
 
                     // Seeds.
-                    const pda = node.pda ? linkables.get(node.pda, stack) : undefined;
+                    const pda = node.pda ? linkables.get([...stack.getPath(), node.pda]) : undefined;
                     const pdaSeeds = pda?.seeds ?? [];
                     const seeds = pdaSeeds.map(seed => {
                         if (isNode(seed, 'variablePdaSeedNode')) {

--- a/packages/renderers-js-umi/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-js-umi/src/getTypeManifestVisitor.ts
@@ -429,7 +429,7 @@ export function getTypeManifestVisitor(input: {
                     const importFrom = getImportFrom(node.enum);
 
                     // FIXME(loris): No program node can ever be in this stack.
-                    const enumNode = linkables.get(node.enum, stack)?.type;
+                    const enumNode = linkables.get([...stack.getPath(), node.enum])?.type;
                     const isScalar =
                         enumNode && isNode(enumNode, 'enumTypeNode')
                             ? isScalarEnum(enumNode)

--- a/packages/renderers-js/src/fragments/accountPdaHelpers.ts
+++ b/packages/renderers-js/src/fragments/accountPdaHelpers.ts
@@ -13,7 +13,7 @@ export function getAccountPdaHelpersFragment(
     },
 ): Fragment {
     const { accountNode, accountStack, nameApi, linkables, customAccountData, typeManifest } = scope;
-    const pdaNode = accountNode.pda ? linkables.get(accountNode.pda, accountStack) : undefined;
+    const pdaNode = accountNode.pda ? linkables.get([...accountStack.getPath(), accountNode.pda]) : undefined;
     if (!pdaNode) {
         return fragment('');
     }

--- a/packages/renderers-js/src/fragments/instructionAccountTypeParam.ts
+++ b/packages/renderers-js/src/fragments/instructionAccountTypeParam.ts
@@ -43,9 +43,8 @@ function getDefaultAddress(
         case 'publicKeyValueNode':
             return `"${defaultValue.publicKey}"`;
         case 'programLinkNode':
-            // FIXME(loris): No need for a stack here.
             // eslint-disable-next-line no-case-declarations
-            const programNode = linkables.get(defaultValue, new NodeStack());
+            const programNode = linkables.get([defaultValue]);
             return programNode ? `"${programNode.publicKey}"` : 'string';
         case 'programIdValueNode':
             return `"${programId}"`;

--- a/packages/renderers-js/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-js/src/getTypeManifestVisitor.ts
@@ -355,7 +355,7 @@ export function getTypeManifestVisitor(input: {
                     const importFrom = getImportFrom(node.enum);
 
                     // FIXME(loris): No program node can ever be in this stack.
-                    const enumNode = linkables.get(node.enum, stack)?.type;
+                    const enumNode = linkables.get([...stack.getPath(), node.enum])?.type;
                     const isScalar =
                         enumNode && isNode(enumNode, 'enumTypeNode')
                             ? isScalarEnum(enumNode)

--- a/packages/renderers-rust/src/getRenderMapVisitor.ts
+++ b/packages/renderers-rust/src/getRenderMapVisitor.ts
@@ -64,7 +64,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
 
                     // Seeds.
                     const seedsImports = new ImportMap();
-                    const pda = node.pda ? linkables.get(node.pda, stack) : undefined;
+                    const pda = node.pda ? linkables.get([...stack.getPath(), node.pda]) : undefined;
                     const pdaSeeds = pda?.seeds ?? [];
                     const seeds = pdaSeeds.map(seed => {
                         if (isNode(seed, 'variablePdaSeedNode')) {

--- a/packages/validators/README.md
+++ b/packages/validators/README.md
@@ -36,8 +36,8 @@ type ValidationItem = {
     message: string;
     // The node that the validation item is related to.
     node: Node;
-    // The stack of nodes that led to the node above.
-    stack: readonly Node[];
+    // The path of nodes that led to the node above (including the node itself).
+    path: readonly Node[];
 };
 ```
 

--- a/packages/validators/src/ValidationItem.ts
+++ b/packages/validators/src/ValidationItem.ts
@@ -8,7 +8,7 @@ export type ValidationItem = {
     level: LogLevel;
     message: string;
     node: Node;
-    stack: readonly Node[];
+    path: readonly Node[];
 };
 
 export function validationItem(
@@ -21,7 +21,7 @@ export function validationItem(
         level,
         message,
         node,
-        stack: Array.isArray(stack) ? [...stack] : stack.all(),
+        path: Array.isArray(stack) ? [...stack] : stack.all(),
     };
 }
 

--- a/packages/validators/src/getValidationItemsVisitor.ts
+++ b/packages/validators/src/getValidationItemsVisitor.ts
@@ -47,7 +47,7 @@ export function getValidationItemsVisitor(): Visitor<readonly ValidationItem[]> 
                     const items = [] as ValidationItem[];
                     if (!node.name) {
                         items.push(validationItem('error', 'Pointing to a defined type with no name.', node, stack));
-                    } else if (!linkables.has(node, stack)) {
+                    } else if (!linkables.has(stack.getPath())) {
                         items.push(
                             validationItem(
                                 'error',

--- a/packages/visitors-core/README.md
+++ b/packages/visitors-core/README.md
@@ -653,11 +653,8 @@ It offers the following API:
 ```ts
 const linkables = new LinkableDictionary();
 
-// Record program nodes.
-linkables.record(programNode, stack);
-
-// Record other linkable nodes with their associated program node.
-linkables.record(accountNode, stack);
+// Record linkable nodes via their full path.
+linkables.recordPath([rootNode, programNode, accountNode]);
 
 // Get a linkable node using a link node, or throw an error if it is not found.
 const programNode = linkables.getOrThrow(programLinkNode, stack);

--- a/packages/visitors-core/src/NodePath.ts
+++ b/packages/visitors-core/src/NodePath.ts
@@ -1,7 +1,62 @@
-import { Node } from '@codama/nodes';
+import { assertIsNode, GetNodeFromKind, InstructionNode, isNode, Node, NodeKind, ProgramNode } from '@codama/nodes';
 
 export type NodePath<TNode extends Node = Node> = readonly [...Node[], TNode];
 
 export function getLastNodeFromPath<TNode extends Node>(path: NodePath<TNode>): TNode {
     return path[path.length - 1] as TNode;
+}
+
+export function findFirstNodeFromPath<TKind extends NodeKind>(
+    path: NodePath,
+    kind: TKind | TKind[],
+): GetNodeFromKind<TKind> | undefined {
+    return path.find(node => isNode(node, kind));
+}
+
+export function findLastNodeFromPath<TKind extends NodeKind>(
+    path: NodePath,
+    kind: TKind | TKind[],
+): GetNodeFromKind<TKind> | undefined {
+    for (let index = path.length - 1; index >= 0; index--) {
+        const node = path[index];
+        if (isNode(node, kind)) return node;
+    }
+    return undefined;
+}
+
+export function findProgramNodeFromPath(path: NodePath): ProgramNode | undefined {
+    return findLastNodeFromPath(path, 'programNode');
+}
+
+export function findInstructionNodeFromPath(path: NodePath): InstructionNode | undefined {
+    return findLastNodeFromPath(path, 'instructionNode');
+}
+
+export function getNodePathUntilLastNode<TKind extends NodeKind>(
+    path: NodePath,
+    kind: TKind | TKind[],
+): NodePath<GetNodeFromKind<TKind>> | undefined {
+    const lastIndex = (() => {
+        for (let index = path.length - 1; index >= 0; index--) {
+            const node = path[index];
+            if (isNode(node, kind)) return index;
+        }
+        return -1;
+    })();
+    if (lastIndex === -1) return undefined;
+    return path.slice(0, lastIndex + 1) as unknown as NodePath<GetNodeFromKind<TKind>>;
+}
+
+export function isNodePath<TKind extends NodeKind>(
+    path: NodePath | null | undefined,
+    kind: TKind | TKind[],
+): path is NodePath<GetNodeFromKind<TKind>> {
+    return isNode(path ? getLastNodeFromPath(path) : null, kind);
+}
+
+export function assertIsNodePath<TKind extends NodeKind>(
+    path: NodePath | null | undefined,
+    kind: TKind | TKind[],
+): asserts path is NodePath<GetNodeFromKind<TKind>> {
+    assertIsNode(path ? getLastNodeFromPath(path) : null, kind);
 }

--- a/packages/visitors-core/src/NodeStack.ts
+++ b/packages/visitors-core/src/NodeStack.ts
@@ -2,14 +2,13 @@ import {
     assertIsNode,
     GetNodeFromKind,
     InstructionNode,
-    isNode,
     Node,
     NodeKind,
     ProgramNode,
     REGISTERED_NODE_KINDS,
 } from '@codama/nodes';
 
-import { NodePath } from './NodePath';
+import { findLastNodeFromPath, NodePath } from './NodePath';
 
 export class NodeStack {
     /**
@@ -58,11 +57,7 @@ export class NodeStack {
     }
 
     public find<TKind extends NodeKind>(kind: TKind | TKind[]): GetNodeFromKind<TKind> | undefined {
-        for (let index = this.stack.length - 1; index >= 0; index--) {
-            const node = this.stack[index];
-            if (isNode(node, kind)) return node;
-        }
-        return undefined;
+        return findLastNodeFromPath([...this.stack] as unknown as NodePath<GetNodeFromKind<TKind>>, kind);
     }
 
     public getProgram(): ProgramNode | undefined {

--- a/packages/visitors-core/src/getByteSizeVisitor.ts
+++ b/packages/visitors-core/src/getByteSizeVisitor.ts
@@ -69,7 +69,8 @@ export function getByteSizeVisitor(
                 visitDefinedTypeLink(node, { self }) {
                     // Fetch the linked type and return null if not found.
                     // The validator visitor will throw a proper error later on.
-                    const linkedDefinedType = linkables.get(node, stack);
+                    // FIXME: Keep track of our own internal stack within this visitor (starting from a provided NodePath).
+                    const linkedDefinedType = linkables.get([...stack.getPath(), node]);
                     if (!linkedDefinedType) {
                         return null;
                     }

--- a/packages/visitors-core/src/recordLinkablesVisitor.ts
+++ b/packages/visitors-core/src/recordLinkablesVisitor.ts
@@ -18,7 +18,7 @@ export function getRecordLinkablesVisitor<TNodeKind extends NodeKind>(
         v =>
             interceptVisitor(v, (node, next) => {
                 if (isNode(node, LINKABLE_NODES)) {
-                    linkables.record(node, stack);
+                    linkables.recordPath(stack.getPath());
                 }
                 return next(node);
             }),

--- a/packages/visitors-core/test/recordLinkablesVisitor.test.ts
+++ b/packages/visitors-core/test/recordLinkablesVisitor.test.ts
@@ -45,10 +45,9 @@ test('it records program nodes', () => {
     // When we visit the tree.
     visit(node, visitor);
 
-    // Then we expect program nodes to be recorded and retrievable.
-    const emptyStack = new NodeStack();
-    expect(linkables.get(programLinkNode('programA'), emptyStack)).toEqual(node.program);
-    expect(linkables.get(programLinkNode('programB'), emptyStack)).toEqual(node.additionalPrograms[0]);
+    // Then we expect program paths to be recorded and retrievable.
+    expect(linkables.getPath([programLinkNode('programA')])).toEqual([node, node.program]);
+    expect(linkables.getPath([programLinkNode('programB')])).toEqual([node, node.additionalPrograms[0]]);
 });
 
 test('it records account nodes', () => {
@@ -66,10 +65,9 @@ test('it records account nodes', () => {
     // When we visit the tree.
     visit(node, visitor);
 
-    // Then we expect account nodes to be recorded and retrievable.
-    const emptyStack = new NodeStack();
-    expect(linkables.get(accountLinkNode('accountA', 'myProgram'), emptyStack)).toEqual(node.accounts[0]);
-    expect(linkables.get(accountLinkNode('accountB', 'myProgram'), emptyStack)).toEqual(node.accounts[1]);
+    // Then we expect account paths to be recorded and retrievable.
+    expect(linkables.getPath([accountLinkNode('accountA', 'myProgram')])).toEqual([node, node.accounts[0]]);
+    expect(linkables.getPath([accountLinkNode('accountB', 'myProgram')])).toEqual([node, node.accounts[1]]);
 });
 
 test('it records defined type nodes', () => {
@@ -90,10 +88,9 @@ test('it records defined type nodes', () => {
     // When we visit the tree.
     visit(node, visitor);
 
-    // Then we expect defined type nodes to be recorded and retrievable.
-    const emptyStack = new NodeStack();
-    expect(linkables.get(definedTypeLinkNode('typeA', 'myProgram'), emptyStack)).toEqual(node.definedTypes[0]);
-    expect(linkables.get(definedTypeLinkNode('typeB', 'myProgram'), emptyStack)).toEqual(node.definedTypes[1]);
+    // Then we expect defined type paths to be recorded and retrievable.
+    expect(linkables.getPath([definedTypeLinkNode('typeA', 'myProgram')])).toEqual([node, node.definedTypes[0]]);
+    expect(linkables.getPath([definedTypeLinkNode('typeB', 'myProgram')])).toEqual([node, node.definedTypes[1]]);
 });
 
 test('it records pda nodes', () => {
@@ -111,10 +108,9 @@ test('it records pda nodes', () => {
     // When we visit the tree.
     visit(node, visitor);
 
-    // Then we expect pda nodes to be recorded and retrievable.
-    const emptyStack = new NodeStack();
-    expect(linkables.get(pdaLinkNode('pdaA', 'myProgram'), emptyStack)).toEqual(node.pdas[0]);
-    expect(linkables.get(pdaLinkNode('pdaB', 'myProgram'), emptyStack)).toEqual(node.pdas[1]);
+    // Then we expect pda paths to be recorded and retrievable.
+    expect(linkables.getPath([pdaLinkNode('pdaA', 'myProgram')])).toEqual([node, node.pdas[0]]);
+    expect(linkables.getPath([pdaLinkNode('pdaB', 'myProgram')])).toEqual([node, node.pdas[1]]);
 });
 
 test('it records instruction nodes', () => {
@@ -132,10 +128,9 @@ test('it records instruction nodes', () => {
     // When we visit the tree.
     visit(node, visitor);
 
-    // Then we expect instruction nodes to be recorded and retrievable.
-    const emptyStack = new NodeStack();
-    expect(linkables.get(instructionLinkNode('instructionA', 'myProgram'), emptyStack)).toEqual(node.instructions[0]);
-    expect(linkables.get(instructionLinkNode('instructionB', 'myProgram'), emptyStack)).toEqual(node.instructions[1]);
+    // Then we expect instruction paths to be recorded and retrievable.
+    expect(linkables.getPath([instructionLinkNode('instructionA', 'myProgram')])).toEqual([node, node.instructions[0]]);
+    expect(linkables.getPath([instructionLinkNode('instructionB', 'myProgram')])).toEqual([node, node.instructions[1]]);
 });
 
 test('it records instruction account nodes', () => {
@@ -157,15 +152,18 @@ test('it records instruction account nodes', () => {
     // When we visit the tree.
     visit(node, visitor);
 
-    // Then we expect instruction account nodes to be recorded and retrievable.
-    const emptyStack = new NodeStack();
+    // Then we expect instruction account paths to be recorded and retrievable.
     const instruction = instructionLinkNode('myInstruction', 'myProgram');
-    expect(linkables.get(instructionAccountLinkNode('accountA', instruction), emptyStack)).toEqual(
+    expect(linkables.getPath([instructionAccountLinkNode('accountA', instruction)])).toEqual([
+        node,
+        node.instructions[0],
         instructionAccounts[0],
-    );
-    expect(linkables.get(instructionAccountLinkNode('accountB', instruction), emptyStack)).toEqual(
+    ]);
+    expect(linkables.getPath([instructionAccountLinkNode('accountB', instruction)])).toEqual([
+        node,
+        node.instructions[0],
         instructionAccounts[1],
-    );
+    ]);
 });
 
 test('it records instruction argument nodes', () => {
@@ -187,15 +185,18 @@ test('it records instruction argument nodes', () => {
     // When we visit the tree.
     visit(node, visitor);
 
-    // Then we expect instruction argument nodes to be recorded and retrievable.
-    const emptyStack = new NodeStack();
+    // Then we expect instruction argument paths to be recorded and retrievable.
     const instruction = instructionLinkNode('myInstruction', 'myProgram');
-    expect(linkables.get(instructionArgumentLinkNode('argumentA', instruction), emptyStack)).toEqual(
+    expect(linkables.getPath([instructionArgumentLinkNode('argumentA', instruction)])).toEqual([
+        node,
+        node.instructions[0],
         instructionArguments[0],
-    );
-    expect(linkables.get(instructionArgumentLinkNode('argumentB', instruction), emptyStack)).toEqual(
+    ]);
+    expect(linkables.getPath([instructionArgumentLinkNode('argumentB', instruction)])).toEqual([
+        node,
+        node.instructions[0],
         instructionArguments[1],
-    );
+    ]);
 });
 
 test('it records all linkable before the first visit of the base visitor', () => {
@@ -207,11 +208,10 @@ test('it records all linkable before the first visit of the base visitor', () =>
     // And a recordLinkablesOnFirstVisitVisitor extending a base visitor that
     // stores the linkable programs available at every visit.
     const linkables = new LinkableDictionary();
-    const emptyStack = new NodeStack();
     const events: string[] = [];
     const baseVisitor = interceptFirstVisitVisitor(voidVisitor(), (node, next) => {
-        events.push(`programA:${linkables.has(programLinkNode('programA'), emptyStack)}`);
-        events.push(`programB:${linkables.has(programLinkNode('programB'), emptyStack)}`);
+        events.push(`programA:${linkables.has([programLinkNode('programA')])}`);
+        events.push(`programB:${linkables.has([programLinkNode('programB')])}`);
         next(node);
     });
     const visitor = recordLinkablesOnFirstVisitVisitor(baseVisitor, linkables);
@@ -245,7 +245,7 @@ test('it keeps track of the current program when extending a visitor', () => {
     const baseVisitor = interceptVisitor(voidVisitor(), (node, next) => {
         stack.push(node);
         if (isNode(node, 'programNode')) {
-            dictionary[node.name] = linkables.getOrThrow(accountLinkNode('someAccount'), stack);
+            dictionary[node.name] = linkables.getOrThrow([...stack.getPath(), accountLinkNode('someAccount')]);
         }
         next(node);
         stack.pop();
@@ -285,7 +285,10 @@ test('it keeps track of the current instruction when extending a visitor', () =>
     const baseVisitor = interceptVisitor(voidVisitor(), (node, next) => {
         stack.push(node);
         if (isNode(node, 'instructionNode')) {
-            dictionary[node.name] = linkables.getOrThrow(instructionAccountLinkNode('someAccount'), stack);
+            dictionary[node.name] = linkables.getOrThrow([
+                ...stack.getPath(),
+                instructionAccountLinkNode('someAccount'),
+            ]);
         }
         next(node);
         stack.pop();
@@ -312,8 +315,7 @@ test('it does not record linkable types that are not under a program node', () =
     visit(node, visitor);
 
     // Then we expect the account node to not be recorded.
-    const emptyStack = new NodeStack();
-    expect(linkables.has(accountLinkNode('someAccount'), emptyStack)).toBe(false);
+    expect(linkables.has([accountLinkNode('someAccount')])).toBe(false);
 });
 
 test('it can throw an exception when trying to retrieve a missing linked node', () => {
@@ -330,8 +332,7 @@ test('it can throw an exception when trying to retrieve a missing linked node', 
     visit(node, visitor);
 
     // When we try to retrieve a missing account node.
-    const emptyStack = new NodeStack();
-    const getMissingAccount = () => linkables.getOrThrow(accountLinkNode('missingAccount', 'myProgram'), emptyStack);
+    const getMissingAccount = () => linkables.getOrThrow([node, accountLinkNode('missingAccount', 'myProgram')]);
 
     // Then we expect an exception to be thrown.
     expect(getMissingAccount).toThrow(

--- a/packages/visitors/src/fillDefaultPdaSeedValuesVisitor.ts
+++ b/packages/visitors/src/fillDefaultPdaSeedValuesVisitor.ts
@@ -41,7 +41,7 @@ export function fillDefaultPdaSeedValuesVisitor(
                 assertIsNode(visitedNode, 'pdaValueNode');
                 const foundPda = isNode(visitedNode.pda, 'pdaNode')
                     ? visitedNode.pda
-                    : linkables.get(visitedNode.pda, stack);
+                    : linkables.get([...stack.getPath(), visitedNode.pda]);
                 if (!foundPda) return visitedNode;
                 const seeds = addDefaultSeedValuesFromPdaWhenMissing(instruction, foundPda, visitedNode.seeds);
                 if (strictMode && !allSeedsAreValid(instruction, foundPda, seeds)) {

--- a/packages/visitors/src/unwrapDefinedTypesVisitor.ts
+++ b/packages/visitors/src/unwrapDefinedTypesVisitor.ts
@@ -25,7 +25,9 @@ export function unwrapDefinedTypesVisitor(typesToInline: string[] | '*' = '*') {
                     if (!shouldInline(linkType.name)) {
                         return linkType;
                     }
-                    return visit(linkables.getOrThrow(linkType, stack).type, self);
+                    const definedType = linkables.getOrThrow(stack.getPath('definedTypeLinkNode'));
+                    // FIXME: Wrap in heap.pushStack() and heap.popStack().
+                    return visit(definedType.type, self);
                 },
 
                 visitProgram(program, { self }) {

--- a/packages/visitors/src/unwrapTypeDefinedLinksVisitor.ts
+++ b/packages/visitors/src/unwrapTypeDefinedLinksVisitor.ts
@@ -1,29 +1,21 @@
-import { assertIsNode } from '@codama/nodes';
 import {
     BottomUpNodeTransformerWithSelector,
     bottomUpTransformerVisitor,
     LinkableDictionary,
-    NodeStack,
     pipe,
     recordLinkablesOnFirstVisitVisitor,
-    recordNodeStackVisitor,
 } from '@codama/visitors-core';
 
 export function unwrapTypeDefinedLinksVisitor(definedLinksType: string[]) {
     const linkables = new LinkableDictionary();
-    const stack = new NodeStack();
 
     const transformers: BottomUpNodeTransformerWithSelector[] = definedLinksType.map(selector => ({
         select: ['[definedTypeLinkNode]', selector],
-        transform: node => {
-            assertIsNode(node, 'definedTypeLinkNode');
-            return linkables.getOrThrow(node, stack).type;
+        transform: (_, stack) => {
+            const definedType = linkables.getOrThrow(stack.getPath('definedTypeLinkNode'));
+            return definedType.type;
         },
     }));
 
-    return pipe(
-        bottomUpTransformerVisitor(transformers),
-        v => recordNodeStackVisitor(v, stack),
-        v => recordLinkablesOnFirstVisitVisitor(v, linkables),
-    );
+    return pipe(bottomUpTransformerVisitor(transformers), v => recordLinkablesOnFirstVisitVisitor(v, linkables));
 }

--- a/packages/visitors/test/fillDefaultPdaSeedValuesVisitor.test.ts
+++ b/packages/visitors/test/fillDefaultPdaSeedValuesVisitor.test.ts
@@ -39,7 +39,7 @@ test('it fills missing pda seed values with default values', () => {
 
     // And a linkable dictionary that recorded this PDA.
     const linkables = new LinkableDictionary();
-    linkables.record(pda, new NodeStack([program, pda]));
+    linkables.recordPath([program, pda]);
 
     // And a pdaValueNode with a single seed filled.
     const node = pdaValueNode('myPda', [pdaSeedValueNode('seed1', numberValueNode(42))]);
@@ -91,7 +91,7 @@ test('it fills nested pda value nodes', () => {
 
     // And a linkable dictionary that recorded this PDA.
     const linkables = new LinkableDictionary();
-    linkables.record(pda, new NodeStack([program, pda]));
+    linkables.recordPath([program, pda]);
 
     // And a pdaValueNode nested inside a conditionalValueNode.
     const node = conditionalValueNode({
@@ -149,7 +149,7 @@ test('it ignores default seeds missing from the instruction', () => {
 
     // And a linkable dictionary that recorded this PDA.
     const linkables = new LinkableDictionary();
-    linkables.record(pda, new NodeStack([program, pda]));
+    linkables.recordPath([program, pda]);
 
     // And a pdaValueNode with a single seed filled.
     const node = pdaValueNode('myPda', [pdaSeedValueNode('seed1', numberValueNode(42))]);


### PR DESCRIPTION
This PR records and resolves `NodePaths` instead of `Nodes` in `LinkableDictionaries`. This means, we can now access the whole path from the nodes we resolve and, therefore, push that path within our current `NodeStack`.