### PR TITLE
Use NodePaths in renderers-js

### DIFF
--- a/packages/renderers-js/src/fragments/accountFetchHelpers.ts
+++ b/packages/renderers-js/src/fragments/accountFetchHelpers.ts
@@ -1,4 +1,5 @@
 import { AccountNode } from '@codama/nodes';
+import { getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { TypeManifest } from '../TypeManifest';
@@ -6,11 +7,12 @@ import { Fragment, fragment, fragmentFromTemplate } from './common';
 
 export function getAccountFetchHelpersFragment(
     scope: Pick<GlobalFragmentScope, 'customAccountData' | 'nameApi'> & {
-        accountNode: AccountNode;
+        accountPath: NodePath<AccountNode>;
         typeManifest: TypeManifest;
     },
 ): Fragment {
-    const { accountNode, typeManifest, nameApi, customAccountData } = scope;
+    const { accountPath, typeManifest, nameApi, customAccountData } = scope;
+    const accountNode = getLastNodeFromPath(accountPath);
     const hasCustomData = customAccountData.has(accountNode.name);
     const accountTypeFragment = hasCustomData
         ? typeManifest.strictType.clone()

--- a/packages/renderers-js/src/fragments/accountPdaHelpers.ts
+++ b/packages/renderers-js/src/fragments/accountPdaHelpers.ts
@@ -1,5 +1,5 @@
 import { AccountNode, isNodeFilter } from '@codama/nodes';
-import { NodeStack } from '@codama/visitors-core';
+import { findProgramNodeFromPath, getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import type { TypeManifest } from '../TypeManifest';
@@ -7,13 +7,14 @@ import { Fragment, fragment, fragmentFromTemplate } from './common';
 
 export function getAccountPdaHelpersFragment(
     scope: Pick<GlobalFragmentScope, 'customAccountData' | 'linkables' | 'nameApi'> & {
-        accountNode: AccountNode;
-        accountStack: NodeStack;
+        accountPath: NodePath<AccountNode>;
         typeManifest: TypeManifest;
     },
 ): Fragment {
-    const { accountNode, accountStack, nameApi, linkables, customAccountData, typeManifest } = scope;
-    const pdaNode = accountNode.pda ? linkables.get([...accountStack.getPath(), accountNode.pda]) : undefined;
+    const { accountPath, nameApi, linkables, customAccountData, typeManifest } = scope;
+    const accountNode = getLastNodeFromPath(accountPath);
+    const programNode = findProgramNodeFromPath(accountPath)!;
+    const pdaNode = accountNode.pda ? linkables.get([...accountPath, accountNode.pda]) : undefined;
     if (!pdaNode) {
         return fragment('');
     }
@@ -39,7 +40,7 @@ export function getAccountPdaHelpersFragment(
         findPdaFunction,
         hasVariableSeeds,
         pdaSeedsType,
-        program: accountStack.getProgram(),
+        program: programNode,
     })
         .mergeImportsWith(accountTypeFragment)
         .addImports(importFrom, hasVariableSeeds ? [pdaSeedsType, findPdaFunction] : [findPdaFunction])

--- a/packages/renderers-js/src/fragments/accountSizeHelpers.ts
+++ b/packages/renderers-js/src/fragments/accountSizeHelpers.ts
@@ -1,12 +1,14 @@
 import { AccountNode } from '@codama/nodes';
+import { getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { Fragment, fragment, fragmentFromTemplate } from './common';
 
 export function getAccountSizeHelpersFragment(
-    scope: Pick<GlobalFragmentScope, 'nameApi'> & { accountNode: AccountNode },
+    scope: Pick<GlobalFragmentScope, 'nameApi'> & { accountPath: NodePath<AccountNode> },
 ): Fragment {
-    const { accountNode, nameApi } = scope;
+    const { accountPath, nameApi } = scope;
+    const accountNode = getLastNodeFromPath(accountPath);
     if (accountNode.size == null) {
         return fragment('');
     }

--- a/packages/renderers-js/src/fragments/accountType.ts
+++ b/packages/renderers-js/src/fragments/accountType.ts
@@ -1,4 +1,5 @@
 import { AccountNode } from '@codama/nodes';
+import { getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { TypeManifest } from '../TypeManifest';
@@ -7,11 +8,12 @@ import { getTypeWithCodecFragment } from './typeWithCodec';
 
 export function getAccountTypeFragment(
     scope: Pick<GlobalFragmentScope, 'customAccountData' | 'nameApi'> & {
-        accountNode: AccountNode;
+        accountPath: NodePath<AccountNode>;
         typeManifest: TypeManifest;
     },
 ): Fragment {
-    const { accountNode, typeManifest, nameApi, customAccountData } = scope;
+    const { accountPath, typeManifest, nameApi, customAccountData } = scope;
+    const accountNode = getLastNodeFromPath(accountPath);
 
     if (customAccountData.has(accountNode.name)) {
         return fragment('');

--- a/packages/renderers-js/src/fragments/instructionByteDelta.ts
+++ b/packages/renderers-js/src/fragments/instructionByteDelta.ts
@@ -1,15 +1,16 @@
 import { assertIsNode, camelCase, InstructionByteDeltaNode, InstructionNode, isNode } from '@codama/nodes';
+import { getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { Fragment, fragment, mergeFragments } from './common';
 
 export function getInstructionByteDeltaFragment(
     scope: Pick<GlobalFragmentScope, 'asyncResolvers' | 'getImportFrom' | 'nameApi'> & {
-        instructionNode: InstructionNode;
+        instructionPath: NodePath<InstructionNode>;
         useAsync: boolean;
     },
 ): Fragment {
-    const { byteDeltas } = scope.instructionNode;
+    const { byteDeltas } = getLastNodeFromPath(scope.instructionPath);
     const fragments = (byteDeltas ?? []).flatMap(r => getByteDeltaFragment(r, scope));
     if (fragments.length === 0) return fragment('');
     return mergeFragments(

--- a/packages/renderers-js/src/fragments/instructionData.ts
+++ b/packages/renderers-js/src/fragments/instructionData.ts
@@ -1,4 +1,5 @@
 import { InstructionNode } from '@codama/nodes';
+import { getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { TypeManifest } from '../TypeManifest';
@@ -8,10 +9,11 @@ import { getTypeWithCodecFragment } from './typeWithCodec';
 export function getInstructionDataFragment(
     scope: Pick<GlobalFragmentScope, 'customInstructionData' | 'nameApi'> & {
         dataArgsManifest: TypeManifest;
-        instructionNode: InstructionNode;
+        instructionPath: NodePath<InstructionNode>;
     },
 ): Fragment {
-    const { instructionNode, dataArgsManifest, nameApi, customInstructionData } = scope;
+    const { instructionPath, dataArgsManifest, nameApi, customInstructionData } = scope;
+    const instructionNode = getLastNodeFromPath(instructionPath);
     if (instructionNode.arguments.length === 0 || customInstructionData.has(instructionNode.name)) {
         return fragment('');
     }

--- a/packages/renderers-js/src/fragments/instructionExtraArgs.ts
+++ b/packages/renderers-js/src/fragments/instructionExtraArgs.ts
@@ -1,4 +1,5 @@
 import { InstructionNode } from '@codama/nodes';
+import { getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 
 import { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { TypeManifest } from '../TypeManifest';
@@ -7,10 +8,11 @@ import { Fragment, fragment, fragmentFromTemplate } from './common';
 export function getInstructionExtraArgsFragment(
     scope: Pick<GlobalFragmentScope, 'nameApi'> & {
         extraArgsManifest: TypeManifest;
-        instructionNode: InstructionNode;
+        instructionPath: NodePath<InstructionNode>;
     },
 ): Fragment {
-    const { instructionNode, extraArgsManifest, nameApi } = scope;
+    const { instructionPath, extraArgsManifest, nameApi } = scope;
+    const instructionNode = getLastNodeFromPath(instructionPath);
     if ((instructionNode.extraArguments ?? []).length === 0) {
         return fragment('');
     }

--- a/packages/renderers-js/src/fragments/instructionInputResolved.ts
+++ b/packages/renderers-js/src/fragments/instructionInputResolved.ts
@@ -1,5 +1,5 @@
 import { camelCase, InstructionNode, isNode } from '@codama/nodes';
-import { ResolvedInstructionInput } from '@codama/visitors-core';
+import { getLastNodeFromPath, NodePath, ResolvedInstructionInput } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { Fragment, fragment, mergeFragments } from './common';
@@ -7,16 +7,17 @@ import { getInstructionInputDefaultFragment } from './instructionInputDefault';
 
 export function getInstructionInputResolvedFragment(
     scope: Pick<GlobalFragmentScope, 'asyncResolvers' | 'getImportFrom' | 'nameApi' | 'typeManifestVisitor'> & {
-        instructionNode: InstructionNode;
+        instructionPath: NodePath<InstructionNode>;
         resolvedInputs: ResolvedInstructionInput[];
         useAsync: boolean;
     },
 ): Fragment {
+    const instructionNode = getLastNodeFromPath(scope.instructionPath);
     const resolvedInputFragments = scope.resolvedInputs.flatMap((input: ResolvedInstructionInput): Fragment[] => {
         const inputFragment = getInstructionInputDefaultFragment({
             ...scope,
             input,
-            optionalAccountStrategy: scope.instructionNode.optionalAccountStrategy,
+            optionalAccountStrategy: instructionNode.optionalAccountStrategy,
         });
         if (!inputFragment.render) return [];
         const camelName = camelCase(input.name);

--- a/packages/renderers-js/src/fragments/instructionInputType.ts
+++ b/packages/renderers-js/src/fragments/instructionInputType.ts
@@ -7,6 +7,8 @@ import {
     pascalCase,
 } from '@codama/nodes';
 import {
+    getLastNodeFromPath,
+    NodePath,
     ResolvedInstructionAccount,
     ResolvedInstructionArgument,
     ResolvedInstructionInput,
@@ -20,13 +22,14 @@ import { Fragment, fragment, fragmentFromTemplate, mergeFragments } from './comm
 export function getInstructionInputTypeFragment(
     scope: Pick<GlobalFragmentScope, 'asyncResolvers' | 'customInstructionData' | 'nameApi'> & {
         dataArgsManifest: TypeManifest;
-        instructionNode: InstructionNode;
+        instructionPath: NodePath<InstructionNode>;
         renamedArgs: Map<string, string>;
         resolvedInputs: ResolvedInstructionInput[];
         useAsync: boolean;
     },
 ): Fragment {
-    const { instructionNode, useAsync, nameApi } = scope;
+    const { instructionPath, useAsync, nameApi } = scope;
+    const instructionNode = getLastNodeFromPath(instructionPath);
 
     const instructionInputType = useAsync
         ? nameApi.instructionAsyncInputType(instructionNode.name)
@@ -57,12 +60,13 @@ export function getInstructionInputTypeFragment(
 
 function getAccountsFragment(
     scope: Pick<GlobalFragmentScope, 'asyncResolvers' | 'customInstructionData' | 'nameApi'> & {
-        instructionNode: InstructionNode;
+        instructionPath: NodePath<InstructionNode>;
         resolvedInputs: ResolvedInstructionInput[];
         useAsync: boolean;
     },
 ): Fragment {
-    const { instructionNode, resolvedInputs, useAsync, asyncResolvers } = scope;
+    const { instructionPath, resolvedInputs, useAsync, asyncResolvers } = scope;
+    const instructionNode = getLastNodeFromPath(instructionPath);
 
     const fragments = instructionNode.accounts.map(account => {
         const resolvedAccount = resolvedInputs.find(
@@ -113,12 +117,13 @@ function getAccountTypeFragment(account: Pick<ResolvedInstructionAccount, 'isPda
 function getDataArgumentsFragments(
     scope: Pick<GlobalFragmentScope, 'customInstructionData' | 'nameApi'> & {
         dataArgsManifest: TypeManifest;
-        instructionNode: InstructionNode;
+        instructionPath: NodePath<InstructionNode>;
         renamedArgs: Map<string, string>;
         resolvedInputs: ResolvedInstructionInput[];
     },
 ): [Fragment, Fragment] {
-    const { instructionNode, nameApi } = scope;
+    const { instructionPath, nameApi } = scope;
+    const instructionNode = getLastNodeFromPath(instructionPath);
 
     const customData = scope.customInstructionData.get(instructionNode.name);
     if (customData) {
@@ -143,12 +148,13 @@ function getDataArgumentsFragments(
 
 function getExtraArgumentsFragment(
     scope: Pick<GlobalFragmentScope, 'nameApi'> & {
-        instructionNode: InstructionNode;
+        instructionPath: NodePath<InstructionNode>;
         renamedArgs: Map<string, string>;
         resolvedInputs: ResolvedInstructionInput[];
     },
 ): Fragment {
-    const { instructionNode, nameApi } = scope;
+    const { instructionPath, nameApi } = scope;
+    const instructionNode = getLastNodeFromPath(instructionPath);
     const instructionExtraName = nameApi.instructionExtraType(instructionNode.name);
     const extraArgsType = nameApi.dataArgsType(instructionExtraName);
 

--- a/packages/renderers-js/src/fragments/instructionParseFunction.ts
+++ b/packages/renderers-js/src/fragments/instructionParseFunction.ts
@@ -1,5 +1,5 @@
 import { InstructionNode } from '@codama/nodes';
-import { NodeStack } from '@codama/visitors-core';
+import { findProgramNodeFromPath, getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { TypeManifest } from '../TypeManifest';
@@ -8,11 +8,12 @@ import { Fragment, fragment, fragmentFromTemplate } from './common';
 export function getInstructionParseFunctionFragment(
     scope: Pick<GlobalFragmentScope, 'customInstructionData' | 'nameApi'> & {
         dataArgsManifest: TypeManifest;
-        instructionNode: InstructionNode;
-        instructionStack: NodeStack;
+        instructionPath: NodePath<InstructionNode>;
     },
 ): Fragment {
-    const { instructionNode, instructionStack, dataArgsManifest, nameApi, customInstructionData } = scope;
+    const { instructionPath, dataArgsManifest, nameApi, customInstructionData } = scope;
+    const instructionNode = getLastNodeFromPath(instructionPath);
+    const programNode = findProgramNodeFromPath(instructionPath)!;
     const customData = customInstructionData.get(instructionNode.name);
     const hasAccounts = instructionNode.accounts.length > 0;
     const hasOptionalAccounts = instructionNode.accounts.some(account => account.isOptional);
@@ -23,7 +24,7 @@ export function getInstructionParseFunctionFragment(
     const hasData = !!customData || instructionNode.arguments.length > 0;
 
     const instructionDataName = nameApi.instructionDataType(instructionNode.name);
-    const programAddressConstant = nameApi.programAddressConstant(instructionStack.getProgram()!.name);
+    const programAddressConstant = nameApi.programAddressConstant(programNode.name);
     const dataTypeFragment = fragment(
         customData ? dataArgsManifest.strictType.render : nameApi.dataType(instructionDataName),
     );

--- a/packages/renderers-js/src/fragments/instructionRemainingAccounts.ts
+++ b/packages/renderers-js/src/fragments/instructionRemainingAccounts.ts
@@ -6,17 +6,18 @@ import {
     InstructionRemainingAccountsNode,
     isNode,
 } from '@codama/nodes';
+import { getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { Fragment, fragment, mergeFragments } from './common';
 
 export function getInstructionRemainingAccountsFragment(
     scope: Pick<GlobalFragmentScope, 'asyncResolvers' | 'getImportFrom' | 'nameApi'> & {
-        instructionNode: InstructionNode;
+        instructionPath: NodePath<InstructionNode>;
         useAsync: boolean;
     },
 ): Fragment {
-    const { remainingAccounts } = scope.instructionNode;
+    const { remainingAccounts } = getLastNodeFromPath(scope.instructionPath);
     const fragments = (remainingAccounts ?? []).flatMap(r => getRemainingAccountsFragment(r, scope));
     if (fragments.length === 0) return fragment('');
     return mergeFragments(
@@ -30,7 +31,7 @@ export function getInstructionRemainingAccountsFragment(
 function getRemainingAccountsFragment(
     remainingAccounts: InstructionRemainingAccountsNode,
     scope: Pick<GlobalFragmentScope, 'asyncResolvers' | 'getImportFrom' | 'nameApi'> & {
-        instructionNode: InstructionNode;
+        instructionPath: NodePath<InstructionNode>;
         useAsync: boolean;
     },
 ): Fragment[] {
@@ -50,9 +51,9 @@ function getRemainingAccountsFragment(
 
 function getArgumentValueNodeFragment(
     remainingAccounts: InstructionRemainingAccountsNode,
-    scope: { instructionNode: InstructionNode },
+    scope: { instructionPath: NodePath<InstructionNode> },
 ): Fragment {
-    const { instructionNode } = scope;
+    const instructionNode = getLastNodeFromPath(scope.instructionPath);
     assertIsNode(remainingAccounts.value, 'argumentValueNode');
     const argumentName = camelCase(remainingAccounts.value.name);
     const isOptional = remainingAccounts.isOptional ?? false;

--- a/packages/renderers-js/src/fragments/instructionType.ts
+++ b/packages/renderers-js/src/fragments/instructionType.ts
@@ -1,5 +1,5 @@
 import { InstructionNode, pascalCase } from '@codama/nodes';
-import { NodeStack } from '@codama/visitors-core';
+import { findProgramNodeFromPath, getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { Fragment, fragmentFromTemplate, mergeFragments } from './common';
@@ -8,12 +8,12 @@ import { getInstructionAccountTypeParamFragment } from './instructionAccountType
 
 export function getInstructionTypeFragment(
     scope: Pick<GlobalFragmentScope, 'customInstructionData' | 'linkables' | 'nameApi'> & {
-        instructionNode: InstructionNode;
-        instructionStack: NodeStack;
+        instructionPath: NodePath<InstructionNode>;
     },
 ): Fragment {
-    const { instructionNode, instructionStack, nameApi, customInstructionData } = scope;
-    const programNode = instructionStack.getProgram()!;
+    const { instructionPath, nameApi, customInstructionData } = scope;
+    const instructionNode = getLastNodeFromPath(instructionPath);
+    const programNode = findProgramNodeFromPath(instructionPath)!;
     const hasAccounts = instructionNode.accounts.length > 0;
     const customData = customInstructionData.get(instructionNode.name);
     const hasData = !!customData || instructionNode.arguments.length > 0;
@@ -25,7 +25,7 @@ export function getInstructionTypeFragment(
             getInstructionAccountTypeParamFragment({
                 ...scope,
                 allowAccountMeta: true,
-                instructionAccountNode: account,
+                instructionAccountPath: [...instructionPath, account],
             }),
         ),
         renders => renders.join(', '),

--- a/packages/renderers-js/src/fragments/pdaFunction.ts
+++ b/packages/renderers-js/src/fragments/pdaFunction.ts
@@ -1,5 +1,5 @@
 import { isNode, isNodeFilter, PdaNode } from '@codama/nodes';
-import { NodeStack, visit } from '@codama/visitors-core';
+import { findProgramNodeFromPath, getLastNodeFromPath, NodePath, visit } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { ImportMap } from '../ImportMap';
@@ -7,11 +7,12 @@ import { Fragment, fragmentFromTemplate } from './common';
 
 export function getPdaFunctionFragment(
     scope: Pick<GlobalFragmentScope, 'nameApi' | 'typeManifestVisitor'> & {
-        pdaNode: PdaNode;
-        pdaStack: NodeStack;
+        pdaPath: NodePath<PdaNode>;
     },
 ): Fragment {
-    const { pdaNode, pdaStack, typeManifestVisitor, nameApi } = scope;
+    const { pdaPath, typeManifestVisitor, nameApi } = scope;
+    const pdaNode = getLastNodeFromPath(pdaPath);
+    const programNode = findProgramNodeFromPath(pdaPath)!;
 
     // Seeds.
     const imports = new ImportMap();
@@ -37,7 +38,7 @@ export function getPdaFunctionFragment(
         findPdaFunction: nameApi.pdaFindFunction(pdaNode.name),
         hasVariableSeeds,
         pdaSeedsType: nameApi.pdaSeedsType(pdaNode.name),
-        programAddress: pdaNode.programId ?? pdaStack.getProgram()!.publicKey,
+        programAddress: pdaNode.programId ?? programNode.publicKey,
         seeds,
     })
         .mergeImportsWith(imports)

--- a/packages/renderers-js/src/getRenderMapVisitor.ts
+++ b/packages/renderers-js/src/getRenderMapVisitor.ts
@@ -147,8 +147,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
 
                     const scope = {
                         ...globalScope,
-                        accountNode: node,
-                        accountStack: stack.clone(),
+                        accountPath: stack.getPath('accountNode'),
                         typeManifest: visit(node, typeManifestVisitor),
                     };
 
@@ -237,8 +236,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                                 strict: nameApi.dataType(instructionExtraName),
                             }),
                         ),
-                        instructionNode: node,
-                        instructionStack: stack,
+                        instructionPath: stack.getPath('instructionNode'),
                         renamedArgs: getRenamedArgsMap(node),
                         resolvedInputs: visit(node, resolvedInstructionInputVisitor),
                     };
@@ -295,7 +293,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                         throw new Error('Account must be visited inside a program.');
                     }
 
-                    const scope = { ...globalScope, pdaNode: node, pdaStack: stack };
+                    const scope = { ...globalScope, pdaPath: stack.getPath('pdaNode') };
                     const pdaFunctionFragment = getPdaFunctionFragment(scope);
                     const imports = new ImportMap().mergeWith(pdaFunctionFragment);
 


### PR DESCRIPTION
This PR refactors the JS renderer to use `NodePaths` in helper fragments.