### PR TITLE
Use NodePaths in NodeSelectors

### DIFF
--- a/.changeset/gold-eyes-battle.md
+++ b/.changeset/gold-eyes-battle.md
@@ -1,0 +1,6 @@
+---
+'@codama/visitors-core': minor
+'@codama/visitors': minor
+---
+
+Use `NodePaths` in `NodeSelectors`

--- a/packages/visitors-core/src/NodePath.ts
+++ b/packages/visitors-core/src/NodePath.ts
@@ -2,7 +2,7 @@ import { assertIsNode, GetNodeFromKind, InstructionNode, isNode, Node, NodeKind,
 
 export type NodePath<TNode extends Node | undefined = undefined> = TNode extends undefined
     ? readonly Node[]
-    : readonly [...Node[], TNode];
+    : readonly [...(readonly Node[]), TNode];
 
 export function getLastNodeFromPath<TNode extends Node>(path: NodePath<TNode>): TNode {
     return path[path.length - 1] as TNode;
@@ -49,7 +49,7 @@ export function getNodePathUntilLastNode<TKind extends NodeKind>(
     return path.slice(0, lastIndex + 1) as unknown as NodePath<GetNodeFromKind<TKind>>;
 }
 
-function isNotEmptyNodePath(path: NodePath | null | undefined): path is NodePath<Node> {
+export function isFilledNodePath(path: NodePath | null | undefined): path is NodePath<Node> {
     return !!path && path.length > 0;
 }
 
@@ -57,14 +57,14 @@ export function isNodePath<TKind extends NodeKind>(
     path: NodePath | null | undefined,
     kind: TKind | TKind[],
 ): path is NodePath<GetNodeFromKind<TKind>> {
-    return isNode(isNotEmptyNodePath(path) ? getLastNodeFromPath<Node>(path) : null, kind);
+    return isNode(isFilledNodePath(path) ? getLastNodeFromPath<Node>(path) : null, kind);
 }
 
 export function assertIsNodePath<TKind extends NodeKind>(
     path: NodePath | null | undefined,
     kind: TKind | TKind[],
 ): asserts path is NodePath<GetNodeFromKind<TKind>> {
-    assertIsNode(isNotEmptyNodePath(path) ? getLastNodeFromPath<Node>(path) : null, kind);
+    assertIsNode(isFilledNodePath(path) ? getLastNodeFromPath<Node>(path) : null, kind);
 }
 
 export function nodePathToStringArray(path: NodePath): string[] {

--- a/packages/visitors-core/src/topDownTransformerVisitor.ts
+++ b/packages/visitors-core/src/topDownTransformerVisitor.ts
@@ -8,14 +8,11 @@ import { pipe } from './pipe';
 import { recordNodeStackVisitor } from './recordNodeStackVisitor';
 import { Visitor } from './visitor';
 
-export type TopDownNodeTransformer<TNode extends Node = Node> = <T extends TNode = TNode>(
-    node: T,
-    stack: NodeStack,
-) => T | null;
+export type TopDownNodeTransformer = <TNode extends Node>(node: TNode, stack: NodeStack) => TNode | null;
 
-export type TopDownNodeTransformerWithSelector<TNode extends Node = Node> = {
+export type TopDownNodeTransformerWithSelector = {
     select: NodeSelector | NodeSelector[];
-    transform: TopDownNodeTransformer<TNode>;
+    transform: TopDownNodeTransformer;
 };
 
 export function topDownTransformerVisitor<TNodeKind extends NodeKind = NodeKind>(
@@ -25,7 +22,7 @@ export function topDownTransformerVisitor<TNodeKind extends NodeKind = NodeKind>
     const transformerFunctions = transformers.map((transformer): TopDownNodeTransformer => {
         if (typeof transformer === 'function') return transformer;
         return (node, stack) =>
-            getConjunctiveNodeSelectorFunction(transformer.select)(node, stack)
+            getConjunctiveNodeSelectorFunction(transformer.select)(stack.getPath())
                 ? transformer.transform(node, stack)
                 : node;
     });
@@ -33,15 +30,15 @@ export function topDownTransformerVisitor<TNodeKind extends NodeKind = NodeKind>
     const stack = new NodeStack();
     return pipe(
         identityVisitor(nodeKeys),
-        v => recordNodeStackVisitor(v, stack),
         v =>
             interceptVisitor(v, (node, next) => {
                 const appliedNode = transformerFunctions.reduce(
-                    (acc, transformer) => (acc === null ? null : transformer(acc, stack.clone())),
+                    (acc, transformer) => (acc === null ? null : transformer(acc, stack)),
                     node as Parameters<typeof next>[0] | null,
                 );
                 if (appliedNode === null) return null;
                 return next(appliedNode);
             }),
+        v => recordNodeStackVisitor(v, stack),
     );
 }

--- a/packages/visitors-core/test/NodeSelector.test.ts
+++ b/packages/visitors-core/test/NodeSelector.test.ts
@@ -10,7 +10,6 @@ import {
     instructionAccountNode,
     instructionArgumentNode,
     instructionNode,
-    isNode,
     Node,
     numberTypeNode,
     optionTypeNode,
@@ -23,9 +22,11 @@ import {
 import { expect, test } from 'vitest';
 
 import {
+    getLastNodeFromPath,
     getNodeSelectorFunction,
     identityVisitor,
     interceptVisitor,
+    isNodePath,
     NodeSelector,
     NodeStack,
     pipe,
@@ -196,12 +197,12 @@ const macro = (selector: NodeSelector, expectedSelected: Node[]) => {
         const selected = [] as Node[];
         const visitor = pipe(
             identityVisitor(),
-            v => recordNodeStackVisitor(v, stack),
             v =>
                 interceptVisitor(v, (node, next) => {
-                    if (selectorFunction(node, stack.clone())) selected.push(node);
+                    if (selectorFunction(stack.getPath())) selected.push(node);
                     return next(node);
                 }),
+            v => recordNodeStackVisitor(v, stack),
         );
 
         // When we visit the tree.
@@ -329,4 +330,7 @@ macro('[accountNode]gift.[publicKeyTypeNode|booleanTypeNode]', [
 ]);
 
 // Select using functions.
-macro(node => isNode(node, 'numberTypeNode') && node.format === 'u32', [tokenDelegatedAmountOption.prefix]);
+macro(
+    path => isNodePath(path, 'numberTypeNode') && getLastNodeFromPath(path).format === 'u32',
+    [tokenDelegatedAmountOption.prefix],
+);

--- a/packages/visitors-core/test/bottomUpTransformerVisitor.test.ts
+++ b/packages/visitors-core/test/bottomUpTransformerVisitor.test.ts
@@ -94,7 +94,7 @@ test('it can transform nodes using multiple node selectors', () => {
     // - the second one selects all nodes with more than one ancestor.
     const visitor = bottomUpTransformerVisitor([
         {
-            select: ['[numberTypeNode]', (_, nodeStack) => nodeStack.getPath().length > 1],
+            select: ['[numberTypeNode]', path => path.length > 2],
             transform: () => stringTypeNode('utf8'),
         },
     ]);

--- a/packages/visitors-core/test/topDownTransformerVisitor.test.ts
+++ b/packages/visitors-core/test/topDownTransformerVisitor.test.ts
@@ -102,7 +102,7 @@ test('it can transform nodes using multiple node selectors', () => {
     // - the second one selects all nodes with more than one ancestor.
     const visitor = topDownTransformerVisitor([
         {
-            select: ['[numberTypeNode]', (_, nodeStack) => nodeStack.getPath().length > 1],
+            select: ['[numberTypeNode]', path => path.length > 2],
             transform: node => numberTypeNode('u64') as typeof node,
         },
     ]);

--- a/packages/visitors/src/setFixedAccountSizesVisitor.ts
+++ b/packages/visitors/src/setFixedAccountSizesVisitor.ts
@@ -1,6 +1,8 @@
-import { accountNode, assertIsNode, isNode } from '@codama/nodes';
+import { accountNode, assertIsNode } from '@codama/nodes';
 import {
     getByteSizeVisitor,
+    getLastNodeFromPath,
+    isNodePath,
     LinkableDictionary,
     NodeStack,
     pipe,
@@ -18,7 +20,7 @@ export function setFixedAccountSizesVisitor() {
     const visitor = topDownTransformerVisitor(
         [
             {
-                select: node => isNode(node, 'accountNode') && node.size === undefined,
+                select: path => isNodePath(path, 'accountNode') && getLastNodeFromPath(path).size === undefined,
                 transform: node => {
                     assertIsNode(node, 'accountNode');
                     const size = visit(node.data, byteSizeVisitor);

--- a/packages/visitors/src/unwrapTupleEnumWithSingleStructVisitor.ts
+++ b/packages/visitors/src/unwrapTupleEnumWithSingleStructVisitor.ts
@@ -3,7 +3,6 @@ import {
     CamelCaseString,
     DefinedTypeNode,
     enumStructVariantTypeNode,
-    EnumTupleVariantTypeNode,
     getAllDefinedTypes,
     isNode,
     resolveNestedTypeNode,
@@ -28,8 +27,7 @@ export function unwrapTupleEnumWithSingleStructVisitor(enumsOrVariantsToUnwrap: 
             ? [() => true]
             : enumsOrVariantsToUnwrap.map(selector => getNodeSelectorFunction(selector));
 
-    const shouldUnwrap = (node: EnumTupleVariantTypeNode, stack: NodeStack): boolean =>
-        selectorFunctions.some(selector => selector(node, stack));
+    const shouldUnwrap = (stack: NodeStack): boolean => selectorFunctions.some(selector => selector(stack.getPath()));
 
     return rootNodeVisitor(root => {
         const typesToPotentiallyUnwrap: string[] = [];
@@ -44,7 +42,7 @@ export function unwrapTupleEnumWithSingleStructVisitor(enumsOrVariantsToUnwrap: 
                     select: '[enumTupleVariantTypeNode]',
                     transform: (node, stack) => {
                         assertIsNode(node, 'enumTupleVariantTypeNode');
-                        if (!shouldUnwrap(node, stack)) return node;
+                        if (!shouldUnwrap(stack)) return node;
                         const tupleNode = resolveNestedTypeNode(node.tuple);
                         if (tupleNode.items.length !== 1) return node;
                         let item = tupleNode.items[0];


### PR DESCRIPTION
This PR uses the new `NodePath` type inside `NodeSelector` types instead of using the combo `Node + NodeStack`.