### PR TITLE
Fix LinkNode paths for getByteSizeVisitor

### DIFF
--- a/.changeset/soft-beds-jam.md
+++ b/.changeset/soft-beds-jam.md
@@ -1,0 +1,5 @@
+---
+'@codama/visitors-core': minor
+---
+
+Fix LinkNode paths for `getByteSizeVisitor`

--- a/packages/renderers-js-umi/src/getRenderMapVisitor.ts
+++ b/packages/renderers-js-umi/src/getRenderMapVisitor.ts
@@ -63,7 +63,6 @@ export type GetRenderMapOptions = {
 export function getRenderMapVisitor(options: GetRenderMapOptions = {}): Visitor<RenderMap> {
     const linkables = new LinkableDictionary();
     const stack = new NodeStack();
-    const byteSizeVisitor = getByteSizeVisitor(linkables, stack);
     let program: ProgramNode | null = null;
 
     const renderParentInstructions = options.renderParentInstructions ?? false;
@@ -100,6 +99,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}): Visitor<
         });
     const typeManifestVisitor = getTypeManifestVisitor();
     const resolvedInstructionInputVisitor = getResolvedInstructionInputsVisitor();
+    const byteSizeVisitor = getByteSizeVisitor(linkables, stack);
 
     function getInstructionAccountType(account: ResolvedInstructionAccount): string {
         if (account.isPda && account.isSigner === false) return 'Pda';


### PR DESCRIPTION
This PR fixes an issue in the `getByteSizeVisitor` where complex link node paths would be incorrectly resolved due to the fact that the `NodeStack` would follow in invalid path in the tree. The new methods to save and restore `NodePaths` inside the `NodeStack` help us fix this.