### PR TITLE
Refactor JS type manifest visitors

### DIFF
--- a/packages/renderers-js-umi/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-js-umi/src/getTypeManifestVisitor.ts
@@ -63,13 +63,12 @@ export function getTypeManifestVisitor(input: {
     getImportFrom: GetImportFromFunction;
     linkables: LinkableDictionary;
     nonScalarEnums: CamelCaseString[];
-    parentName?: { loose: string; strict: string };
     stack?: NodeStack;
 }) {
     const { linkables, nonScalarEnums, customAccountData, customInstructionData, getImportFrom } = input;
-    let parentName = input.parentName ?? null;
-    let parentSize: NumberTypeNode | number | null = null;
     const stack = input.stack ?? new NodeStack();
+    let parentName: { loose: string; strict: string } | null = null;
+    let parentSize: NumberTypeNode | number | null = null;
 
     return pipe(
         staticVisitor(

--- a/packages/renderers-js/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-js/src/getTypeManifestVisitor.ts
@@ -40,12 +40,11 @@ export function getTypeManifestVisitor(input: {
     linkables: LinkableDictionary;
     nameApi: NameApi;
     nonScalarEnums: CamelCaseString[];
-    parentName?: { loose: string; strict: string };
     stack?: NodeStack;
 }) {
     const { nameApi, linkables, nonScalarEnums, customAccountData, customInstructionData, getImportFrom } = input;
     const stack = input.stack ?? new NodeStack();
-    let parentName = input.parentName ?? null;
+    let parentName: { loose: string; strict: string } | null = null;
 
     return pipe(
         staticVisitor(


### PR DESCRIPTION
This PR applies a small refactoring to the JavaScript `getTypeManifestVisitors` that enables them to use the same instead of the visitor.