### PR TITLE
Use program names when unwrapping link nodes

### DIFF
--- a/packages/visitors/src/unwrapInstructionArgsDefinedTypesVisitor.ts
+++ b/packages/visitors/src/unwrapInstructionArgsDefinedTypesVisitor.ts
@@ -1,5 +1,5 @@
-import { assertIsNode, CamelCaseString, getAllDefinedTypes, isNode } from '@codama/nodes';
-import { rootNodeVisitor, visit } from '@codama/visitors-core';
+import { assertIsNode, CamelCaseString, definedTypeLinkNode, isNode } from '@codama/nodes';
+import { getRecordLinkablesVisitor, LinkableDictionary, rootNodeVisitor, visit } from '@codama/visitors-core';
 
 import { getDefinedTypeHistogramVisitor } from './getDefinedTypeHistogramVisitor';
 import { unwrapDefinedTypesVisitor } from './unwrapDefinedTypesVisitor';
@@ -7,18 +7,17 @@ import { unwrapDefinedTypesVisitor } from './unwrapDefinedTypesVisitor';
 export function unwrapInstructionArgsDefinedTypesVisitor() {
     return rootNodeVisitor(root => {
         const histogram = visit(root, getDefinedTypeHistogramVisitor());
-        const allDefinedTypes = getAllDefinedTypes(root);
+        const linkables = new LinkableDictionary();
+        visit(root, getRecordLinkablesVisitor(linkables));
 
-        const definedTypesToInline: string[] = Object.keys(histogram)
+        const definedTypesToInline = (Object.keys(histogram) as CamelCaseString[])
             // Get all defined types used exactly once as an instruction argument.
-            .filter(
-                name =>
-                    (histogram[name as CamelCaseString].total ?? 0) === 1 &&
-                    (histogram[name as CamelCaseString].directlyAsInstructionArgs ?? 0) === 1,
-            )
+            .filter(key => (histogram[key].total ?? 0) === 1 && (histogram[key].directlyAsInstructionArgs ?? 0) === 1)
             // Filter out enums which are better defined as external types.
-            .filter(name => {
-                const found = allDefinedTypes.find(type => type.name === name);
+            .filter(key => {
+                const names = key.split('.');
+                const link = names.length == 2 ? definedTypeLinkNode(names[1], names[0]) : definedTypeLinkNode(key);
+                const found = linkables.get([link]);
                 return found && !isNode(found.type, 'enumTypeNode');
             });
 

--- a/packages/visitors/test/unwrapDefinedTypesVisitor.test.ts
+++ b/packages/visitors/test/unwrapDefinedTypesVisitor.test.ts
@@ -96,7 +96,7 @@ test('it does not unwrap types from the wrong programs', () => {
 
     // When we unwrap the defined type from programA.
     const node = rootNode(programA, [programB]);
-    const result = visit(node, unwrapDefinedTypesVisitor(['myType']));
+    const result = visit(node, unwrapDefinedTypesVisitor(['programA.myType']));
 
     // Then we expect programA to have been modified but not programB.
     assertIsNode(result, 'rootNode');

--- a/packages/visitors/test/unwrapInstructionArgsDefinedTypesVisitor.test.ts
+++ b/packages/visitors/test/unwrapInstructionArgsDefinedTypesVisitor.test.ts
@@ -1,0 +1,190 @@
+import {
+    arrayTypeNode,
+    definedTypeLinkNode,
+    definedTypeNode,
+    fixedCountNode,
+    instructionArgumentNode,
+    instructionNode,
+    numberTypeNode,
+    programNode,
+    rootNode,
+    structFieldTypeNode,
+    structTypeNode,
+} from '@codama/nodes';
+import { visit } from '@codama/visitors-core';
+import { expect, test } from 'vitest';
+
+import { unwrapInstructionArgsDefinedTypesVisitor } from '../src';
+
+test('it unwraps defined type link nodes used as instruction arguments', () => {
+    // Given a program with a type used only once as a direct instruction argument.
+    const node = rootNode(
+        programNode({
+            definedTypes: [
+                definedTypeNode({
+                    name: 'typeA',
+                    type: structTypeNode([structFieldTypeNode({ name: 'foo', type: numberTypeNode('u8') })]),
+                }),
+                definedTypeNode({
+                    name: 'typeB',
+                    type: structTypeNode([structFieldTypeNode({ name: 'bar', type: numberTypeNode('u8') })]),
+                }),
+            ],
+            instructions: [
+                instructionNode({
+                    arguments: [instructionArgumentNode({ name: 'argA', type: definedTypeLinkNode('typeA') })],
+                    name: 'myInstruction',
+                }),
+            ],
+            name: 'MyProgram',
+            publicKey: '1111',
+            version: '1.2.3',
+        }),
+    );
+
+    // When the defined type link nodes are unwrapped.
+    const result = visit(node, unwrapInstructionArgsDefinedTypesVisitor());
+
+    // Then we expect the following node.
+    expect(result).toStrictEqual(
+        rootNode(
+            programNode({
+                definedTypes: [
+                    definedTypeNode({
+                        name: 'typeB',
+                        type: structTypeNode([structFieldTypeNode({ name: 'bar', type: numberTypeNode('u8') })]),
+                    }),
+                ],
+                instructions: [
+                    instructionNode({
+                        arguments: [
+                            instructionArgumentNode({
+                                name: 'argA',
+                                type: structTypeNode([
+                                    structFieldTypeNode({ name: 'foo', type: numberTypeNode('u8') }),
+                                ]),
+                            }),
+                        ],
+                        name: 'myInstruction',
+                    }),
+                ],
+                name: 'MyProgram',
+                publicKey: '1111',
+                version: '1.2.3',
+            }),
+        ),
+    );
+});
+
+test('it does not unwrap defined type link nodes that are used in more than one place.', () => {
+    // Given a link node used in an instruction argument and in another place.
+    const node = rootNode(
+        programNode({
+            definedTypes: [
+                definedTypeNode({
+                    name: 'myType',
+                    type: structTypeNode([structFieldTypeNode({ name: 'foo', type: numberTypeNode('u8') })]),
+                }),
+                definedTypeNode({ name: 'myCopyType', type: definedTypeLinkNode('myType') }),
+            ],
+            instructions: [
+                instructionNode({
+                    arguments: [instructionArgumentNode({ name: 'myArg', type: definedTypeLinkNode('myType') })],
+                    name: 'myInstruction',
+                }),
+            ],
+            name: 'MyProgram',
+            publicKey: '1111',
+            version: '1.2.3',
+        }),
+    );
+
+    // When we try to unwrap defined type link nodes for instruction arguments.
+    const result = visit(node, unwrapInstructionArgsDefinedTypesVisitor());
+
+    // Then we expect the same node.
+    expect(result).toStrictEqual(node);
+});
+
+test('it only unwraps defined type link nodes if they are direct instruction arguments', () => {
+    // Given a link node used in an instruction argument but not as a direct argument.
+    const node = rootNode(
+        programNode({
+            definedTypes: [
+                definedTypeNode({
+                    name: 'myType',
+                    type: structTypeNode([structFieldTypeNode({ name: 'foo', type: numberTypeNode('u8') })]),
+                }),
+            ],
+            instructions: [
+                instructionNode({
+                    arguments: [
+                        instructionArgumentNode({
+                            name: 'myArg',
+                            type: arrayTypeNode(definedTypeLinkNode('myType'), fixedCountNode(3)),
+                        }),
+                    ],
+                    name: 'myInstruction',
+                }),
+            ],
+            name: 'MyProgram',
+            publicKey: '1111',
+            version: '1.2.3',
+        }),
+    );
+
+    // When we try to unwrap defined type link nodes for instruction arguments.
+    const result = visit(node, unwrapInstructionArgsDefinedTypesVisitor());
+
+    // Then we expect the same node.
+    expect(result).toStrictEqual(node);
+});
+
+test('it does not unwrap defined type link nodes from other programs', () => {
+    // Given a program that defines the
+    const programA = programNode({
+        definedTypes: [definedTypeNode({ name: 'myType', type: numberTypeNode('u8') })],
+        instructions: [
+            instructionNode({
+                arguments: [instructionArgumentNode({ name: 'myArg', type: definedTypeLinkNode('myType') })],
+                name: 'myInstruction',
+            }),
+        ],
+        name: 'programA',
+        publicKey: '1111',
+        version: '1.2.3',
+    });
+
+    // And another program with a defined type sharing the same name.
+    const programB = programNode({
+        definedTypes: [
+            definedTypeNode({ name: 'myType', type: numberTypeNode('u16') }),
+            definedTypeNode({ name: 'myCopyType', type: definedTypeLinkNode('myType') }),
+        ],
+        name: 'programB',
+        publicKey: '2222',
+        version: '1.2.3',
+    });
+
+    // When we unwrap defined type link nodes for instruction arguments for both of them.
+    const node = rootNode(programA, [programB]);
+    const result = visit(node, unwrapInstructionArgsDefinedTypesVisitor());
+
+    // Then we expect program A to have been modified but not program B.
+    expect(result).toStrictEqual(
+        rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({
+                        arguments: [instructionArgumentNode({ name: 'myArg', type: numberTypeNode('u8') })],
+                        name: 'myInstruction',
+                    }),
+                ],
+                name: 'programA',
+                publicKey: '1111',
+                version: '1.2.3',
+            }),
+            [programB],
+        ),
+    );
+});

--- a/packages/visitors/test/unwrapInstructionArgsDefinedTypesVisitor.test.ts
+++ b/packages/visitors/test/unwrapInstructionArgsDefinedTypesVisitor.test.ts
@@ -38,7 +38,6 @@ test('it unwraps defined type link nodes used as instruction arguments', () => {
             ],
             name: 'MyProgram',
             publicKey: '1111',
-            version: '1.2.3',
         }),
     );
 
@@ -70,7 +69,6 @@ test('it unwraps defined type link nodes used as instruction arguments', () => {
                 ],
                 name: 'MyProgram',
                 publicKey: '1111',
-                version: '1.2.3',
             }),
         ),
     );
@@ -95,7 +93,6 @@ test('it does not unwrap defined type link nodes that are used in more than one 
             ],
             name: 'MyProgram',
             publicKey: '1111',
-            version: '1.2.3',
         }),
     );
 
@@ -129,7 +126,6 @@ test('it only unwraps defined type link nodes if they are direct instruction arg
             ],
             name: 'MyProgram',
             publicKey: '1111',
-            version: '1.2.3',
         }),
     );
 
@@ -152,7 +148,6 @@ test('it does not unwrap defined type link nodes from other programs', () => {
         ],
         name: 'programA',
         publicKey: '1111',
-        version: '1.2.3',
     });
 
     // And another program with a defined type sharing the same name.
@@ -163,7 +158,6 @@ test('it does not unwrap defined type link nodes from other programs', () => {
         ],
         name: 'programB',
         publicKey: '2222',
-        version: '1.2.3',
     });
 
     // When we unwrap defined type link nodes for instruction arguments for both of them.
@@ -182,7 +176,6 @@ test('it does not unwrap defined type link nodes from other programs', () => {
                 ],
                 name: 'programA',
                 publicKey: '1111',
-                version: '1.2.3',
             }),
             [programB],
         ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3348,7 +3348,7 @@ snapshots:
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,3 @@
+import { defineWorkspace } from 'vitest/config';
+
+export default defineWorkspace(['./packages/internals/vitest.config.node.mts']);


### PR DESCRIPTION
This PR fixes a few issues with the following three visitors.

- `unwrapInstructionArgsDefinedTypesVisitor` which uses:
- `unwrapDefinedTypesVisitor` which uses:
- `getDefinedTypeHistogramVisitor`

Namely, this PR makes it possible for identified `DefinedTypeLinkNodes` to be sandboxed by programs. That way, if two programs inside a `RootNode` provide a type node with the same name, unwrapping one will not affect the other.