### PR TITLE
Update usage of `IInstructionWithData`

### DIFF
--- a/.changeset/spicy-books-remain.md
+++ b/.changeset/spicy-books-remain.md
@@ -1,0 +1,9 @@
+---
+'@codama/renderers-js-umi': minor
+'@codama/dynamic-parsers': minor
+'@codama/dynamic-codecs': minor
+'@codama/renderers-rust': minor
+'@codama/renderers-js': minor
+---
+
+Update usage of `IInstructionWithData` and bump web3.js dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   # Among other things, opts out of Turborepo telemetry. See https://consoledonottrack.com/.
   DO_NOT_TRACK: '1'
-  NODE_VERSION: 18
+  NODE_VERSION: 20
   CODAMA_VERSION: 1.x
   SOLANA_VERSION: 1.18.12
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "zx": "^8.2.2"
     },
     "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
     },
     "packageManager": "pnpm@9.1.0",
     "prettier": "@solana/prettier-config-solana"

--- a/packages/dynamic-codecs/package.json
+++ b/packages/dynamic-codecs/package.json
@@ -53,7 +53,7 @@
         "@codama/errors": "workspace:*",
         "@codama/nodes": "workspace:*",
         "@codama/visitors-core": "workspace:*",
-        "@solana/codecs": "2.0.0"
+        "@solana/codecs": "2.1.0-canary-20241128134801"
     },
     "license": "MIT",
     "repository": {

--- a/packages/dynamic-parsers/package.json
+++ b/packages/dynamic-parsers/package.json
@@ -54,10 +54,10 @@
         "@codama/errors": "workspace:*",
         "@codama/nodes": "workspace:*",
         "@codama/visitors-core": "workspace:*",
-        "@solana/instructions": "2.0.0"
+        "@solana/instructions": "2.1.0-canary-20241128134801"
     },
     "devDependencies": {
-        "@solana/codecs": "2.0.0"
+        "@solana/codecs": "2.1.0-canary-20241128134801"
     },
     "license": "MIT",
     "repository": {

--- a/packages/dynamic-parsers/src/parsers.ts
+++ b/packages/dynamic-parsers/src/parsers.ts
@@ -49,7 +49,7 @@ export function parseInstruction(
     root: RootNode,
     instruction: IInstruction &
         IInstructionWithAccounts<readonly (IAccountLookupMeta | IAccountMeta)[]> &
-        IInstructionWithData<Uint8Array>,
+        IInstructionWithData<ReadonlyUint8Array>,
 ): ParsedInstruction | undefined {
     const parsedData = parseInstructionData(root, instruction.data);
     if (!parsedData) return undefined;

--- a/packages/renderers-js-umi/package.json
+++ b/packages/renderers-js-umi/package.json
@@ -48,7 +48,7 @@
         "@codama/renderers-core": "workspace:*",
         "@codama/validators": "workspace:*",
         "@codama/visitors-core": "workspace:*",
-        "@solana/codecs-strings": "rc",
+        "@solana/codecs-strings": "2.1.0-canary-20241128134801",
         "nunjucks": "^3.2.4",
         "prettier": "^3.4.1"
     },

--- a/packages/renderers-js/e2e/anchor/package.json
+++ b/packages/renderers-js/e2e/anchor/package.json
@@ -22,7 +22,6 @@
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.0",
     "@solana/web3.js": "2.1.0-canary-20241128134801",
-    "@solana/webcrypto-ed25519-polyfill": "2.1.0-canary-20241128134801",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "ava": "^6.1.2",
@@ -35,9 +34,6 @@
     "typescript": "^5.4.2"
   },
   "ava": {
-    "require": [
-      "@solana/webcrypto-ed25519-polyfill"
-    ],
     "typescript": {
       "compile": false,
       "rewritePaths": {

--- a/packages/renderers-js/e2e/anchor/package.json
+++ b/packages/renderers-js/e2e/anchor/package.json
@@ -16,13 +16,13 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@solana/web3.js": "2.0.0-rc.0"
+    "@solana/web3.js": "2.1.0-canary-20241128134801"
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.0",
-    "@solana/web3.js": "rc",
-    "@solana/webcrypto-ed25519-polyfill": "rc",
+    "@solana/web3.js": "2.1.0-canary-20241128134801",
+    "@solana/webcrypto-ed25519-polyfill": "2.1.0-canary-20241128134801",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "ava": "^6.1.2",

--- a/packages/renderers-js/e2e/anchor/pnpm-lock.yaml
+++ b/packages/renderers-js/e2e/anchor/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3))(@typescript-eslint/parser@7.15.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.0))(eslint-plugin-simple-import-sort@10.0.0(eslint@8.57.0))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.2.0(@typescript-eslint/parser@7.15.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
       '@solana/web3.js':
-        specifier: rc
-        version: 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)
       '@solana/webcrypto-ed25519-polyfill':
-        specifier: rc
-        version: 2.0.0-rc.0(typescript@5.5.3)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(typescript@5.5.3)
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.3.1
         version: 7.15.0(@typescript-eslint/parser@7.15.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
@@ -359,49 +359,58 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@solana/accounts@2.0.0-rc.0':
-    resolution: {integrity: sha512-Xun9ASXuJd3njGgc8q32Ra2f2r5J4KNhVZn6g5G//uQVpc+8QpBrTqS0lV+q7f6i0+um8WD4Q7OYOtnRb6mBiA==}
+  '@solana/accounts@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-HTrVWzbaAgxVNstQcYCaz3734Zx/Yf7O3cCecTCwPrLJhgxR10fdk4YekPn+bgceLM7LHhNOQlYAPLyd841PIg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/addresses@2.0.0-rc.0':
-    resolution: {integrity: sha512-cx/Vdwqn7Ns3ud+tyvD5ua4q2UtTleaAWuqyv7opAZLJOZWq2sL9esG3MIEZR5P9wW6sai8Mk9ule1DoWC+pqQ==}
+  '@solana/addresses@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-KKldgGUmjLRQK0+w3UcXKOlHOF0OhuUYoUzXANvshMT3Th/JMglbdvj1YjW9p2WThyQpUVg0X/OYap0v4oLkag==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/assertions@2.0.0-rc.0':
-    resolution: {integrity: sha512-O9g764n0CC3y8OTe7o02syj/S6ecqHvOcquf0z1qwQKZkwCJ8eyb6Xj9l82RKuMEvMtgaIiMrg8jMDo2ML5aCw==}
+  '@solana/assertions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-/BmDS6BD3YoSGMoYTp9BqOMno2QwOyrdYJQ1+CqNidbOMM7qnG+V3cSLPZVmxWoUM4bAo+0PWwALgR04TOvwdw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-core@2.0.0-rc.0':
-    resolution: {integrity: sha512-eIMMZiSfzZNlMK0uJRfpj9URrvuRo8SXncbCva+Wmpaob9dS+Mplo9VrH0T7+aTZJUAb5o9FbZgo4tUAOecVhg==}
+  '@solana/codecs-core@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-Lgd9IZ7coAc6F/X8RAIR+Sc0jIf8jHzYw/g4eBMcJU/Zjmcmja6l+2LGIpdlkn2+x+lMckK3HO4RHifXUS0ytQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-data-structures@2.0.0-rc.0':
-    resolution: {integrity: sha512-CTFOIV+I6LjGosKBkfYYFSRH+i2WG0F46Qf5zBsa52X/UGFFW7Nwaf6XJl84xYIFi4JMMZOA3x221vjK0JoYWg==}
+  '@solana/codecs-data-structures@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-356XK2JCygLz9FZvrSXWLqGhIQZmpKIlwqY8PiZEho4xmWUaupvyvNjWAAohCK8YXhfEMzKOnyoO3yHMLnLJIg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-numbers@2.0.0-rc.0':
-    resolution: {integrity: sha512-KqIU/xuB+IHNex9uYsB9y2MoH6VX2zRBnDJpdu9L/dE9Uw5xVKJRGdeHB9mBC4PBZ90VPMz3mP+xfFIXMS0j8g==}
+  '@solana/codecs-numbers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-2PZ/xY8tOUFjgFuga/tAbinrcS2p9YX3RaxbXvMBJYvi3DAcdi0zqTwE4ganEzfQ5Os9o1shw88zYSKk0vy8lQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-strings@2.0.0-rc.0':
-    resolution: {integrity: sha512-9yYBvJpo1WTT8idzomrHF602Snylo1+pmEGNrYlUaxmzVU2Hdb28U0WKv0iz9TdCDvMDlIwjsBznt6DmVf4i6g==}
+  '@solana/codecs-strings@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-SEmAc9c6692Tm7wEmzot7mxaDsTN3wnA78uDj2IgqXmznLOGfw3kAcA8Xcq6rTL5NhUlePjxaJg6I2T+GRVIRA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
 
-  '@solana/codecs@2.0.0-rc.0':
-    resolution: {integrity: sha512-C92OLr/4k2+o+hlZb5ukXn4/KlDZa/YMvgVYlKk87+RoSPLS6/WWHpU8+Anh2bAW8TD+BwFx4p1WtLWPd6Jwdg==}
+  '@solana/codecs@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-uQ9rI7odB91z9jI0lR1LnBMohmk2MnZTYVRl0CDEEfet57UfaFFV0T++x5LV4zpUL8TeBqj1OQQE/zSdl2BRUg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/errors@2.0.0-rc.0':
-    resolution: {integrity: sha512-4zaFxuYWQJi+CBucncGPc+QsWZktdmC6rDne3JxZGDKqqY5AMwktRC9LyUKaey/dVThmFGo1wv1wNQy1ryvbWw==}
+  '@solana/errors@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-l3bv0rIwhbmumsqIT6j4zxBKdStgfQIfUio85P3lzMCh+0eTp+1hAGvsXQMbXtZ8ovLe5xiV3g1PB8Kr0a2h3w==}
+    engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
       typescript: '>=5'
@@ -419,129 +428,166 @@ packages:
       eslint-plugin-typescript-sort-keys: ^3.2.0
       typescript: ^5.1.6
 
-  '@solana/fast-stable-stringify@2.0.0-rc.0':
-    resolution: {integrity: sha512-qpHZNKzVP5PFEIK1TQvIM+A+DjSCV53KaxXzxPFiYd/JfjdxIhH6h1C0bbRMdsbBqwWlbacs2H5/xrKP3X42cw==}
+  '@solana/fast-stable-stringify@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-w+5mMzLH7y/mIa9/iMOEoebrKbW8Sz8VkS3EKjUNmUy48Vbk+27xryK46xbVoTFz2rcX0lrDcKDpilOhhPAh1w==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/functional@2.0.0-rc.0':
-    resolution: {integrity: sha512-Z+nkjtWyjp3yktU8ip2MxbKb7+I2YUiY8kbpvxAWnWKGcUoKhgcW3EhxhSxFWKbaiEcBmyoPCEdM2MJgJPZJug==}
+  '@solana/functional@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-5CX30yRL2iG3YL8Mofe+OMKe373FQJa/P6bPiD91SJ93o17dQtvUIQ+JnKNRKi+ZSZCBr1j/+2S8g4aQOEFOhA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/instructions@2.0.0-rc.0':
-    resolution: {integrity: sha512-0/MQ80BXZfELZuCc7GudopuCpQC4VnN9WJDHtR8Tur0j8shiSyHWOOZlWfx66eQuSiQsnbOLT1CRTdhEt/vZhA==}
+  '@solana/instructions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-RCxxH9mMFruqAz3Py1q5GJJECi1KWZiJQpqMiUhDH5f3LkNsDQqmi2VL2ByGnUKSptPRhyEWrpItR3ZQCUmJ4Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/keys@2.0.0-rc.0':
-    resolution: {integrity: sha512-k/2uvObJdQfsmKUI+vL+9zcRRdZpaScq0SKIQLe33dbv+3XIEhCRizPEIg8Q8fzIKB9rrbwHqJ5RPDxThZa++g==}
+  '@solana/keys@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-sGIkISsZHZagO9I6gmZSDiUMJIlHj833ULDyGcH9P9MLhs1sNYM2iW8FvDxWFY6/c3aYSyOZ28QSHHoaTKUsUA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/options@2.0.0-rc.0':
-    resolution: {integrity: sha512-uPc/31v+FZj9mkq2mQ6uAJfvmxGnQsx2mJ90IlJdDLSlkcx6GymNyXp0meh8qfhvfEaz4F5lCOzSeApofIZPvw==}
+  '@solana/options@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-f9Zbn1nhG0P3dxjl4LnA9FsJWCeVgSgkeix1hx85p8dbVy3q8NLNVCkyK2osC7KW655f6CL113vyl1dzkscm9w==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/programs@2.0.0-rc.0':
-    resolution: {integrity: sha512-sihHN5HDXEXJnoeG/hnahFreF6d2AMGIELtF2kv5uHM9F5NcdYFmX1Q0tWBC6Y/DugIf3Qtk+jMFceM7qUoWXA==}
+  '@solana/programs@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-32KEp3LiVH7joX55S111NV1Yh0udohddEtMAVWWKwgMClbaAkd3ATV978ahGk3VFLeyICvpndwQ29D4SxXqPXw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-api@2.0.0-rc.0':
-    resolution: {integrity: sha512-vP21oksg3lU8bbSyJfgfT9a/eeQ/q5sN76VSR05T7j3Tv8VmI9N77ZNrtrfG4DZfIiYWw3qlSrVI8XTwgMIW8A==}
+  '@solana/promises@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-ToZnDEGUwsHVQYgxuGC0qC6Rwir+9YoUnJHB4tQ8Qt9XS13FdgQuofeGsMZFZQFadbtrWJ5ROI4Z974/oCvIYA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-parsed-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-EvyOGZ6vbKG5XWDoPmNpMbm4Z0HE+hEIBxhQFkB+ML+qKPghtrifyF0bvydna7AIBkpc0OccVmv22Vd+gBvHng==}
+  '@solana/rpc-api@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-xpb8QLFMg6WXxXJdTSQ+536SAQTjiNKvccT074enGcXFsqIHoVfP+zHRYdUwypORnJ7xFPNgo5SAnFGNxIZWOg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-spec-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-0h2uQfjHIoUpP5ha3lzLFep6WLnggrksjWiCd8+iIoktPeh09CPJI2iU/hFheP7e+tUKhmErGqsL+OPNECwD2g==}
+  '@solana/rpc-parsed-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-jmKsbywEJ0Kil1aIYHiwPn37hofrAREOw49R2Go3Aw91zzAFOVXM2wuJ9WtK5U4JD36KCdDcX8t8aHKdHM/uJw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-spec@2.0.0-rc.0':
-    resolution: {integrity: sha512-Cdwj8ief8ek5VUWRfSZDqdFzRfC6HVzyoPMIOdWRtEd8KocUGo7BTbwN9ilVJL/vIi52vi6e2A6oPMFNRyuBFw==}
+  '@solana/rpc-spec-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-0aAOaxbBNaJomDDgyY/QoDID/vyVSfzU0/qRFVfWE0DVROGXa9cbGyH2I/FkLrfbuCc0TNi0150NmLLkHJK9VQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-api@2.0.0-rc.0':
-    resolution: {integrity: sha512-Q4/rR4epPud7Z/3lrtGNMJd5oSrrxp/JgJTnkxEzGxs07RHmVfvO/9jrS+dgDtj3epyjD4BhmecO98Bg8bZ2yg==}
+  '@solana/rpc-spec@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-I2XsRVtIU3RqihaVsTZP5itXZQ3mLD90sQ/GBYMSu9TVZfOgLdOFP0RpdQG5wIZvOun05vemon5f3PRIYfJyLQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-spec@2.0.0-rc.0':
-    resolution: {integrity: sha512-ZUxFAGy1nAIpLZ3RgWsRlRvPOLlx/vk1isFo5YcA+GAFZDLIt+jOZJF/J6QUjOohMc5xSkTRmJuMURCDmu+1dg==}
+  '@solana/rpc-subscriptions-api@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-+R/SBC+llwUUMVxolBgxrUWYrB/V6ybRkxF2ERB/ENC5EECM/Z3t8ZzXh6UwI0JTnjFoLivjUeZsrlKkLZC50A==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-transport-websocket@2.0.0-rc.0':
-    resolution: {integrity: sha512-Qg3w/zMAVaXhm/WQYFV0qXUjUDKmSJrRG/CzdjMfiqYPSFX1286uwyq5wnua4NzrbPd+ZtbGKyvdSVRnmy1WkA==}
+  '@solana/rpc-subscriptions-channel-websocket@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-RKIuZVFBTKGivLGiDQDwzu/uIGWMaFYGI4nWHjs0joCLr+Ixh4L7moeoimBUJtg3mWJ9/t8G/58ZcTEhiFrFOg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
-      ws: ^7.5.9
+      ws: ^8.18.0
 
-  '@solana/rpc-subscriptions@2.0.0-rc.0':
-    resolution: {integrity: sha512-ThLHuf6dxpq1RTWu7GAItjLubhcJsBdhGdGGtPjGEBW1zX5YnGLsG2sc16XLgbH5LZhUDQ37wub6iwMTOBqVhA==}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/rpc-transformers@2.0.0-rc.0':
-    resolution: {integrity: sha512-F/aL/ivIh2rPIpAGId8ZC3WG88wv025yLSmAhFZUOSbvF1ZCp8h63TUS5qpRGbDVUNr7PLu2Cm8EMkF6MoDSDA==}
+  '@solana/rpc-subscriptions-spec@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-/566STNmiTDjCIpwHZ7GCW/7qXdCBkE9shgjMFhYEKc1Kx+iOQJkFrHgVpaYH1stfs4+duRO8CYNrpCFkJfqOQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-transport-http@2.0.0-rc.0':
-    resolution: {integrity: sha512-ZuT3nhlfTGcDXjEkVlwG+XeLUKLxZvh/Am1em2vO8zGSQJmtFKlEq+Wk3C55acs0CrH00s29w3TcEcTtltikbg==}
+  '@solana/rpc-subscriptions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-u+GfSMAeLCpljznTJVk2FWOMPak/jYmYgKhH1V/ekIMol/9u7c/DaQmRrfvOjEYzxa3btRfem+kRkuoGw5n3cQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-KFuPmkVlZitZnncDGbwu5FSFXljHQsWb4u6fJbmq0yNGwjAlUspOnl7ufL0bS7e+hh0NKfyNOXWuC4vmYEMThw==}
+  '@solana/rpc-transformers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-rmyuZOYxmj7mmGrkLK9Ksc0GJ8bKACWgtHcgjhmPHJYIvSkFrGRoSxD45Y3d5sYN+cW8lrvQwB7GX6wC0ArFtQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc@2.0.0-rc.0':
-    resolution: {integrity: sha512-isWQk5Cfu3hmjdzMfYLPn65KTkJHARocwx8i1+hF53kqrgvFGgAWtqDJXJfjkEan8ksSRfI5FzZB02YFB4zKSw==}
+  '@solana/rpc-transport-http@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-sE0dNSkOtCQyZa5CD7lGykzFIXxyQ+kPYa8FAnTqeojFGFUsj5nuME9Q+u0KvMPMAcqvWndIC3oxn7zyQuyxpQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/signers@2.0.0-rc.0':
-    resolution: {integrity: sha512-woQAIFe/kVrDPIC45wAt539hXYBOgIcVFuNVn3/aeKBpxosAokX1/NI7lWrIJChPHYB48wdnx6FOdV++EErwdQ==}
+  '@solana/rpc-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-2LK04mI0Vhce6OP2oW9adagyOpuEkXC2u48x1XUfGxB5U3Vlyu49noNzMqyPkyyICwSOPOYlRu910LZohLz8xQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/sysvars@2.0.0-rc.0':
-    resolution: {integrity: sha512-re+H9N4jFlFlpVxZt2y7QwWpo1HvqMgxLzJgnJicn6KPTeQX+UgH9+N1yNInLrBWDmgdvw+xjUinojqt3xPlEA==}
+  '@solana/rpc@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-jCxXDq09tIBot6wldr+nFTZ8AkEEEqTAnyJjDfdRm3U2NysOj3w3gv8gUBHo4KDrda3l2zKwAtYvejrakYoWJQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transaction-confirmation@2.0.0-rc.0':
-    resolution: {integrity: sha512-dGHxDaMd+a5BN52IZMiTv0oBcVwvNugGPJdE431ltSY47Q3rMUeGKQ9fj/EMY9WzVGEnbcD4Q67hERz1CRSJTA==}
+  '@solana/signers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-WWlbN8RdKzuk0j6wBnL8MYbU1sDp6mzaHmsIiNU3z057OUpRTDqXbQnHaD5ULortxKkeQnLiisZljtB4dJtqyA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transaction-messages@2.0.0-rc.0':
-    resolution: {integrity: sha512-WY3eQ6z1gsRffwSzRWy8MjJzLlNs47Wd99Up1vQggn9vJtwoGPF1uIYkjkTxsCEBXQOC1Z1RTy87dgcM7US/Jg==}
+  '@solana/subscribable@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-c8QmXCl7R67aMUGmwAvxnEoY38Si5+jnKlCYv8nkWHLqMDsg7kcyubGaDM4KLyR2YgE7wsppt/vEQlULjEb5Xw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transactions@2.0.0-rc.0':
-    resolution: {integrity: sha512-0+d37gqvxAo172AtRkW2MDT19IYIcapeSZE4/RLa87JFBbouJovDZStDoYpcVCwjv4uxS3Squtc9PyAPhKLSnw==}
+  '@solana/sysvars@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-HUMALRIAKv4CBZ2aZHOGR3XkjdXgXvHKmWkTe5bIIZkWAtm690u7haNhdW64zHsiS+uST5hY7Xmn/83c11WWTw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/web3.js@2.0.0-rc.0':
-    resolution: {integrity: sha512-yJFhDdWM/REW635Cx2pIwa+cXxAEYQwdQ17ZvFO/fUZtU+In/OWYE3fXyC2ShfpUYzeCuMIfxHVPUhmeuSpUyA==}
+  '@solana/transaction-confirmation@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-AXlhSEvQb42EfA8Lei9UFamLiSOmKd7ZwCkPKEYDeQPM7iqAWtlp35jq8+Je3aiWkRUucxNpoYlg27EnkmTXtA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/webcrypto-ed25519-polyfill@2.0.0-rc.0':
-    resolution: {integrity: sha512-Ol5+EexErkKhIprhONGcgjXbUpdAo6zefoA058G7MA7TG98SWTszNg0obDHhHi5IW+r2x5zXc9uOuv55bP9mgw==}
+  '@solana/transaction-messages@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-NuWJxMZZPhuhnI+qPJ7yd2I0ExGDfwUHK44ez+li8rqmUEMndcpdT3BLOlNcr2x1lv0nhxaDTw+Jfl7765FdMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/transactions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-nwzNsl7QsccPBqw8x0YvDeeIPStynJRhRqLzMvTtmwXWvJMeC69YgN75slQZzhClbGva4V9KMY2WL1Q2J0xnMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/web3.js@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-kEL7sl61MX3vO8vSvOjnwGQkdN8jnvS6xUJw6TSSSbPynBNqws27Zn7sHu1n8J9qq+gQNGMy7aJVP8/vsvCpzg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-mtoi+P/3BVRM/L5rReM0K0etTwAP1uGsl6mMcbl647qKMHTaXHwdGCqPO6j1uPkeYnt2hEI49e7iKEtDIRpS3Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
@@ -1856,8 +1902,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.19.5:
-    resolution: {integrity: sha512-VQUzGd+K73uDi/pTqzDBbxZneciOuMRjF0r/Lep2zr/GOnU+cUvfgRu4T5k4TWJfpGdSK5nrzVDoQVoEIAFbmg==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -2178,71 +2224,71 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@solana/accounts@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/accounts@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/addresses@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/assertions': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
+      '@solana/assertions': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/assertions@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
 
-  '@solana/codecs-core@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/codecs-core@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
 
-  '@solana/codecs-data-structures@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/codecs-data-structures@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
 
-  '@solana/codecs-numbers@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/codecs-numbers@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
 
-  '@solana/codecs-strings@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/codecs-strings@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.5.3
 
-  '@solana/codecs@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/codecs@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/options': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/options': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/errors@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
@@ -2260,257 +2306,278 @@ snapshots:
       eslint-plugin-typescript-sort-keys: 3.2.0(@typescript-eslint/parser@7.15.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
       typescript: 5.5.3
 
-  '@solana/fast-stable-stringify@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/fast-stable-stringify@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
       typescript: 5.5.3
 
-  '@solana/functional@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/functional@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
       typescript: 5.5.3
 
-  '@solana/instructions@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/instructions@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
 
-  '@solana/keys@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/keys@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/assertions': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      typescript: 5.5.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/options@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
+      '@solana/assertions': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/options@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-api@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/programs@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc-parsed-types': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-parsed-types@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/promises@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
       typescript: 5.5.3
 
-  '@solana/rpc-spec-types@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/rpc-api@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      typescript: 5.5.3
-
-  '@solana/rpc-spec@2.0.0-rc.0(typescript@5.5.3)':
-    dependencies:
-      '@solana/rpc-spec-types': 2.0.0-rc.0(typescript@5.5.3)
-      typescript: 5.5.3
-
-  '@solana/rpc-subscriptions-api@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
-    dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/rpc-parsed-types': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-spec@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/rpc-parsed-types@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-spec-types': 2.0.0-rc.0(typescript@5.5.3)
       typescript: 5.5.3
 
-  '@solana/rpc-subscriptions-transport-websocket@2.0.0-rc.0(typescript@5.5.3)(ws@8.17.1)':
+  '@solana/rpc-spec-types@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.5.3)
+      typescript: 5.5.3
+
+  '@solana/rpc-spec@2.1.0-canary-20241128134801(typescript@5.5.3)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      typescript: 5.5.3
+
+  '@solana/rpc-subscriptions-api@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      typescript: 5.5.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-channel-websocket@2.1.0-canary-20241128134801(typescript@5.5.3)(ws@8.17.1)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
       ws: 8.17.1
 
-  '@solana/rpc-subscriptions@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)':
+  '@solana/rpc-subscriptions-spec@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/fast-stable-stringify': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-subscriptions-api': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-subscriptions-transport-websocket': 2.0.0-rc.0(typescript@5.5.3)(ws@8.17.1)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      typescript: 5.5.3
+
+  '@solana/rpc-subscriptions@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/fast-stable-stringify': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-subscriptions-api': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/rpc-subscriptions-channel-websocket': 2.1.0-canary-20241128134801(typescript@5.5.3)(ws@8.17.1)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/rpc-transformers@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/rpc-transformers@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transport-http@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/rpc-transport-http@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
-      undici-types: 6.19.5
+      undici-types: 6.21.0
 
-  '@solana/rpc-types@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/rpc-types@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      typescript: 5.5.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
-    dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/fast-stable-stringify': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-api': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc-transport-http': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/rpc@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/fast-stable-stringify': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-api': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/rpc-transport-http': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/sysvars@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/signers@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/accounts': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/codecs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)':
+  '@solana/subscribable@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc-subscriptions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
       typescript: 5.5.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
 
-  '@solana/transaction-messages@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/sysvars@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/accounts': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/codecs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+  '@solana/transaction-confirmation@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      typescript: 5.5.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/web3.js@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)':
-    dependencies:
-      '@solana/accounts': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/codecs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/programs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/rpc-parsed-types': 2.0.0-rc.0(typescript@5.5.3)
-      '@solana/rpc-subscriptions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/signers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/sysvars': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/transaction-confirmation': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/rpc-subscriptions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/webcrypto-ed25519-polyfill@2.0.0-rc.0(typescript@5.5.3)':
+  '@solana/transaction-messages@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      typescript: 5.5.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      typescript: 5.5.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/web3.js@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)':
+    dependencies:
+      '@solana/accounts': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/codecs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/programs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/rpc': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/rpc-parsed-types': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.5.3)
+      '@solana/rpc-subscriptions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/signers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/sysvars': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/transaction-confirmation': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
+      typescript: 5.5.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801(typescript@5.5.3)':
     dependencies:
       '@noble/ed25519': 2.1.0
       typescript: 5.5.3
@@ -3836,7 +3903,7 @@ snapshots:
 
   typescript@5.5.3: {}
 
-  undici-types@6.19.5: {}
+  undici-types@6.21.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/packages/renderers-js/e2e/anchor/pnpm-lock.yaml
+++ b/packages/renderers-js/e2e/anchor/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@solana/web3.js':
         specifier: 2.1.0-canary-20241128134801
         version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)(ws@8.17.1)
-      '@solana/webcrypto-ed25519-polyfill':
-        specifier: 2.1.0-canary-20241128134801
-        version: 2.1.0-canary-20241128134801(typescript@5.5.3)
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.3.1
         version: 7.15.0(@typescript-eslint/parser@7.15.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
@@ -251,9 +248,6 @@ packages:
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
-
-  '@noble/ed25519@2.1.0':
-    resolution: {integrity: sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -581,12 +575,6 @@ packages:
 
   '@solana/web3.js@2.1.0-canary-20241128134801':
     resolution: {integrity: sha512-kEL7sl61MX3vO8vSvOjnwGQkdN8jnvS6xUJw6TSSSbPynBNqws27Zn7sHu1n8J9qq+gQNGMy7aJVP8/vsvCpzg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801':
-    resolution: {integrity: sha512-mtoi+P/3BVRM/L5rReM0K0etTwAP1uGsl6mMcbl647qKMHTaXHwdGCqPO6j1uPkeYnt2hEI49e7iKEtDIRpS3Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
@@ -2152,8 +2140,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@noble/ed25519@2.1.0': {}
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2576,11 +2562,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
-
-  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801(typescript@5.5.3)':
-    dependencies:
-      '@noble/ed25519': 2.1.0
-      typescript: 5.5.3
 
   '@types/estree@1.0.5': {}
 

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/createGuard.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/createGuard.ts
@@ -94,7 +94,7 @@ export type CreateGuardInstruction<
     | IAccountMeta<string> = '11111111111111111111111111111111',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountGuard extends string
@@ -510,7 +510,7 @@ export function parseCreateGuardInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedCreateGuardInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 8) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/execute.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/execute.ts
@@ -58,7 +58,7 @@ export type ExecuteInstruction<
     | IAccountMeta<string> = 'Sysvar1nstructions1111111111111111111111111',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountSourceAccount extends string
@@ -389,7 +389,7 @@ export function parseExecuteInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedExecuteInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 7) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/initialize.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/initialize.ts
@@ -59,7 +59,7 @@ export type InitializeInstruction<
   TAccountPayer extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountExtraMetasAccount extends string
@@ -347,7 +347,7 @@ export function parseInitializeInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 6) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/updateGuard.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/updateGuard.ts
@@ -83,7 +83,7 @@ export type UpdateGuardInstruction<
     | IAccountMeta<string> = '11111111111111111111111111111111',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountGuard extends string
@@ -420,7 +420,7 @@ export function parseUpdateGuardInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedUpdateGuardInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 6) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/dummy/package.json
+++ b/packages/renderers-js/e2e/dummy/package.json
@@ -22,7 +22,6 @@
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.0",
     "@solana/web3.js": "2.1.0-canary-20241128134801",
-    "@solana/webcrypto-ed25519-polyfill": "2.1.0-canary-20241128134801",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "ava": "^6.1.2",
@@ -35,9 +34,6 @@
     "typescript": "^5.4.2"
   },
   "ava": {
-    "require": [
-      "@solana/webcrypto-ed25519-polyfill"
-    ],
     "typescript": {
       "compile": false,
       "rewritePaths": {

--- a/packages/renderers-js/e2e/dummy/package.json
+++ b/packages/renderers-js/e2e/dummy/package.json
@@ -16,13 +16,13 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@solana/web3.js": "2.0.0-rc.0"
+    "@solana/web3.js": "2.1.0-canary-20241128134801"
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.0",
-    "@solana/web3.js": "rc",
-    "@solana/webcrypto-ed25519-polyfill": "rc",
+    "@solana/web3.js": "2.1.0-canary-20241128134801",
+    "@solana/webcrypto-ed25519-polyfill": "2.1.0-canary-20241128134801",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "ava": "^6.1.2",

--- a/packages/renderers-js/e2e/dummy/pnpm-lock.yaml
+++ b/packages/renderers-js/e2e/dummy/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3(@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.0))(eslint-plugin-simple-import-sort@10.0.0(eslint@8.57.0))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.2.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       '@solana/web3.js':
-        specifier: rc
-        version: 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
       '@solana/webcrypto-ed25519-polyfill':
-        specifier: rc
-        version: 2.0.0-rc.0(typescript@5.4.5)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(typescript@5.4.5)
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.3.1
         version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
@@ -357,49 +357,58 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@solana/accounts@2.0.0-rc.0':
-    resolution: {integrity: sha512-Xun9ASXuJd3njGgc8q32Ra2f2r5J4KNhVZn6g5G//uQVpc+8QpBrTqS0lV+q7f6i0+um8WD4Q7OYOtnRb6mBiA==}
+  '@solana/accounts@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-HTrVWzbaAgxVNstQcYCaz3734Zx/Yf7O3cCecTCwPrLJhgxR10fdk4YekPn+bgceLM7LHhNOQlYAPLyd841PIg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/addresses@2.0.0-rc.0':
-    resolution: {integrity: sha512-cx/Vdwqn7Ns3ud+tyvD5ua4q2UtTleaAWuqyv7opAZLJOZWq2sL9esG3MIEZR5P9wW6sai8Mk9ule1DoWC+pqQ==}
+  '@solana/addresses@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-KKldgGUmjLRQK0+w3UcXKOlHOF0OhuUYoUzXANvshMT3Th/JMglbdvj1YjW9p2WThyQpUVg0X/OYap0v4oLkag==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/assertions@2.0.0-rc.0':
-    resolution: {integrity: sha512-O9g764n0CC3y8OTe7o02syj/S6ecqHvOcquf0z1qwQKZkwCJ8eyb6Xj9l82RKuMEvMtgaIiMrg8jMDo2ML5aCw==}
+  '@solana/assertions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-/BmDS6BD3YoSGMoYTp9BqOMno2QwOyrdYJQ1+CqNidbOMM7qnG+V3cSLPZVmxWoUM4bAo+0PWwALgR04TOvwdw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-core@2.0.0-rc.0':
-    resolution: {integrity: sha512-eIMMZiSfzZNlMK0uJRfpj9URrvuRo8SXncbCva+Wmpaob9dS+Mplo9VrH0T7+aTZJUAb5o9FbZgo4tUAOecVhg==}
+  '@solana/codecs-core@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-Lgd9IZ7coAc6F/X8RAIR+Sc0jIf8jHzYw/g4eBMcJU/Zjmcmja6l+2LGIpdlkn2+x+lMckK3HO4RHifXUS0ytQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-data-structures@2.0.0-rc.0':
-    resolution: {integrity: sha512-CTFOIV+I6LjGosKBkfYYFSRH+i2WG0F46Qf5zBsa52X/UGFFW7Nwaf6XJl84xYIFi4JMMZOA3x221vjK0JoYWg==}
+  '@solana/codecs-data-structures@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-356XK2JCygLz9FZvrSXWLqGhIQZmpKIlwqY8PiZEho4xmWUaupvyvNjWAAohCK8YXhfEMzKOnyoO3yHMLnLJIg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-numbers@2.0.0-rc.0':
-    resolution: {integrity: sha512-KqIU/xuB+IHNex9uYsB9y2MoH6VX2zRBnDJpdu9L/dE9Uw5xVKJRGdeHB9mBC4PBZ90VPMz3mP+xfFIXMS0j8g==}
+  '@solana/codecs-numbers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-2PZ/xY8tOUFjgFuga/tAbinrcS2p9YX3RaxbXvMBJYvi3DAcdi0zqTwE4ganEzfQ5Os9o1shw88zYSKk0vy8lQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-strings@2.0.0-rc.0':
-    resolution: {integrity: sha512-9yYBvJpo1WTT8idzomrHF602Snylo1+pmEGNrYlUaxmzVU2Hdb28U0WKv0iz9TdCDvMDlIwjsBznt6DmVf4i6g==}
+  '@solana/codecs-strings@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-SEmAc9c6692Tm7wEmzot7mxaDsTN3wnA78uDj2IgqXmznLOGfw3kAcA8Xcq6rTL5NhUlePjxaJg6I2T+GRVIRA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
 
-  '@solana/codecs@2.0.0-rc.0':
-    resolution: {integrity: sha512-C92OLr/4k2+o+hlZb5ukXn4/KlDZa/YMvgVYlKk87+RoSPLS6/WWHpU8+Anh2bAW8TD+BwFx4p1WtLWPd6Jwdg==}
+  '@solana/codecs@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-uQ9rI7odB91z9jI0lR1LnBMohmk2MnZTYVRl0CDEEfet57UfaFFV0T++x5LV4zpUL8TeBqj1OQQE/zSdl2BRUg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/errors@2.0.0-rc.0':
-    resolution: {integrity: sha512-4zaFxuYWQJi+CBucncGPc+QsWZktdmC6rDne3JxZGDKqqY5AMwktRC9LyUKaey/dVThmFGo1wv1wNQy1ryvbWw==}
+  '@solana/errors@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-l3bv0rIwhbmumsqIT6j4zxBKdStgfQIfUio85P3lzMCh+0eTp+1hAGvsXQMbXtZ8ovLe5xiV3g1PB8Kr0a2h3w==}
+    engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
       typescript: '>=5'
@@ -417,129 +426,166 @@ packages:
       eslint-plugin-typescript-sort-keys: ^3.2.0
       typescript: ^5.1.6
 
-  '@solana/fast-stable-stringify@2.0.0-rc.0':
-    resolution: {integrity: sha512-qpHZNKzVP5PFEIK1TQvIM+A+DjSCV53KaxXzxPFiYd/JfjdxIhH6h1C0bbRMdsbBqwWlbacs2H5/xrKP3X42cw==}
+  '@solana/fast-stable-stringify@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-w+5mMzLH7y/mIa9/iMOEoebrKbW8Sz8VkS3EKjUNmUy48Vbk+27xryK46xbVoTFz2rcX0lrDcKDpilOhhPAh1w==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/functional@2.0.0-rc.0':
-    resolution: {integrity: sha512-Z+nkjtWyjp3yktU8ip2MxbKb7+I2YUiY8kbpvxAWnWKGcUoKhgcW3EhxhSxFWKbaiEcBmyoPCEdM2MJgJPZJug==}
+  '@solana/functional@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-5CX30yRL2iG3YL8Mofe+OMKe373FQJa/P6bPiD91SJ93o17dQtvUIQ+JnKNRKi+ZSZCBr1j/+2S8g4aQOEFOhA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/instructions@2.0.0-rc.0':
-    resolution: {integrity: sha512-0/MQ80BXZfELZuCc7GudopuCpQC4VnN9WJDHtR8Tur0j8shiSyHWOOZlWfx66eQuSiQsnbOLT1CRTdhEt/vZhA==}
+  '@solana/instructions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-RCxxH9mMFruqAz3Py1q5GJJECi1KWZiJQpqMiUhDH5f3LkNsDQqmi2VL2ByGnUKSptPRhyEWrpItR3ZQCUmJ4Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/keys@2.0.0-rc.0':
-    resolution: {integrity: sha512-k/2uvObJdQfsmKUI+vL+9zcRRdZpaScq0SKIQLe33dbv+3XIEhCRizPEIg8Q8fzIKB9rrbwHqJ5RPDxThZa++g==}
+  '@solana/keys@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-sGIkISsZHZagO9I6gmZSDiUMJIlHj833ULDyGcH9P9MLhs1sNYM2iW8FvDxWFY6/c3aYSyOZ28QSHHoaTKUsUA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/options@2.0.0-rc.0':
-    resolution: {integrity: sha512-uPc/31v+FZj9mkq2mQ6uAJfvmxGnQsx2mJ90IlJdDLSlkcx6GymNyXp0meh8qfhvfEaz4F5lCOzSeApofIZPvw==}
+  '@solana/options@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-f9Zbn1nhG0P3dxjl4LnA9FsJWCeVgSgkeix1hx85p8dbVy3q8NLNVCkyK2osC7KW655f6CL113vyl1dzkscm9w==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/programs@2.0.0-rc.0':
-    resolution: {integrity: sha512-sihHN5HDXEXJnoeG/hnahFreF6d2AMGIELtF2kv5uHM9F5NcdYFmX1Q0tWBC6Y/DugIf3Qtk+jMFceM7qUoWXA==}
+  '@solana/programs@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-32KEp3LiVH7joX55S111NV1Yh0udohddEtMAVWWKwgMClbaAkd3ATV978ahGk3VFLeyICvpndwQ29D4SxXqPXw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-api@2.0.0-rc.0':
-    resolution: {integrity: sha512-vP21oksg3lU8bbSyJfgfT9a/eeQ/q5sN76VSR05T7j3Tv8VmI9N77ZNrtrfG4DZfIiYWw3qlSrVI8XTwgMIW8A==}
+  '@solana/promises@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-ToZnDEGUwsHVQYgxuGC0qC6Rwir+9YoUnJHB4tQ8Qt9XS13FdgQuofeGsMZFZQFadbtrWJ5ROI4Z974/oCvIYA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-parsed-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-EvyOGZ6vbKG5XWDoPmNpMbm4Z0HE+hEIBxhQFkB+ML+qKPghtrifyF0bvydna7AIBkpc0OccVmv22Vd+gBvHng==}
+  '@solana/rpc-api@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-xpb8QLFMg6WXxXJdTSQ+536SAQTjiNKvccT074enGcXFsqIHoVfP+zHRYdUwypORnJ7xFPNgo5SAnFGNxIZWOg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-spec-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-0h2uQfjHIoUpP5ha3lzLFep6WLnggrksjWiCd8+iIoktPeh09CPJI2iU/hFheP7e+tUKhmErGqsL+OPNECwD2g==}
+  '@solana/rpc-parsed-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-jmKsbywEJ0Kil1aIYHiwPn37hofrAREOw49R2Go3Aw91zzAFOVXM2wuJ9WtK5U4JD36KCdDcX8t8aHKdHM/uJw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-spec@2.0.0-rc.0':
-    resolution: {integrity: sha512-Cdwj8ief8ek5VUWRfSZDqdFzRfC6HVzyoPMIOdWRtEd8KocUGo7BTbwN9ilVJL/vIi52vi6e2A6oPMFNRyuBFw==}
+  '@solana/rpc-spec-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-0aAOaxbBNaJomDDgyY/QoDID/vyVSfzU0/qRFVfWE0DVROGXa9cbGyH2I/FkLrfbuCc0TNi0150NmLLkHJK9VQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-api@2.0.0-rc.0':
-    resolution: {integrity: sha512-Q4/rR4epPud7Z/3lrtGNMJd5oSrrxp/JgJTnkxEzGxs07RHmVfvO/9jrS+dgDtj3epyjD4BhmecO98Bg8bZ2yg==}
+  '@solana/rpc-spec@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-I2XsRVtIU3RqihaVsTZP5itXZQ3mLD90sQ/GBYMSu9TVZfOgLdOFP0RpdQG5wIZvOun05vemon5f3PRIYfJyLQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-spec@2.0.0-rc.0':
-    resolution: {integrity: sha512-ZUxFAGy1nAIpLZ3RgWsRlRvPOLlx/vk1isFo5YcA+GAFZDLIt+jOZJF/J6QUjOohMc5xSkTRmJuMURCDmu+1dg==}
+  '@solana/rpc-subscriptions-api@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-+R/SBC+llwUUMVxolBgxrUWYrB/V6ybRkxF2ERB/ENC5EECM/Z3t8ZzXh6UwI0JTnjFoLivjUeZsrlKkLZC50A==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-transport-websocket@2.0.0-rc.0':
-    resolution: {integrity: sha512-Qg3w/zMAVaXhm/WQYFV0qXUjUDKmSJrRG/CzdjMfiqYPSFX1286uwyq5wnua4NzrbPd+ZtbGKyvdSVRnmy1WkA==}
+  '@solana/rpc-subscriptions-channel-websocket@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-RKIuZVFBTKGivLGiDQDwzu/uIGWMaFYGI4nWHjs0joCLr+Ixh4L7moeoimBUJtg3mWJ9/t8G/58ZcTEhiFrFOg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
-      ws: ^7.5.9
+      ws: ^8.18.0
 
-  '@solana/rpc-subscriptions@2.0.0-rc.0':
-    resolution: {integrity: sha512-ThLHuf6dxpq1RTWu7GAItjLubhcJsBdhGdGGtPjGEBW1zX5YnGLsG2sc16XLgbH5LZhUDQ37wub6iwMTOBqVhA==}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/rpc-transformers@2.0.0-rc.0':
-    resolution: {integrity: sha512-F/aL/ivIh2rPIpAGId8ZC3WG88wv025yLSmAhFZUOSbvF1ZCp8h63TUS5qpRGbDVUNr7PLu2Cm8EMkF6MoDSDA==}
+  '@solana/rpc-subscriptions-spec@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-/566STNmiTDjCIpwHZ7GCW/7qXdCBkE9shgjMFhYEKc1Kx+iOQJkFrHgVpaYH1stfs4+duRO8CYNrpCFkJfqOQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-transport-http@2.0.0-rc.0':
-    resolution: {integrity: sha512-ZuT3nhlfTGcDXjEkVlwG+XeLUKLxZvh/Am1em2vO8zGSQJmtFKlEq+Wk3C55acs0CrH00s29w3TcEcTtltikbg==}
+  '@solana/rpc-subscriptions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-u+GfSMAeLCpljznTJVk2FWOMPak/jYmYgKhH1V/ekIMol/9u7c/DaQmRrfvOjEYzxa3btRfem+kRkuoGw5n3cQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-KFuPmkVlZitZnncDGbwu5FSFXljHQsWb4u6fJbmq0yNGwjAlUspOnl7ufL0bS7e+hh0NKfyNOXWuC4vmYEMThw==}
+  '@solana/rpc-transformers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-rmyuZOYxmj7mmGrkLK9Ksc0GJ8bKACWgtHcgjhmPHJYIvSkFrGRoSxD45Y3d5sYN+cW8lrvQwB7GX6wC0ArFtQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc@2.0.0-rc.0':
-    resolution: {integrity: sha512-isWQk5Cfu3hmjdzMfYLPn65KTkJHARocwx8i1+hF53kqrgvFGgAWtqDJXJfjkEan8ksSRfI5FzZB02YFB4zKSw==}
+  '@solana/rpc-transport-http@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-sE0dNSkOtCQyZa5CD7lGykzFIXxyQ+kPYa8FAnTqeojFGFUsj5nuME9Q+u0KvMPMAcqvWndIC3oxn7zyQuyxpQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/signers@2.0.0-rc.0':
-    resolution: {integrity: sha512-woQAIFe/kVrDPIC45wAt539hXYBOgIcVFuNVn3/aeKBpxosAokX1/NI7lWrIJChPHYB48wdnx6FOdV++EErwdQ==}
+  '@solana/rpc-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-2LK04mI0Vhce6OP2oW9adagyOpuEkXC2u48x1XUfGxB5U3Vlyu49noNzMqyPkyyICwSOPOYlRu910LZohLz8xQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/sysvars@2.0.0-rc.0':
-    resolution: {integrity: sha512-re+H9N4jFlFlpVxZt2y7QwWpo1HvqMgxLzJgnJicn6KPTeQX+UgH9+N1yNInLrBWDmgdvw+xjUinojqt3xPlEA==}
+  '@solana/rpc@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-jCxXDq09tIBot6wldr+nFTZ8AkEEEqTAnyJjDfdRm3U2NysOj3w3gv8gUBHo4KDrda3l2zKwAtYvejrakYoWJQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transaction-confirmation@2.0.0-rc.0':
-    resolution: {integrity: sha512-dGHxDaMd+a5BN52IZMiTv0oBcVwvNugGPJdE431ltSY47Q3rMUeGKQ9fj/EMY9WzVGEnbcD4Q67hERz1CRSJTA==}
+  '@solana/signers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-WWlbN8RdKzuk0j6wBnL8MYbU1sDp6mzaHmsIiNU3z057OUpRTDqXbQnHaD5ULortxKkeQnLiisZljtB4dJtqyA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transaction-messages@2.0.0-rc.0':
-    resolution: {integrity: sha512-WY3eQ6z1gsRffwSzRWy8MjJzLlNs47Wd99Up1vQggn9vJtwoGPF1uIYkjkTxsCEBXQOC1Z1RTy87dgcM7US/Jg==}
+  '@solana/subscribable@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-c8QmXCl7R67aMUGmwAvxnEoY38Si5+jnKlCYv8nkWHLqMDsg7kcyubGaDM4KLyR2YgE7wsppt/vEQlULjEb5Xw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transactions@2.0.0-rc.0':
-    resolution: {integrity: sha512-0+d37gqvxAo172AtRkW2MDT19IYIcapeSZE4/RLa87JFBbouJovDZStDoYpcVCwjv4uxS3Squtc9PyAPhKLSnw==}
+  '@solana/sysvars@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-HUMALRIAKv4CBZ2aZHOGR3XkjdXgXvHKmWkTe5bIIZkWAtm690u7haNhdW64zHsiS+uST5hY7Xmn/83c11WWTw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/web3.js@2.0.0-rc.0':
-    resolution: {integrity: sha512-yJFhDdWM/REW635Cx2pIwa+cXxAEYQwdQ17ZvFO/fUZtU+In/OWYE3fXyC2ShfpUYzeCuMIfxHVPUhmeuSpUyA==}
+  '@solana/transaction-confirmation@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-AXlhSEvQb42EfA8Lei9UFamLiSOmKd7ZwCkPKEYDeQPM7iqAWtlp35jq8+Je3aiWkRUucxNpoYlg27EnkmTXtA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/webcrypto-ed25519-polyfill@2.0.0-rc.0':
-    resolution: {integrity: sha512-Ol5+EexErkKhIprhONGcgjXbUpdAo6zefoA058G7MA7TG98SWTszNg0obDHhHi5IW+r2x5zXc9uOuv55bP9mgw==}
+  '@solana/transaction-messages@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-NuWJxMZZPhuhnI+qPJ7yd2I0ExGDfwUHK44ez+li8rqmUEMndcpdT3BLOlNcr2x1lv0nhxaDTw+Jfl7765FdMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/transactions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-nwzNsl7QsccPBqw8x0YvDeeIPStynJRhRqLzMvTtmwXWvJMeC69YgN75slQZzhClbGva4V9KMY2WL1Q2J0xnMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/web3.js@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-kEL7sl61MX3vO8vSvOjnwGQkdN8jnvS6xUJw6TSSSbPynBNqws27Zn7sHu1n8J9qq+gQNGMy7aJVP8/vsvCpzg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-mtoi+P/3BVRM/L5rReM0K0etTwAP1uGsl6mMcbl647qKMHTaXHwdGCqPO6j1uPkeYnt2hEI49e7iKEtDIRpS3Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
@@ -1845,8 +1891,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.19.5:
-    resolution: {integrity: sha512-VQUzGd+K73uDi/pTqzDBbxZneciOuMRjF0r/Lep2zr/GOnU+cUvfgRu4T5k4TWJfpGdSK5nrzVDoQVoEIAFbmg==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -2167,71 +2213,71 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@solana/accounts@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/accounts@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/addresses@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/assertions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/assertions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/assertions@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-core@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/codecs-core@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-data-structures@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/codecs-data-structures@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-numbers@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/codecs-numbers@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-strings@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/codecs-strings@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.4.5
 
-  '@solana/codecs@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/codecs@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/options': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/options': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/errors@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
@@ -2249,257 +2295,278 @@ snapshots:
       eslint-plugin-typescript-sort-keys: 3.2.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/fast-stable-stringify@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/fast-stable-stringify@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
-  '@solana/functional@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/functional@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
-  '@solana/instructions@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/instructions@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/keys@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/keys@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/assertions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/options@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/assertions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/options@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-api@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/programs@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-parsed-types': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-parsed-types@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/promises@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
-  '@solana/rpc-spec-types@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/rpc-api@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      typescript: 5.4.5
-
-  '@solana/rpc-spec@2.0.0-rc.0(typescript@5.4.5)':
-    dependencies:
-      '@solana/rpc-spec-types': 2.0.0-rc.0(typescript@5.4.5)
-      typescript: 5.4.5
-
-  '@solana/rpc-subscriptions-api@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
-    dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-parsed-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-spec@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/rpc-parsed-types@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec-types': 2.0.0-rc.0(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/rpc-subscriptions-transport-websocket@2.0.0-rc.0(typescript@5.4.5)(ws@8.17.0)':
+  '@solana/rpc-spec-types@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@solana/rpc-spec@2.1.0-canary-20241128134801(typescript@5.4.5)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@solana/rpc-subscriptions-api@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-channel-websocket@2.1.0-canary-20241128134801(typescript@5.4.5)(ws@8.17.0)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
       ws: 8.17.0
 
-  '@solana/rpc-subscriptions@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+  '@solana/rpc-subscriptions-spec@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/fast-stable-stringify': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-api': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-transport-websocket': 2.0.0-rc.0(typescript@5.4.5)(ws@8.17.0)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@solana/rpc-subscriptions@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/fast-stable-stringify': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-subscriptions-api': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-subscriptions-channel-websocket': 2.1.0-canary-20241128134801(typescript@5.4.5)(ws@8.17.0)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/rpc-transformers@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/rpc-transformers@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transport-http@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/rpc-transport-http@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
-      undici-types: 6.19.5
+      undici-types: 6.21.0
 
-  '@solana/rpc-types@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/rpc-types@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
-    dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/fast-stable-stringify': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-api': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-transport-http': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/rpc@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/fast-stable-stringify': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-api': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-transport-http': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/sysvars@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/signers@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/accounts': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+  '@solana/subscribable@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-subscriptions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
 
-  '@solana/transaction-messages@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/sysvars@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/accounts': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/transaction-confirmation@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/web3.js@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
-    dependencies:
-      '@solana/accounts': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/programs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-parsed-types': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/signers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/sysvars': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-confirmation': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-subscriptions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/webcrypto-ed25519-polyfill@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/transaction-messages@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/web3.js@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+    dependencies:
+      '@solana/accounts': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/programs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-parsed-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-subscriptions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/signers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/sysvars': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-confirmation': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       '@noble/ed25519': 2.1.0
       typescript: 5.4.5
@@ -3820,7 +3887,7 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  undici-types@6.19.5: {}
+  undici-types@6.21.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/packages/renderers-js/e2e/dummy/pnpm-lock.yaml
+++ b/packages/renderers-js/e2e/dummy/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@solana/web3.js':
         specifier: 2.1.0-canary-20241128134801
         version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/webcrypto-ed25519-polyfill':
-        specifier: 2.1.0-canary-20241128134801
-        version: 2.1.0-canary-20241128134801(typescript@5.4.5)
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.3.1
         version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
@@ -249,9 +246,6 @@ packages:
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
-
-  '@noble/ed25519@2.1.0':
-    resolution: {integrity: sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -579,12 +573,6 @@ packages:
 
   '@solana/web3.js@2.1.0-canary-20241128134801':
     resolution: {integrity: sha512-kEL7sl61MX3vO8vSvOjnwGQkdN8jnvS6xUJw6TSSSbPynBNqws27Zn7sHu1n8J9qq+gQNGMy7aJVP8/vsvCpzg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801':
-    resolution: {integrity: sha512-mtoi+P/3BVRM/L5rReM0K0etTwAP1uGsl6mMcbl647qKMHTaXHwdGCqPO6j1uPkeYnt2hEI49e7iKEtDIRpS3Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
@@ -2141,8 +2129,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@noble/ed25519@2.1.0': {}
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2565,11 +2551,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
-
-  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801(typescript@5.4.5)':
-    dependencies:
-      '@noble/ed25519': 2.1.0
-      typescript: 5.4.5
 
   '@types/estree@1.0.5': {}
 

--- a/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction3.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction3.ts
@@ -21,6 +21,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyUint8Array,
 } from '@solana/web3.js';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
@@ -34,7 +35,7 @@ export type Instruction3Instruction<
   TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction3InstructionData = { discriminator: number };
@@ -88,7 +89,7 @@ export type ParsedInstruction3Instruction<
 };
 
 export function parseInstruction3Instruction<TProgram extends string>(
-  instruction: IInstruction<TProgram> & IInstructionWithData<Uint8Array>
+  instruction: IInstruction<TProgram> & IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInstruction3Instruction<TProgram> {
   return {
     programAddress: instruction.programAddress,

--- a/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction4.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction4.ts
@@ -20,6 +20,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyUint8Array,
 } from '@solana/web3.js';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
@@ -27,7 +28,7 @@ export type Instruction4Instruction<
   TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction4InstructionData = { myArgument: bigint };
@@ -86,7 +87,7 @@ export type ParsedInstruction4Instruction<
 };
 
 export function parseInstruction4Instruction<TProgram extends string>(
-  instruction: IInstruction<TProgram> & IInstructionWithData<Uint8Array>
+  instruction: IInstruction<TProgram> & IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInstruction4Instruction<TProgram> {
   return {
     programAddress: instruction.programAddress,

--- a/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction5.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction5.ts
@@ -21,6 +21,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyUint8Array,
 } from '@solana/web3.js';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
@@ -28,7 +29,7 @@ export type Instruction5Instruction<
   TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction5InstructionData = { myArgument: bigint };
@@ -90,7 +91,7 @@ export type ParsedInstruction5Instruction<
 };
 
 export function parseInstruction5Instruction<TProgram extends string>(
-  instruction: IInstruction<TProgram> & IInstructionWithData<Uint8Array>
+  instruction: IInstruction<TProgram> & IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInstruction5Instruction<TProgram> {
   return {
     programAddress: instruction.programAddress,

--- a/packages/renderers-js/e2e/memo/package.json
+++ b/packages/renderers-js/e2e/memo/package.json
@@ -22,7 +22,6 @@
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.0",
     "@solana/web3.js": "2.1.0-canary-20241128134801",
-    "@solana/webcrypto-ed25519-polyfill": "2.1.0-canary-20241128134801",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "ava": "^6.1.2",
@@ -35,9 +34,6 @@
     "typescript": "^5.4.2"
   },
   "ava": {
-    "require": [
-      "@solana/webcrypto-ed25519-polyfill"
-    ],
     "typescript": {
       "compile": false,
       "rewritePaths": {

--- a/packages/renderers-js/e2e/memo/package.json
+++ b/packages/renderers-js/e2e/memo/package.json
@@ -16,13 +16,13 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@solana/web3.js": "2.0.0-rc.0"
+    "@solana/web3.js": "2.1.0-canary-20241128134801"
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.0",
-    "@solana/web3.js": "rc",
-    "@solana/webcrypto-ed25519-polyfill": "rc",
+    "@solana/web3.js": "2.1.0-canary-20241128134801",
+    "@solana/webcrypto-ed25519-polyfill": "2.1.0-canary-20241128134801",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "ava": "^6.1.2",

--- a/packages/renderers-js/e2e/memo/pnpm-lock.yaml
+++ b/packages/renderers-js/e2e/memo/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3(@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.0))(eslint-plugin-simple-import-sort@10.0.0(eslint@8.57.0))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.2.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       '@solana/web3.js':
-        specifier: rc
-        version: 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
       '@solana/webcrypto-ed25519-polyfill':
-        specifier: rc
-        version: 2.0.0-rc.0(typescript@5.4.5)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(typescript@5.4.5)
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.3.1
         version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
@@ -357,49 +357,58 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@solana/accounts@2.0.0-rc.0':
-    resolution: {integrity: sha512-Xun9ASXuJd3njGgc8q32Ra2f2r5J4KNhVZn6g5G//uQVpc+8QpBrTqS0lV+q7f6i0+um8WD4Q7OYOtnRb6mBiA==}
+  '@solana/accounts@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-HTrVWzbaAgxVNstQcYCaz3734Zx/Yf7O3cCecTCwPrLJhgxR10fdk4YekPn+bgceLM7LHhNOQlYAPLyd841PIg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/addresses@2.0.0-rc.0':
-    resolution: {integrity: sha512-cx/Vdwqn7Ns3ud+tyvD5ua4q2UtTleaAWuqyv7opAZLJOZWq2sL9esG3MIEZR5P9wW6sai8Mk9ule1DoWC+pqQ==}
+  '@solana/addresses@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-KKldgGUmjLRQK0+w3UcXKOlHOF0OhuUYoUzXANvshMT3Th/JMglbdvj1YjW9p2WThyQpUVg0X/OYap0v4oLkag==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/assertions@2.0.0-rc.0':
-    resolution: {integrity: sha512-O9g764n0CC3y8OTe7o02syj/S6ecqHvOcquf0z1qwQKZkwCJ8eyb6Xj9l82RKuMEvMtgaIiMrg8jMDo2ML5aCw==}
+  '@solana/assertions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-/BmDS6BD3YoSGMoYTp9BqOMno2QwOyrdYJQ1+CqNidbOMM7qnG+V3cSLPZVmxWoUM4bAo+0PWwALgR04TOvwdw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-core@2.0.0-rc.0':
-    resolution: {integrity: sha512-eIMMZiSfzZNlMK0uJRfpj9URrvuRo8SXncbCva+Wmpaob9dS+Mplo9VrH0T7+aTZJUAb5o9FbZgo4tUAOecVhg==}
+  '@solana/codecs-core@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-Lgd9IZ7coAc6F/X8RAIR+Sc0jIf8jHzYw/g4eBMcJU/Zjmcmja6l+2LGIpdlkn2+x+lMckK3HO4RHifXUS0ytQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-data-structures@2.0.0-rc.0':
-    resolution: {integrity: sha512-CTFOIV+I6LjGosKBkfYYFSRH+i2WG0F46Qf5zBsa52X/UGFFW7Nwaf6XJl84xYIFi4JMMZOA3x221vjK0JoYWg==}
+  '@solana/codecs-data-structures@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-356XK2JCygLz9FZvrSXWLqGhIQZmpKIlwqY8PiZEho4xmWUaupvyvNjWAAohCK8YXhfEMzKOnyoO3yHMLnLJIg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-numbers@2.0.0-rc.0':
-    resolution: {integrity: sha512-KqIU/xuB+IHNex9uYsB9y2MoH6VX2zRBnDJpdu9L/dE9Uw5xVKJRGdeHB9mBC4PBZ90VPMz3mP+xfFIXMS0j8g==}
+  '@solana/codecs-numbers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-2PZ/xY8tOUFjgFuga/tAbinrcS2p9YX3RaxbXvMBJYvi3DAcdi0zqTwE4ganEzfQ5Os9o1shw88zYSKk0vy8lQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-strings@2.0.0-rc.0':
-    resolution: {integrity: sha512-9yYBvJpo1WTT8idzomrHF602Snylo1+pmEGNrYlUaxmzVU2Hdb28U0WKv0iz9TdCDvMDlIwjsBznt6DmVf4i6g==}
+  '@solana/codecs-strings@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-SEmAc9c6692Tm7wEmzot7mxaDsTN3wnA78uDj2IgqXmznLOGfw3kAcA8Xcq6rTL5NhUlePjxaJg6I2T+GRVIRA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
 
-  '@solana/codecs@2.0.0-rc.0':
-    resolution: {integrity: sha512-C92OLr/4k2+o+hlZb5ukXn4/KlDZa/YMvgVYlKk87+RoSPLS6/WWHpU8+Anh2bAW8TD+BwFx4p1WtLWPd6Jwdg==}
+  '@solana/codecs@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-uQ9rI7odB91z9jI0lR1LnBMohmk2MnZTYVRl0CDEEfet57UfaFFV0T++x5LV4zpUL8TeBqj1OQQE/zSdl2BRUg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/errors@2.0.0-rc.0':
-    resolution: {integrity: sha512-4zaFxuYWQJi+CBucncGPc+QsWZktdmC6rDne3JxZGDKqqY5AMwktRC9LyUKaey/dVThmFGo1wv1wNQy1ryvbWw==}
+  '@solana/errors@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-l3bv0rIwhbmumsqIT6j4zxBKdStgfQIfUio85P3lzMCh+0eTp+1hAGvsXQMbXtZ8ovLe5xiV3g1PB8Kr0a2h3w==}
+    engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
       typescript: '>=5'
@@ -417,129 +426,166 @@ packages:
       eslint-plugin-typescript-sort-keys: ^3.2.0
       typescript: ^5.1.6
 
-  '@solana/fast-stable-stringify@2.0.0-rc.0':
-    resolution: {integrity: sha512-qpHZNKzVP5PFEIK1TQvIM+A+DjSCV53KaxXzxPFiYd/JfjdxIhH6h1C0bbRMdsbBqwWlbacs2H5/xrKP3X42cw==}
+  '@solana/fast-stable-stringify@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-w+5mMzLH7y/mIa9/iMOEoebrKbW8Sz8VkS3EKjUNmUy48Vbk+27xryK46xbVoTFz2rcX0lrDcKDpilOhhPAh1w==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/functional@2.0.0-rc.0':
-    resolution: {integrity: sha512-Z+nkjtWyjp3yktU8ip2MxbKb7+I2YUiY8kbpvxAWnWKGcUoKhgcW3EhxhSxFWKbaiEcBmyoPCEdM2MJgJPZJug==}
+  '@solana/functional@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-5CX30yRL2iG3YL8Mofe+OMKe373FQJa/P6bPiD91SJ93o17dQtvUIQ+JnKNRKi+ZSZCBr1j/+2S8g4aQOEFOhA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/instructions@2.0.0-rc.0':
-    resolution: {integrity: sha512-0/MQ80BXZfELZuCc7GudopuCpQC4VnN9WJDHtR8Tur0j8shiSyHWOOZlWfx66eQuSiQsnbOLT1CRTdhEt/vZhA==}
+  '@solana/instructions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-RCxxH9mMFruqAz3Py1q5GJJECi1KWZiJQpqMiUhDH5f3LkNsDQqmi2VL2ByGnUKSptPRhyEWrpItR3ZQCUmJ4Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/keys@2.0.0-rc.0':
-    resolution: {integrity: sha512-k/2uvObJdQfsmKUI+vL+9zcRRdZpaScq0SKIQLe33dbv+3XIEhCRizPEIg8Q8fzIKB9rrbwHqJ5RPDxThZa++g==}
+  '@solana/keys@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-sGIkISsZHZagO9I6gmZSDiUMJIlHj833ULDyGcH9P9MLhs1sNYM2iW8FvDxWFY6/c3aYSyOZ28QSHHoaTKUsUA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/options@2.0.0-rc.0':
-    resolution: {integrity: sha512-uPc/31v+FZj9mkq2mQ6uAJfvmxGnQsx2mJ90IlJdDLSlkcx6GymNyXp0meh8qfhvfEaz4F5lCOzSeApofIZPvw==}
+  '@solana/options@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-f9Zbn1nhG0P3dxjl4LnA9FsJWCeVgSgkeix1hx85p8dbVy3q8NLNVCkyK2osC7KW655f6CL113vyl1dzkscm9w==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/programs@2.0.0-rc.0':
-    resolution: {integrity: sha512-sihHN5HDXEXJnoeG/hnahFreF6d2AMGIELtF2kv5uHM9F5NcdYFmX1Q0tWBC6Y/DugIf3Qtk+jMFceM7qUoWXA==}
+  '@solana/programs@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-32KEp3LiVH7joX55S111NV1Yh0udohddEtMAVWWKwgMClbaAkd3ATV978ahGk3VFLeyICvpndwQ29D4SxXqPXw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-api@2.0.0-rc.0':
-    resolution: {integrity: sha512-vP21oksg3lU8bbSyJfgfT9a/eeQ/q5sN76VSR05T7j3Tv8VmI9N77ZNrtrfG4DZfIiYWw3qlSrVI8XTwgMIW8A==}
+  '@solana/promises@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-ToZnDEGUwsHVQYgxuGC0qC6Rwir+9YoUnJHB4tQ8Qt9XS13FdgQuofeGsMZFZQFadbtrWJ5ROI4Z974/oCvIYA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-parsed-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-EvyOGZ6vbKG5XWDoPmNpMbm4Z0HE+hEIBxhQFkB+ML+qKPghtrifyF0bvydna7AIBkpc0OccVmv22Vd+gBvHng==}
+  '@solana/rpc-api@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-xpb8QLFMg6WXxXJdTSQ+536SAQTjiNKvccT074enGcXFsqIHoVfP+zHRYdUwypORnJ7xFPNgo5SAnFGNxIZWOg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-spec-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-0h2uQfjHIoUpP5ha3lzLFep6WLnggrksjWiCd8+iIoktPeh09CPJI2iU/hFheP7e+tUKhmErGqsL+OPNECwD2g==}
+  '@solana/rpc-parsed-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-jmKsbywEJ0Kil1aIYHiwPn37hofrAREOw49R2Go3Aw91zzAFOVXM2wuJ9WtK5U4JD36KCdDcX8t8aHKdHM/uJw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-spec@2.0.0-rc.0':
-    resolution: {integrity: sha512-Cdwj8ief8ek5VUWRfSZDqdFzRfC6HVzyoPMIOdWRtEd8KocUGo7BTbwN9ilVJL/vIi52vi6e2A6oPMFNRyuBFw==}
+  '@solana/rpc-spec-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-0aAOaxbBNaJomDDgyY/QoDID/vyVSfzU0/qRFVfWE0DVROGXa9cbGyH2I/FkLrfbuCc0TNi0150NmLLkHJK9VQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-api@2.0.0-rc.0':
-    resolution: {integrity: sha512-Q4/rR4epPud7Z/3lrtGNMJd5oSrrxp/JgJTnkxEzGxs07RHmVfvO/9jrS+dgDtj3epyjD4BhmecO98Bg8bZ2yg==}
+  '@solana/rpc-spec@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-I2XsRVtIU3RqihaVsTZP5itXZQ3mLD90sQ/GBYMSu9TVZfOgLdOFP0RpdQG5wIZvOun05vemon5f3PRIYfJyLQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-spec@2.0.0-rc.0':
-    resolution: {integrity: sha512-ZUxFAGy1nAIpLZ3RgWsRlRvPOLlx/vk1isFo5YcA+GAFZDLIt+jOZJF/J6QUjOohMc5xSkTRmJuMURCDmu+1dg==}
+  '@solana/rpc-subscriptions-api@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-+R/SBC+llwUUMVxolBgxrUWYrB/V6ybRkxF2ERB/ENC5EECM/Z3t8ZzXh6UwI0JTnjFoLivjUeZsrlKkLZC50A==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-transport-websocket@2.0.0-rc.0':
-    resolution: {integrity: sha512-Qg3w/zMAVaXhm/WQYFV0qXUjUDKmSJrRG/CzdjMfiqYPSFX1286uwyq5wnua4NzrbPd+ZtbGKyvdSVRnmy1WkA==}
+  '@solana/rpc-subscriptions-channel-websocket@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-RKIuZVFBTKGivLGiDQDwzu/uIGWMaFYGI4nWHjs0joCLr+Ixh4L7moeoimBUJtg3mWJ9/t8G/58ZcTEhiFrFOg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
-      ws: ^7.5.9
+      ws: ^8.18.0
 
-  '@solana/rpc-subscriptions@2.0.0-rc.0':
-    resolution: {integrity: sha512-ThLHuf6dxpq1RTWu7GAItjLubhcJsBdhGdGGtPjGEBW1zX5YnGLsG2sc16XLgbH5LZhUDQ37wub6iwMTOBqVhA==}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/rpc-transformers@2.0.0-rc.0':
-    resolution: {integrity: sha512-F/aL/ivIh2rPIpAGId8ZC3WG88wv025yLSmAhFZUOSbvF1ZCp8h63TUS5qpRGbDVUNr7PLu2Cm8EMkF6MoDSDA==}
+  '@solana/rpc-subscriptions-spec@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-/566STNmiTDjCIpwHZ7GCW/7qXdCBkE9shgjMFhYEKc1Kx+iOQJkFrHgVpaYH1stfs4+duRO8CYNrpCFkJfqOQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-transport-http@2.0.0-rc.0':
-    resolution: {integrity: sha512-ZuT3nhlfTGcDXjEkVlwG+XeLUKLxZvh/Am1em2vO8zGSQJmtFKlEq+Wk3C55acs0CrH00s29w3TcEcTtltikbg==}
+  '@solana/rpc-subscriptions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-u+GfSMAeLCpljznTJVk2FWOMPak/jYmYgKhH1V/ekIMol/9u7c/DaQmRrfvOjEYzxa3btRfem+kRkuoGw5n3cQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-KFuPmkVlZitZnncDGbwu5FSFXljHQsWb4u6fJbmq0yNGwjAlUspOnl7ufL0bS7e+hh0NKfyNOXWuC4vmYEMThw==}
+  '@solana/rpc-transformers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-rmyuZOYxmj7mmGrkLK9Ksc0GJ8bKACWgtHcgjhmPHJYIvSkFrGRoSxD45Y3d5sYN+cW8lrvQwB7GX6wC0ArFtQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc@2.0.0-rc.0':
-    resolution: {integrity: sha512-isWQk5Cfu3hmjdzMfYLPn65KTkJHARocwx8i1+hF53kqrgvFGgAWtqDJXJfjkEan8ksSRfI5FzZB02YFB4zKSw==}
+  '@solana/rpc-transport-http@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-sE0dNSkOtCQyZa5CD7lGykzFIXxyQ+kPYa8FAnTqeojFGFUsj5nuME9Q+u0KvMPMAcqvWndIC3oxn7zyQuyxpQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/signers@2.0.0-rc.0':
-    resolution: {integrity: sha512-woQAIFe/kVrDPIC45wAt539hXYBOgIcVFuNVn3/aeKBpxosAokX1/NI7lWrIJChPHYB48wdnx6FOdV++EErwdQ==}
+  '@solana/rpc-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-2LK04mI0Vhce6OP2oW9adagyOpuEkXC2u48x1XUfGxB5U3Vlyu49noNzMqyPkyyICwSOPOYlRu910LZohLz8xQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/sysvars@2.0.0-rc.0':
-    resolution: {integrity: sha512-re+H9N4jFlFlpVxZt2y7QwWpo1HvqMgxLzJgnJicn6KPTeQX+UgH9+N1yNInLrBWDmgdvw+xjUinojqt3xPlEA==}
+  '@solana/rpc@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-jCxXDq09tIBot6wldr+nFTZ8AkEEEqTAnyJjDfdRm3U2NysOj3w3gv8gUBHo4KDrda3l2zKwAtYvejrakYoWJQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transaction-confirmation@2.0.0-rc.0':
-    resolution: {integrity: sha512-dGHxDaMd+a5BN52IZMiTv0oBcVwvNugGPJdE431ltSY47Q3rMUeGKQ9fj/EMY9WzVGEnbcD4Q67hERz1CRSJTA==}
+  '@solana/signers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-WWlbN8RdKzuk0j6wBnL8MYbU1sDp6mzaHmsIiNU3z057OUpRTDqXbQnHaD5ULortxKkeQnLiisZljtB4dJtqyA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transaction-messages@2.0.0-rc.0':
-    resolution: {integrity: sha512-WY3eQ6z1gsRffwSzRWy8MjJzLlNs47Wd99Up1vQggn9vJtwoGPF1uIYkjkTxsCEBXQOC1Z1RTy87dgcM7US/Jg==}
+  '@solana/subscribable@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-c8QmXCl7R67aMUGmwAvxnEoY38Si5+jnKlCYv8nkWHLqMDsg7kcyubGaDM4KLyR2YgE7wsppt/vEQlULjEb5Xw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transactions@2.0.0-rc.0':
-    resolution: {integrity: sha512-0+d37gqvxAo172AtRkW2MDT19IYIcapeSZE4/RLa87JFBbouJovDZStDoYpcVCwjv4uxS3Squtc9PyAPhKLSnw==}
+  '@solana/sysvars@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-HUMALRIAKv4CBZ2aZHOGR3XkjdXgXvHKmWkTe5bIIZkWAtm690u7haNhdW64zHsiS+uST5hY7Xmn/83c11WWTw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/web3.js@2.0.0-rc.0':
-    resolution: {integrity: sha512-yJFhDdWM/REW635Cx2pIwa+cXxAEYQwdQ17ZvFO/fUZtU+In/OWYE3fXyC2ShfpUYzeCuMIfxHVPUhmeuSpUyA==}
+  '@solana/transaction-confirmation@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-AXlhSEvQb42EfA8Lei9UFamLiSOmKd7ZwCkPKEYDeQPM7iqAWtlp35jq8+Je3aiWkRUucxNpoYlg27EnkmTXtA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/webcrypto-ed25519-polyfill@2.0.0-rc.0':
-    resolution: {integrity: sha512-Ol5+EexErkKhIprhONGcgjXbUpdAo6zefoA058G7MA7TG98SWTszNg0obDHhHi5IW+r2x5zXc9uOuv55bP9mgw==}
+  '@solana/transaction-messages@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-NuWJxMZZPhuhnI+qPJ7yd2I0ExGDfwUHK44ez+li8rqmUEMndcpdT3BLOlNcr2x1lv0nhxaDTw+Jfl7765FdMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/transactions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-nwzNsl7QsccPBqw8x0YvDeeIPStynJRhRqLzMvTtmwXWvJMeC69YgN75slQZzhClbGva4V9KMY2WL1Q2J0xnMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/web3.js@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-kEL7sl61MX3vO8vSvOjnwGQkdN8jnvS6xUJw6TSSSbPynBNqws27Zn7sHu1n8J9qq+gQNGMy7aJVP8/vsvCpzg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-mtoi+P/3BVRM/L5rReM0K0etTwAP1uGsl6mMcbl647qKMHTaXHwdGCqPO6j1uPkeYnt2hEI49e7iKEtDIRpS3Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
@@ -1845,8 +1891,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.19.5:
-    resolution: {integrity: sha512-VQUzGd+K73uDi/pTqzDBbxZneciOuMRjF0r/Lep2zr/GOnU+cUvfgRu4T5k4TWJfpGdSK5nrzVDoQVoEIAFbmg==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -2167,71 +2213,71 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@solana/accounts@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/accounts@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/addresses@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/assertions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/assertions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/assertions@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-core@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/codecs-core@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-data-structures@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/codecs-data-structures@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-numbers@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/codecs-numbers@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-strings@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/codecs-strings@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.4.5
 
-  '@solana/codecs@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/codecs@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/options': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/options': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/errors@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
@@ -2249,257 +2295,278 @@ snapshots:
       eslint-plugin-typescript-sort-keys: 3.2.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/fast-stable-stringify@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/fast-stable-stringify@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
-  '@solana/functional@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/functional@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
-  '@solana/instructions@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/instructions@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/keys@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/keys@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/assertions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/options@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/assertions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/options@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-api@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/programs@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-parsed-types': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-parsed-types@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/promises@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
-  '@solana/rpc-spec-types@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/rpc-api@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      typescript: 5.4.5
-
-  '@solana/rpc-spec@2.0.0-rc.0(typescript@5.4.5)':
-    dependencies:
-      '@solana/rpc-spec-types': 2.0.0-rc.0(typescript@5.4.5)
-      typescript: 5.4.5
-
-  '@solana/rpc-subscriptions-api@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
-    dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-parsed-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-spec@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/rpc-parsed-types@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec-types': 2.0.0-rc.0(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/rpc-subscriptions-transport-websocket@2.0.0-rc.0(typescript@5.4.5)(ws@8.17.0)':
+  '@solana/rpc-spec-types@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@solana/rpc-spec@2.1.0-canary-20241128134801(typescript@5.4.5)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@solana/rpc-subscriptions-api@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-channel-websocket@2.1.0-canary-20241128134801(typescript@5.4.5)(ws@8.17.0)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
       ws: 8.17.0
 
-  '@solana/rpc-subscriptions@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+  '@solana/rpc-subscriptions-spec@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/fast-stable-stringify': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-api': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-transport-websocket': 2.0.0-rc.0(typescript@5.4.5)(ws@8.17.0)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@solana/rpc-subscriptions@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/fast-stable-stringify': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-subscriptions-api': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-subscriptions-channel-websocket': 2.1.0-canary-20241128134801(typescript@5.4.5)(ws@8.17.0)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/rpc-transformers@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/rpc-transformers@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transport-http@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/rpc-transport-http@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
-      undici-types: 6.19.5
+      undici-types: 6.21.0
 
-  '@solana/rpc-types@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/rpc-types@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
-    dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/fast-stable-stringify': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-api': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-transport-http': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/rpc@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/fast-stable-stringify': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-api': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-transport-http': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/sysvars@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/signers@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/accounts': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+  '@solana/subscribable@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-subscriptions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
 
-  '@solana/transaction-messages@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/sysvars@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/accounts': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/transaction-confirmation@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/web3.js@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
-    dependencies:
-      '@solana/accounts': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/programs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-parsed-types': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/signers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/sysvars': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-confirmation': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-subscriptions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/webcrypto-ed25519-polyfill@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/transaction-messages@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/web3.js@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+    dependencies:
+      '@solana/accounts': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/programs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-parsed-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-subscriptions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/signers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/sysvars': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-confirmation': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       '@noble/ed25519': 2.1.0
       typescript: 5.4.5
@@ -3820,7 +3887,7 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  undici-types@6.19.5: {}
+  undici-types@6.21.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/packages/renderers-js/e2e/memo/pnpm-lock.yaml
+++ b/packages/renderers-js/e2e/memo/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@solana/web3.js':
         specifier: 2.1.0-canary-20241128134801
         version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/webcrypto-ed25519-polyfill':
-        specifier: 2.1.0-canary-20241128134801
-        version: 2.1.0-canary-20241128134801(typescript@5.4.5)
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.3.1
         version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
@@ -249,9 +246,6 @@ packages:
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
-
-  '@noble/ed25519@2.1.0':
-    resolution: {integrity: sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -579,12 +573,6 @@ packages:
 
   '@solana/web3.js@2.1.0-canary-20241128134801':
     resolution: {integrity: sha512-kEL7sl61MX3vO8vSvOjnwGQkdN8jnvS6xUJw6TSSSbPynBNqws27Zn7sHu1n8J9qq+gQNGMy7aJVP8/vsvCpzg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801':
-    resolution: {integrity: sha512-mtoi+P/3BVRM/L5rReM0K0etTwAP1uGsl6mMcbl647qKMHTaXHwdGCqPO6j1uPkeYnt2hEI49e7iKEtDIRpS3Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
@@ -2141,8 +2129,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@noble/ed25519@2.1.0': {}
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2565,11 +2551,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
-
-  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801(typescript@5.4.5)':
-    dependencies:
-      '@noble/ed25519': 2.1.0
-      typescript: 5.4.5
 
   '@types/estree@1.0.5': {}
 

--- a/packages/renderers-js/e2e/memo/src/generated/instructions/addMemo.ts
+++ b/packages/renderers-js/e2e/memo/src/generated/instructions/addMemo.ts
@@ -21,6 +21,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyUint8Array,
   type TransactionSigner,
 } from '@solana/web3.js';
 import { MEMO_PROGRAM_ADDRESS } from '../programs';
@@ -29,7 +30,7 @@ export type AddMemoInstruction<
   TProgram extends string = typeof MEMO_PROGRAM_ADDRESS,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<TRemainingAccounts>;
 
 export type AddMemoInstructionData = { memo: string };
@@ -99,7 +100,7 @@ export type ParsedAddMemoInstruction<
 };
 
 export function parseAddMemoInstruction<TProgram extends string>(
-  instruction: IInstruction<TProgram> & IInstructionWithData<Uint8Array>
+  instruction: IInstruction<TProgram> & IInstructionWithData<ReadonlyUint8Array>
 ): ParsedAddMemoInstruction<TProgram> {
   return {
     programAddress: instruction.programAddress,

--- a/packages/renderers-js/e2e/system/package.json
+++ b/packages/renderers-js/e2e/system/package.json
@@ -22,7 +22,6 @@
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.0",
     "@solana/web3.js": "2.1.0-canary-20241128134801",
-    "@solana/webcrypto-ed25519-polyfill": "2.1.0-canary-20241128134801",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "ava": "^6.1.2",
@@ -35,9 +34,6 @@
     "typescript": "^5.4.2"
   },
   "ava": {
-    "require": [
-      "@solana/webcrypto-ed25519-polyfill"
-    ],
     "typescript": {
       "compile": false,
       "rewritePaths": {

--- a/packages/renderers-js/e2e/system/package.json
+++ b/packages/renderers-js/e2e/system/package.json
@@ -16,13 +16,13 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@solana/web3.js": "2.0.0-rc.0"
+    "@solana/web3.js": "2.1.0-canary-20241128134801"
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.0",
-    "@solana/web3.js": "rc",
-    "@solana/webcrypto-ed25519-polyfill": "rc",
+    "@solana/web3.js": "2.1.0-canary-20241128134801",
+    "@solana/webcrypto-ed25519-polyfill": "2.1.0-canary-20241128134801",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "ava": "^6.1.2",

--- a/packages/renderers-js/e2e/system/pnpm-lock.yaml
+++ b/packages/renderers-js/e2e/system/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3(@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.0))(eslint-plugin-simple-import-sort@10.0.0(eslint@8.57.0))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.2.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       '@solana/web3.js':
-        specifier: rc
-        version: 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
       '@solana/webcrypto-ed25519-polyfill':
-        specifier: rc
-        version: 2.0.0-rc.0(typescript@5.4.5)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(typescript@5.4.5)
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.3.1
         version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
@@ -357,49 +357,58 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@solana/accounts@2.0.0-rc.0':
-    resolution: {integrity: sha512-Xun9ASXuJd3njGgc8q32Ra2f2r5J4KNhVZn6g5G//uQVpc+8QpBrTqS0lV+q7f6i0+um8WD4Q7OYOtnRb6mBiA==}
+  '@solana/accounts@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-HTrVWzbaAgxVNstQcYCaz3734Zx/Yf7O3cCecTCwPrLJhgxR10fdk4YekPn+bgceLM7LHhNOQlYAPLyd841PIg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/addresses@2.0.0-rc.0':
-    resolution: {integrity: sha512-cx/Vdwqn7Ns3ud+tyvD5ua4q2UtTleaAWuqyv7opAZLJOZWq2sL9esG3MIEZR5P9wW6sai8Mk9ule1DoWC+pqQ==}
+  '@solana/addresses@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-KKldgGUmjLRQK0+w3UcXKOlHOF0OhuUYoUzXANvshMT3Th/JMglbdvj1YjW9p2WThyQpUVg0X/OYap0v4oLkag==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/assertions@2.0.0-rc.0':
-    resolution: {integrity: sha512-O9g764n0CC3y8OTe7o02syj/S6ecqHvOcquf0z1qwQKZkwCJ8eyb6Xj9l82RKuMEvMtgaIiMrg8jMDo2ML5aCw==}
+  '@solana/assertions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-/BmDS6BD3YoSGMoYTp9BqOMno2QwOyrdYJQ1+CqNidbOMM7qnG+V3cSLPZVmxWoUM4bAo+0PWwALgR04TOvwdw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-core@2.0.0-rc.0':
-    resolution: {integrity: sha512-eIMMZiSfzZNlMK0uJRfpj9URrvuRo8SXncbCva+Wmpaob9dS+Mplo9VrH0T7+aTZJUAb5o9FbZgo4tUAOecVhg==}
+  '@solana/codecs-core@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-Lgd9IZ7coAc6F/X8RAIR+Sc0jIf8jHzYw/g4eBMcJU/Zjmcmja6l+2LGIpdlkn2+x+lMckK3HO4RHifXUS0ytQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-data-structures@2.0.0-rc.0':
-    resolution: {integrity: sha512-CTFOIV+I6LjGosKBkfYYFSRH+i2WG0F46Qf5zBsa52X/UGFFW7Nwaf6XJl84xYIFi4JMMZOA3x221vjK0JoYWg==}
+  '@solana/codecs-data-structures@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-356XK2JCygLz9FZvrSXWLqGhIQZmpKIlwqY8PiZEho4xmWUaupvyvNjWAAohCK8YXhfEMzKOnyoO3yHMLnLJIg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-numbers@2.0.0-rc.0':
-    resolution: {integrity: sha512-KqIU/xuB+IHNex9uYsB9y2MoH6VX2zRBnDJpdu9L/dE9Uw5xVKJRGdeHB9mBC4PBZ90VPMz3mP+xfFIXMS0j8g==}
+  '@solana/codecs-numbers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-2PZ/xY8tOUFjgFuga/tAbinrcS2p9YX3RaxbXvMBJYvi3DAcdi0zqTwE4ganEzfQ5Os9o1shw88zYSKk0vy8lQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-strings@2.0.0-rc.0':
-    resolution: {integrity: sha512-9yYBvJpo1WTT8idzomrHF602Snylo1+pmEGNrYlUaxmzVU2Hdb28U0WKv0iz9TdCDvMDlIwjsBznt6DmVf4i6g==}
+  '@solana/codecs-strings@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-SEmAc9c6692Tm7wEmzot7mxaDsTN3wnA78uDj2IgqXmznLOGfw3kAcA8Xcq6rTL5NhUlePjxaJg6I2T+GRVIRA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
 
-  '@solana/codecs@2.0.0-rc.0':
-    resolution: {integrity: sha512-C92OLr/4k2+o+hlZb5ukXn4/KlDZa/YMvgVYlKk87+RoSPLS6/WWHpU8+Anh2bAW8TD+BwFx4p1WtLWPd6Jwdg==}
+  '@solana/codecs@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-uQ9rI7odB91z9jI0lR1LnBMohmk2MnZTYVRl0CDEEfet57UfaFFV0T++x5LV4zpUL8TeBqj1OQQE/zSdl2BRUg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/errors@2.0.0-rc.0':
-    resolution: {integrity: sha512-4zaFxuYWQJi+CBucncGPc+QsWZktdmC6rDne3JxZGDKqqY5AMwktRC9LyUKaey/dVThmFGo1wv1wNQy1ryvbWw==}
+  '@solana/errors@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-l3bv0rIwhbmumsqIT6j4zxBKdStgfQIfUio85P3lzMCh+0eTp+1hAGvsXQMbXtZ8ovLe5xiV3g1PB8Kr0a2h3w==}
+    engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
       typescript: '>=5'
@@ -417,129 +426,166 @@ packages:
       eslint-plugin-typescript-sort-keys: ^3.2.0
       typescript: ^5.1.6
 
-  '@solana/fast-stable-stringify@2.0.0-rc.0':
-    resolution: {integrity: sha512-qpHZNKzVP5PFEIK1TQvIM+A+DjSCV53KaxXzxPFiYd/JfjdxIhH6h1C0bbRMdsbBqwWlbacs2H5/xrKP3X42cw==}
+  '@solana/fast-stable-stringify@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-w+5mMzLH7y/mIa9/iMOEoebrKbW8Sz8VkS3EKjUNmUy48Vbk+27xryK46xbVoTFz2rcX0lrDcKDpilOhhPAh1w==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/functional@2.0.0-rc.0':
-    resolution: {integrity: sha512-Z+nkjtWyjp3yktU8ip2MxbKb7+I2YUiY8kbpvxAWnWKGcUoKhgcW3EhxhSxFWKbaiEcBmyoPCEdM2MJgJPZJug==}
+  '@solana/functional@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-5CX30yRL2iG3YL8Mofe+OMKe373FQJa/P6bPiD91SJ93o17dQtvUIQ+JnKNRKi+ZSZCBr1j/+2S8g4aQOEFOhA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/instructions@2.0.0-rc.0':
-    resolution: {integrity: sha512-0/MQ80BXZfELZuCc7GudopuCpQC4VnN9WJDHtR8Tur0j8shiSyHWOOZlWfx66eQuSiQsnbOLT1CRTdhEt/vZhA==}
+  '@solana/instructions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-RCxxH9mMFruqAz3Py1q5GJJECi1KWZiJQpqMiUhDH5f3LkNsDQqmi2VL2ByGnUKSptPRhyEWrpItR3ZQCUmJ4Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/keys@2.0.0-rc.0':
-    resolution: {integrity: sha512-k/2uvObJdQfsmKUI+vL+9zcRRdZpaScq0SKIQLe33dbv+3XIEhCRizPEIg8Q8fzIKB9rrbwHqJ5RPDxThZa++g==}
+  '@solana/keys@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-sGIkISsZHZagO9I6gmZSDiUMJIlHj833ULDyGcH9P9MLhs1sNYM2iW8FvDxWFY6/c3aYSyOZ28QSHHoaTKUsUA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/options@2.0.0-rc.0':
-    resolution: {integrity: sha512-uPc/31v+FZj9mkq2mQ6uAJfvmxGnQsx2mJ90IlJdDLSlkcx6GymNyXp0meh8qfhvfEaz4F5lCOzSeApofIZPvw==}
+  '@solana/options@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-f9Zbn1nhG0P3dxjl4LnA9FsJWCeVgSgkeix1hx85p8dbVy3q8NLNVCkyK2osC7KW655f6CL113vyl1dzkscm9w==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/programs@2.0.0-rc.0':
-    resolution: {integrity: sha512-sihHN5HDXEXJnoeG/hnahFreF6d2AMGIELtF2kv5uHM9F5NcdYFmX1Q0tWBC6Y/DugIf3Qtk+jMFceM7qUoWXA==}
+  '@solana/programs@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-32KEp3LiVH7joX55S111NV1Yh0udohddEtMAVWWKwgMClbaAkd3ATV978ahGk3VFLeyICvpndwQ29D4SxXqPXw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-api@2.0.0-rc.0':
-    resolution: {integrity: sha512-vP21oksg3lU8bbSyJfgfT9a/eeQ/q5sN76VSR05T7j3Tv8VmI9N77ZNrtrfG4DZfIiYWw3qlSrVI8XTwgMIW8A==}
+  '@solana/promises@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-ToZnDEGUwsHVQYgxuGC0qC6Rwir+9YoUnJHB4tQ8Qt9XS13FdgQuofeGsMZFZQFadbtrWJ5ROI4Z974/oCvIYA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-parsed-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-EvyOGZ6vbKG5XWDoPmNpMbm4Z0HE+hEIBxhQFkB+ML+qKPghtrifyF0bvydna7AIBkpc0OccVmv22Vd+gBvHng==}
+  '@solana/rpc-api@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-xpb8QLFMg6WXxXJdTSQ+536SAQTjiNKvccT074enGcXFsqIHoVfP+zHRYdUwypORnJ7xFPNgo5SAnFGNxIZWOg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-spec-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-0h2uQfjHIoUpP5ha3lzLFep6WLnggrksjWiCd8+iIoktPeh09CPJI2iU/hFheP7e+tUKhmErGqsL+OPNECwD2g==}
+  '@solana/rpc-parsed-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-jmKsbywEJ0Kil1aIYHiwPn37hofrAREOw49R2Go3Aw91zzAFOVXM2wuJ9WtK5U4JD36KCdDcX8t8aHKdHM/uJw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-spec@2.0.0-rc.0':
-    resolution: {integrity: sha512-Cdwj8ief8ek5VUWRfSZDqdFzRfC6HVzyoPMIOdWRtEd8KocUGo7BTbwN9ilVJL/vIi52vi6e2A6oPMFNRyuBFw==}
+  '@solana/rpc-spec-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-0aAOaxbBNaJomDDgyY/QoDID/vyVSfzU0/qRFVfWE0DVROGXa9cbGyH2I/FkLrfbuCc0TNi0150NmLLkHJK9VQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-api@2.0.0-rc.0':
-    resolution: {integrity: sha512-Q4/rR4epPud7Z/3lrtGNMJd5oSrrxp/JgJTnkxEzGxs07RHmVfvO/9jrS+dgDtj3epyjD4BhmecO98Bg8bZ2yg==}
+  '@solana/rpc-spec@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-I2XsRVtIU3RqihaVsTZP5itXZQ3mLD90sQ/GBYMSu9TVZfOgLdOFP0RpdQG5wIZvOun05vemon5f3PRIYfJyLQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-spec@2.0.0-rc.0':
-    resolution: {integrity: sha512-ZUxFAGy1nAIpLZ3RgWsRlRvPOLlx/vk1isFo5YcA+GAFZDLIt+jOZJF/J6QUjOohMc5xSkTRmJuMURCDmu+1dg==}
+  '@solana/rpc-subscriptions-api@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-+R/SBC+llwUUMVxolBgxrUWYrB/V6ybRkxF2ERB/ENC5EECM/Z3t8ZzXh6UwI0JTnjFoLivjUeZsrlKkLZC50A==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-transport-websocket@2.0.0-rc.0':
-    resolution: {integrity: sha512-Qg3w/zMAVaXhm/WQYFV0qXUjUDKmSJrRG/CzdjMfiqYPSFX1286uwyq5wnua4NzrbPd+ZtbGKyvdSVRnmy1WkA==}
+  '@solana/rpc-subscriptions-channel-websocket@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-RKIuZVFBTKGivLGiDQDwzu/uIGWMaFYGI4nWHjs0joCLr+Ixh4L7moeoimBUJtg3mWJ9/t8G/58ZcTEhiFrFOg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
-      ws: ^7.5.9
+      ws: ^8.18.0
 
-  '@solana/rpc-subscriptions@2.0.0-rc.0':
-    resolution: {integrity: sha512-ThLHuf6dxpq1RTWu7GAItjLubhcJsBdhGdGGtPjGEBW1zX5YnGLsG2sc16XLgbH5LZhUDQ37wub6iwMTOBqVhA==}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/rpc-transformers@2.0.0-rc.0':
-    resolution: {integrity: sha512-F/aL/ivIh2rPIpAGId8ZC3WG88wv025yLSmAhFZUOSbvF1ZCp8h63TUS5qpRGbDVUNr7PLu2Cm8EMkF6MoDSDA==}
+  '@solana/rpc-subscriptions-spec@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-/566STNmiTDjCIpwHZ7GCW/7qXdCBkE9shgjMFhYEKc1Kx+iOQJkFrHgVpaYH1stfs4+duRO8CYNrpCFkJfqOQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-transport-http@2.0.0-rc.0':
-    resolution: {integrity: sha512-ZuT3nhlfTGcDXjEkVlwG+XeLUKLxZvh/Am1em2vO8zGSQJmtFKlEq+Wk3C55acs0CrH00s29w3TcEcTtltikbg==}
+  '@solana/rpc-subscriptions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-u+GfSMAeLCpljznTJVk2FWOMPak/jYmYgKhH1V/ekIMol/9u7c/DaQmRrfvOjEYzxa3btRfem+kRkuoGw5n3cQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-KFuPmkVlZitZnncDGbwu5FSFXljHQsWb4u6fJbmq0yNGwjAlUspOnl7ufL0bS7e+hh0NKfyNOXWuC4vmYEMThw==}
+  '@solana/rpc-transformers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-rmyuZOYxmj7mmGrkLK9Ksc0GJ8bKACWgtHcgjhmPHJYIvSkFrGRoSxD45Y3d5sYN+cW8lrvQwB7GX6wC0ArFtQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc@2.0.0-rc.0':
-    resolution: {integrity: sha512-isWQk5Cfu3hmjdzMfYLPn65KTkJHARocwx8i1+hF53kqrgvFGgAWtqDJXJfjkEan8ksSRfI5FzZB02YFB4zKSw==}
+  '@solana/rpc-transport-http@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-sE0dNSkOtCQyZa5CD7lGykzFIXxyQ+kPYa8FAnTqeojFGFUsj5nuME9Q+u0KvMPMAcqvWndIC3oxn7zyQuyxpQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/signers@2.0.0-rc.0':
-    resolution: {integrity: sha512-woQAIFe/kVrDPIC45wAt539hXYBOgIcVFuNVn3/aeKBpxosAokX1/NI7lWrIJChPHYB48wdnx6FOdV++EErwdQ==}
+  '@solana/rpc-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-2LK04mI0Vhce6OP2oW9adagyOpuEkXC2u48x1XUfGxB5U3Vlyu49noNzMqyPkyyICwSOPOYlRu910LZohLz8xQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/sysvars@2.0.0-rc.0':
-    resolution: {integrity: sha512-re+H9N4jFlFlpVxZt2y7QwWpo1HvqMgxLzJgnJicn6KPTeQX+UgH9+N1yNInLrBWDmgdvw+xjUinojqt3xPlEA==}
+  '@solana/rpc@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-jCxXDq09tIBot6wldr+nFTZ8AkEEEqTAnyJjDfdRm3U2NysOj3w3gv8gUBHo4KDrda3l2zKwAtYvejrakYoWJQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transaction-confirmation@2.0.0-rc.0':
-    resolution: {integrity: sha512-dGHxDaMd+a5BN52IZMiTv0oBcVwvNugGPJdE431ltSY47Q3rMUeGKQ9fj/EMY9WzVGEnbcD4Q67hERz1CRSJTA==}
+  '@solana/signers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-WWlbN8RdKzuk0j6wBnL8MYbU1sDp6mzaHmsIiNU3z057OUpRTDqXbQnHaD5ULortxKkeQnLiisZljtB4dJtqyA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transaction-messages@2.0.0-rc.0':
-    resolution: {integrity: sha512-WY3eQ6z1gsRffwSzRWy8MjJzLlNs47Wd99Up1vQggn9vJtwoGPF1uIYkjkTxsCEBXQOC1Z1RTy87dgcM7US/Jg==}
+  '@solana/subscribable@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-c8QmXCl7R67aMUGmwAvxnEoY38Si5+jnKlCYv8nkWHLqMDsg7kcyubGaDM4KLyR2YgE7wsppt/vEQlULjEb5Xw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transactions@2.0.0-rc.0':
-    resolution: {integrity: sha512-0+d37gqvxAo172AtRkW2MDT19IYIcapeSZE4/RLa87JFBbouJovDZStDoYpcVCwjv4uxS3Squtc9PyAPhKLSnw==}
+  '@solana/sysvars@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-HUMALRIAKv4CBZ2aZHOGR3XkjdXgXvHKmWkTe5bIIZkWAtm690u7haNhdW64zHsiS+uST5hY7Xmn/83c11WWTw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/web3.js@2.0.0-rc.0':
-    resolution: {integrity: sha512-yJFhDdWM/REW635Cx2pIwa+cXxAEYQwdQ17ZvFO/fUZtU+In/OWYE3fXyC2ShfpUYzeCuMIfxHVPUhmeuSpUyA==}
+  '@solana/transaction-confirmation@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-AXlhSEvQb42EfA8Lei9UFamLiSOmKd7ZwCkPKEYDeQPM7iqAWtlp35jq8+Je3aiWkRUucxNpoYlg27EnkmTXtA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/webcrypto-ed25519-polyfill@2.0.0-rc.0':
-    resolution: {integrity: sha512-Ol5+EexErkKhIprhONGcgjXbUpdAo6zefoA058G7MA7TG98SWTszNg0obDHhHi5IW+r2x5zXc9uOuv55bP9mgw==}
+  '@solana/transaction-messages@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-NuWJxMZZPhuhnI+qPJ7yd2I0ExGDfwUHK44ez+li8rqmUEMndcpdT3BLOlNcr2x1lv0nhxaDTw+Jfl7765FdMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/transactions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-nwzNsl7QsccPBqw8x0YvDeeIPStynJRhRqLzMvTtmwXWvJMeC69YgN75slQZzhClbGva4V9KMY2WL1Q2J0xnMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/web3.js@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-kEL7sl61MX3vO8vSvOjnwGQkdN8jnvS6xUJw6TSSSbPynBNqws27Zn7sHu1n8J9qq+gQNGMy7aJVP8/vsvCpzg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-mtoi+P/3BVRM/L5rReM0K0etTwAP1uGsl6mMcbl647qKMHTaXHwdGCqPO6j1uPkeYnt2hEI49e7iKEtDIRpS3Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
@@ -1845,8 +1891,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.19.5:
-    resolution: {integrity: sha512-VQUzGd+K73uDi/pTqzDBbxZneciOuMRjF0r/Lep2zr/GOnU+cUvfgRu4T5k4TWJfpGdSK5nrzVDoQVoEIAFbmg==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -2167,71 +2213,71 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@solana/accounts@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/accounts@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/addresses@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/assertions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/assertions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/assertions@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-core@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/codecs-core@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-data-structures@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/codecs-data-structures@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-numbers@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/codecs-numbers@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-strings@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/codecs-strings@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.4.5
 
-  '@solana/codecs@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/codecs@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/options': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/options': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/errors@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
@@ -2249,257 +2295,278 @@ snapshots:
       eslint-plugin-typescript-sort-keys: 3.2.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/fast-stable-stringify@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/fast-stable-stringify@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
-  '@solana/functional@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/functional@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
-  '@solana/instructions@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/instructions@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/keys@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/keys@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/assertions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/options@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/assertions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/options@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-api@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/programs@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-parsed-types': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-parsed-types@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/promises@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
-  '@solana/rpc-spec-types@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/rpc-api@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      typescript: 5.4.5
-
-  '@solana/rpc-spec@2.0.0-rc.0(typescript@5.4.5)':
-    dependencies:
-      '@solana/rpc-spec-types': 2.0.0-rc.0(typescript@5.4.5)
-      typescript: 5.4.5
-
-  '@solana/rpc-subscriptions-api@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
-    dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-parsed-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-spec@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/rpc-parsed-types@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec-types': 2.0.0-rc.0(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/rpc-subscriptions-transport-websocket@2.0.0-rc.0(typescript@5.4.5)(ws@8.17.0)':
+  '@solana/rpc-spec-types@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@solana/rpc-spec@2.1.0-canary-20241128134801(typescript@5.4.5)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@solana/rpc-subscriptions-api@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-channel-websocket@2.1.0-canary-20241128134801(typescript@5.4.5)(ws@8.17.0)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
       ws: 8.17.0
 
-  '@solana/rpc-subscriptions@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+  '@solana/rpc-subscriptions-spec@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/fast-stable-stringify': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-api': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-transport-websocket': 2.0.0-rc.0(typescript@5.4.5)(ws@8.17.0)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@solana/rpc-subscriptions@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/fast-stable-stringify': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-subscriptions-api': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-subscriptions-channel-websocket': 2.1.0-canary-20241128134801(typescript@5.4.5)(ws@8.17.0)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/rpc-transformers@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/rpc-transformers@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transport-http@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/rpc-transport-http@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
-      undici-types: 6.19.5
+      undici-types: 6.21.0
 
-  '@solana/rpc-types@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/rpc-types@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
-    dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/fast-stable-stringify': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-api': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-transport-http': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/rpc@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/fast-stable-stringify': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-api': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-transport-http': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/sysvars@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/signers@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/accounts': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+  '@solana/subscribable@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-subscriptions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
 
-  '@solana/transaction-messages@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/sysvars@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/accounts': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/transaction-confirmation@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/web3.js@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
-    dependencies:
-      '@solana/accounts': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/programs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-parsed-types': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/signers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/sysvars': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-confirmation': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-subscriptions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/webcrypto-ed25519-polyfill@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/transaction-messages@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/web3.js@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+    dependencies:
+      '@solana/accounts': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/programs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-parsed-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-subscriptions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/signers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/sysvars': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-confirmation': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       '@noble/ed25519': 2.1.0
       typescript: 5.4.5
@@ -3820,7 +3887,7 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  undici-types@6.19.5: {}
+  undici-types@6.21.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/packages/renderers-js/e2e/system/pnpm-lock.yaml
+++ b/packages/renderers-js/e2e/system/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@solana/web3.js':
         specifier: 2.1.0-canary-20241128134801
         version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/webcrypto-ed25519-polyfill':
-        specifier: 2.1.0-canary-20241128134801
-        version: 2.1.0-canary-20241128134801(typescript@5.4.5)
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.3.1
         version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
@@ -249,9 +246,6 @@ packages:
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
-
-  '@noble/ed25519@2.1.0':
-    resolution: {integrity: sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -579,12 +573,6 @@ packages:
 
   '@solana/web3.js@2.1.0-canary-20241128134801':
     resolution: {integrity: sha512-kEL7sl61MX3vO8vSvOjnwGQkdN8jnvS6xUJw6TSSSbPynBNqws27Zn7sHu1n8J9qq+gQNGMy7aJVP8/vsvCpzg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801':
-    resolution: {integrity: sha512-mtoi+P/3BVRM/L5rReM0K0etTwAP1uGsl6mMcbl647qKMHTaXHwdGCqPO6j1uPkeYnt2hEI49e7iKEtDIRpS3Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
@@ -2141,8 +2129,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@noble/ed25519@2.1.0': {}
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2565,11 +2551,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
-
-  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801(typescript@5.4.5)':
-    dependencies:
-      '@noble/ed25519': 2.1.0
-      typescript: 5.4.5
 
   '@types/estree@1.0.5': {}
 

--- a/packages/renderers-js/e2e/system/src/generated/accounts/nonce.ts
+++ b/packages/renderers-js/e2e/system/src/generated/accounts/nonce.ts
@@ -29,7 +29,7 @@ import {
   type Encoder,
   type FetchAccountConfig,
   type FetchAccountsConfig,
-  type LamportsUnsafeBeyond2Pow53Minus1,
+  type Lamports,
   type MaybeAccount,
   type MaybeEncodedAccount,
 } from '@solana/web3.js';
@@ -49,7 +49,7 @@ export type Nonce = {
   state: NonceState;
   authority: Address;
   blockhash: Address;
-  lamportsPerSignature: LamportsUnsafeBeyond2Pow53Minus1;
+  lamportsPerSignature: Lamports;
 };
 
 export type NonceArgs = {
@@ -57,7 +57,7 @@ export type NonceArgs = {
   state: NonceStateArgs;
   authority: Address;
   blockhash: Address;
-  lamportsPerSignature: LamportsUnsafeBeyond2Pow53Minus1;
+  lamportsPerSignature: Lamports;
 };
 
 export function getNonceEncoder(): Encoder<NonceArgs> {

--- a/packages/renderers-js/e2e/system/src/generated/instructions/advanceNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/advanceNonceAccount.ts
@@ -24,6 +24,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -45,7 +46,7 @@ export type AdvanceNonceAccountInstruction<
   TAccountNonceAuthority extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountNonceAccount extends string
@@ -179,7 +180,7 @@ export function parseAdvanceNonceAccountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedAdvanceNonceAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/allocate.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/allocate.ts
@@ -24,6 +24,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableSignerAccount,
 } from '@solana/web3.js';
@@ -41,7 +42,7 @@ export type AllocateInstruction<
   TAccountNewAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountNewAccount extends string
@@ -139,7 +140,7 @@ export function parseAllocateInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedAllocateInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/allocateWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/allocateWithSeed.ts
@@ -31,6 +31,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -49,7 +50,7 @@ export type AllocateWithSeedInstruction<
   TAccountBaseAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountNewAccount extends string
@@ -188,7 +189,7 @@ export function parseAllocateWithSeedInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedAllocateWithSeedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/assign.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/assign.ts
@@ -24,6 +24,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableSignerAccount,
 } from '@solana/web3.js';
@@ -41,7 +42,7 @@ export type AssignInstruction<
   TAccountAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountAccount extends string
@@ -142,7 +143,7 @@ export function parseAssignInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedAssignInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/assignWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/assignWithSeed.ts
@@ -29,6 +29,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -47,7 +48,7 @@ export type AssignWithSeedInstruction<
   TAccountBaseAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountAccount extends string
@@ -181,7 +182,7 @@ export function parseAssignWithSeedInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedAssignWithSeedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/authorizeNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/authorizeNonceAccount.ts
@@ -25,6 +25,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -43,7 +44,7 @@ export type AuthorizeNonceAccountInstruction<
   TAccountNonceAuthority extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountNonceAccount extends string
@@ -173,7 +174,7 @@ export function parseAuthorizeNonceAccountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedAuthorizeNonceAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
@@ -30,6 +30,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type LamportsUnsafeBeyond2Pow53Minus1,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableSignerAccount,
 } from '@solana/web3.js';
@@ -52,7 +53,7 @@ export type CreateAccountInstruction<
   TAccountNewAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountPayer extends string
@@ -194,7 +195,7 @@ export function parseCreateAccountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedCreateAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
@@ -29,7 +29,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
-  type LamportsUnsafeBeyond2Pow53Minus1,
+  type Lamports,
   type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableSignerAccount,
@@ -70,13 +70,13 @@ export type CreateAccountInstruction<
 
 export type CreateAccountInstructionData = {
   discriminator: number;
-  lamports: LamportsUnsafeBeyond2Pow53Minus1;
+  lamports: Lamports;
   space: bigint;
   programAddress: Address;
 };
 
 export type CreateAccountInstructionDataArgs = {
-  lamports: LamportsUnsafeBeyond2Pow53Minus1;
+  lamports: Lamports;
   space: number | bigint;
   programAddress: Address;
 };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/createAccountWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/createAccountWithSeed.ts
@@ -31,6 +31,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
   type WritableSignerAccount,
@@ -51,7 +52,7 @@ export type CreateAccountWithSeedInstruction<
   TAccountBaseAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountPayer extends string
@@ -214,7 +215,7 @@ export function parseCreateAccountWithSeedInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedCreateAccountWithSeedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/initializeNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/initializeNonceAccount.ts
@@ -24,6 +24,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlyAccount,
+  type ReadonlyUint8Array,
   type WritableAccount,
 } from '@solana/web3.js';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
@@ -46,7 +47,7 @@ export type InitializeNonceAccountInstruction<
     | IAccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountNonceAccount extends string
@@ -200,7 +201,7 @@ export function parseInitializeNonceAccountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeNonceAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/transferSol.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/transferSol.ts
@@ -24,6 +24,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
   type WritableSignerAccount,
@@ -43,7 +44,7 @@ export type TransferSolInstruction<
   TAccountDestination extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountSource extends string
@@ -165,7 +166,7 @@ export function parseTransferSolInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedTransferSolInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/transferSolWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/transferSolWithSeed.ts
@@ -31,6 +31,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -50,7 +51,7 @@ export type TransferSolWithSeedInstruction<
   TAccountDestination extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountSource extends string
@@ -202,7 +203,7 @@ export function parseTransferSolWithSeedInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedTransferSolWithSeedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/upgradeNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/upgradeNonceAccount.ts
@@ -21,6 +21,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyUint8Array,
   type WritableAccount,
 } from '@solana/web3.js';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
@@ -37,7 +38,7 @@ export type UpgradeNonceAccountInstruction<
   TAccountNonceAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountNonceAccount extends string
@@ -127,7 +128,7 @@ export function parseUpgradeNonceAccountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedUpgradeNonceAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/withdrawNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/withdrawNonceAccount.ts
@@ -26,6 +26,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -51,7 +52,7 @@ export type WithdrawNonceAccountInstruction<
   TAccountNonceAuthority extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountNonceAccount extends string
@@ -233,7 +234,7 @@ export function parseWithdrawNonceAccountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedWithdrawNonceAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 5) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/test/createAccount.test.ts
+++ b/packages/renderers-js/e2e/system/test/createAccount.test.ts
@@ -52,5 +52,6 @@ test('it creates a new empty account', async (t) => {
     address: newAccount.address,
     data: new Uint8Array(Array.from({ length: 42 }, () => 0)),
     exists: true,
+    space: 42n,
   });
 });

--- a/packages/renderers-js/e2e/token/package.json
+++ b/packages/renderers-js/e2e/token/package.json
@@ -22,7 +22,6 @@
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.0",
     "@solana/web3.js": "2.1.0-canary-20241128134801",
-    "@solana/webcrypto-ed25519-polyfill": "2.1.0-canary-20241128134801",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "ava": "^6.1.2",
@@ -35,9 +34,6 @@
     "typescript": "^5.4.2"
   },
   "ava": {
-    "require": [
-      "@solana/webcrypto-ed25519-polyfill"
-    ],
     "typescript": {
       "compile": false,
       "rewritePaths": {

--- a/packages/renderers-js/e2e/token/package.json
+++ b/packages/renderers-js/e2e/token/package.json
@@ -16,13 +16,13 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@solana/web3.js": "2.0.0-rc.0"
+    "@solana/web3.js": "2.1.0-canary-20241128134801"
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",
     "@solana/eslint-config-solana": "^3.0.0",
-    "@solana/web3.js": "rc",
-    "@solana/webcrypto-ed25519-polyfill": "rc",
+    "@solana/web3.js": "2.1.0-canary-20241128134801",
+    "@solana/webcrypto-ed25519-polyfill": "2.1.0-canary-20241128134801",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "ava": "^6.1.2",

--- a/packages/renderers-js/e2e/token/pnpm-lock.yaml
+++ b/packages/renderers-js/e2e/token/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3(@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.0))(eslint-plugin-simple-import-sort@10.0.0(eslint@8.57.0))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.2.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       '@solana/web3.js':
-        specifier: rc
-        version: 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
       '@solana/webcrypto-ed25519-polyfill':
-        specifier: rc
-        version: 2.0.0-rc.0(typescript@5.4.5)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(typescript@5.4.5)
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.3.1
         version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
@@ -357,49 +357,58 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@solana/accounts@2.0.0-rc.0':
-    resolution: {integrity: sha512-Xun9ASXuJd3njGgc8q32Ra2f2r5J4KNhVZn6g5G//uQVpc+8QpBrTqS0lV+q7f6i0+um8WD4Q7OYOtnRb6mBiA==}
+  '@solana/accounts@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-HTrVWzbaAgxVNstQcYCaz3734Zx/Yf7O3cCecTCwPrLJhgxR10fdk4YekPn+bgceLM7LHhNOQlYAPLyd841PIg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/addresses@2.0.0-rc.0':
-    resolution: {integrity: sha512-cx/Vdwqn7Ns3ud+tyvD5ua4q2UtTleaAWuqyv7opAZLJOZWq2sL9esG3MIEZR5P9wW6sai8Mk9ule1DoWC+pqQ==}
+  '@solana/addresses@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-KKldgGUmjLRQK0+w3UcXKOlHOF0OhuUYoUzXANvshMT3Th/JMglbdvj1YjW9p2WThyQpUVg0X/OYap0v4oLkag==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/assertions@2.0.0-rc.0':
-    resolution: {integrity: sha512-O9g764n0CC3y8OTe7o02syj/S6ecqHvOcquf0z1qwQKZkwCJ8eyb6Xj9l82RKuMEvMtgaIiMrg8jMDo2ML5aCw==}
+  '@solana/assertions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-/BmDS6BD3YoSGMoYTp9BqOMno2QwOyrdYJQ1+CqNidbOMM7qnG+V3cSLPZVmxWoUM4bAo+0PWwALgR04TOvwdw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-core@2.0.0-rc.0':
-    resolution: {integrity: sha512-eIMMZiSfzZNlMK0uJRfpj9URrvuRo8SXncbCva+Wmpaob9dS+Mplo9VrH0T7+aTZJUAb5o9FbZgo4tUAOecVhg==}
+  '@solana/codecs-core@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-Lgd9IZ7coAc6F/X8RAIR+Sc0jIf8jHzYw/g4eBMcJU/Zjmcmja6l+2LGIpdlkn2+x+lMckK3HO4RHifXUS0ytQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-data-structures@2.0.0-rc.0':
-    resolution: {integrity: sha512-CTFOIV+I6LjGosKBkfYYFSRH+i2WG0F46Qf5zBsa52X/UGFFW7Nwaf6XJl84xYIFi4JMMZOA3x221vjK0JoYWg==}
+  '@solana/codecs-data-structures@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-356XK2JCygLz9FZvrSXWLqGhIQZmpKIlwqY8PiZEho4xmWUaupvyvNjWAAohCK8YXhfEMzKOnyoO3yHMLnLJIg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-numbers@2.0.0-rc.0':
-    resolution: {integrity: sha512-KqIU/xuB+IHNex9uYsB9y2MoH6VX2zRBnDJpdu9L/dE9Uw5xVKJRGdeHB9mBC4PBZ90VPMz3mP+xfFIXMS0j8g==}
+  '@solana/codecs-numbers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-2PZ/xY8tOUFjgFuga/tAbinrcS2p9YX3RaxbXvMBJYvi3DAcdi0zqTwE4ganEzfQ5Os9o1shw88zYSKk0vy8lQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-strings@2.0.0-rc.0':
-    resolution: {integrity: sha512-9yYBvJpo1WTT8idzomrHF602Snylo1+pmEGNrYlUaxmzVU2Hdb28U0WKv0iz9TdCDvMDlIwjsBznt6DmVf4i6g==}
+  '@solana/codecs-strings@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-SEmAc9c6692Tm7wEmzot7mxaDsTN3wnA78uDj2IgqXmznLOGfw3kAcA8Xcq6rTL5NhUlePjxaJg6I2T+GRVIRA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
 
-  '@solana/codecs@2.0.0-rc.0':
-    resolution: {integrity: sha512-C92OLr/4k2+o+hlZb5ukXn4/KlDZa/YMvgVYlKk87+RoSPLS6/WWHpU8+Anh2bAW8TD+BwFx4p1WtLWPd6Jwdg==}
+  '@solana/codecs@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-uQ9rI7odB91z9jI0lR1LnBMohmk2MnZTYVRl0CDEEfet57UfaFFV0T++x5LV4zpUL8TeBqj1OQQE/zSdl2BRUg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/errors@2.0.0-rc.0':
-    resolution: {integrity: sha512-4zaFxuYWQJi+CBucncGPc+QsWZktdmC6rDne3JxZGDKqqY5AMwktRC9LyUKaey/dVThmFGo1wv1wNQy1ryvbWw==}
+  '@solana/errors@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-l3bv0rIwhbmumsqIT6j4zxBKdStgfQIfUio85P3lzMCh+0eTp+1hAGvsXQMbXtZ8ovLe5xiV3g1PB8Kr0a2h3w==}
+    engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
       typescript: '>=5'
@@ -417,129 +426,166 @@ packages:
       eslint-plugin-typescript-sort-keys: ^3.2.0
       typescript: ^5.1.6
 
-  '@solana/fast-stable-stringify@2.0.0-rc.0':
-    resolution: {integrity: sha512-qpHZNKzVP5PFEIK1TQvIM+A+DjSCV53KaxXzxPFiYd/JfjdxIhH6h1C0bbRMdsbBqwWlbacs2H5/xrKP3X42cw==}
+  '@solana/fast-stable-stringify@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-w+5mMzLH7y/mIa9/iMOEoebrKbW8Sz8VkS3EKjUNmUy48Vbk+27xryK46xbVoTFz2rcX0lrDcKDpilOhhPAh1w==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/functional@2.0.0-rc.0':
-    resolution: {integrity: sha512-Z+nkjtWyjp3yktU8ip2MxbKb7+I2YUiY8kbpvxAWnWKGcUoKhgcW3EhxhSxFWKbaiEcBmyoPCEdM2MJgJPZJug==}
+  '@solana/functional@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-5CX30yRL2iG3YL8Mofe+OMKe373FQJa/P6bPiD91SJ93o17dQtvUIQ+JnKNRKi+ZSZCBr1j/+2S8g4aQOEFOhA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/instructions@2.0.0-rc.0':
-    resolution: {integrity: sha512-0/MQ80BXZfELZuCc7GudopuCpQC4VnN9WJDHtR8Tur0j8shiSyHWOOZlWfx66eQuSiQsnbOLT1CRTdhEt/vZhA==}
+  '@solana/instructions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-RCxxH9mMFruqAz3Py1q5GJJECi1KWZiJQpqMiUhDH5f3LkNsDQqmi2VL2ByGnUKSptPRhyEWrpItR3ZQCUmJ4Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/keys@2.0.0-rc.0':
-    resolution: {integrity: sha512-k/2uvObJdQfsmKUI+vL+9zcRRdZpaScq0SKIQLe33dbv+3XIEhCRizPEIg8Q8fzIKB9rrbwHqJ5RPDxThZa++g==}
+  '@solana/keys@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-sGIkISsZHZagO9I6gmZSDiUMJIlHj833ULDyGcH9P9MLhs1sNYM2iW8FvDxWFY6/c3aYSyOZ28QSHHoaTKUsUA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/options@2.0.0-rc.0':
-    resolution: {integrity: sha512-uPc/31v+FZj9mkq2mQ6uAJfvmxGnQsx2mJ90IlJdDLSlkcx6GymNyXp0meh8qfhvfEaz4F5lCOzSeApofIZPvw==}
+  '@solana/options@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-f9Zbn1nhG0P3dxjl4LnA9FsJWCeVgSgkeix1hx85p8dbVy3q8NLNVCkyK2osC7KW655f6CL113vyl1dzkscm9w==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/programs@2.0.0-rc.0':
-    resolution: {integrity: sha512-sihHN5HDXEXJnoeG/hnahFreF6d2AMGIELtF2kv5uHM9F5NcdYFmX1Q0tWBC6Y/DugIf3Qtk+jMFceM7qUoWXA==}
+  '@solana/programs@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-32KEp3LiVH7joX55S111NV1Yh0udohddEtMAVWWKwgMClbaAkd3ATV978ahGk3VFLeyICvpndwQ29D4SxXqPXw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-api@2.0.0-rc.0':
-    resolution: {integrity: sha512-vP21oksg3lU8bbSyJfgfT9a/eeQ/q5sN76VSR05T7j3Tv8VmI9N77ZNrtrfG4DZfIiYWw3qlSrVI8XTwgMIW8A==}
+  '@solana/promises@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-ToZnDEGUwsHVQYgxuGC0qC6Rwir+9YoUnJHB4tQ8Qt9XS13FdgQuofeGsMZFZQFadbtrWJ5ROI4Z974/oCvIYA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-parsed-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-EvyOGZ6vbKG5XWDoPmNpMbm4Z0HE+hEIBxhQFkB+ML+qKPghtrifyF0bvydna7AIBkpc0OccVmv22Vd+gBvHng==}
+  '@solana/rpc-api@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-xpb8QLFMg6WXxXJdTSQ+536SAQTjiNKvccT074enGcXFsqIHoVfP+zHRYdUwypORnJ7xFPNgo5SAnFGNxIZWOg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-spec-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-0h2uQfjHIoUpP5ha3lzLFep6WLnggrksjWiCd8+iIoktPeh09CPJI2iU/hFheP7e+tUKhmErGqsL+OPNECwD2g==}
+  '@solana/rpc-parsed-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-jmKsbywEJ0Kil1aIYHiwPn37hofrAREOw49R2Go3Aw91zzAFOVXM2wuJ9WtK5U4JD36KCdDcX8t8aHKdHM/uJw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-spec@2.0.0-rc.0':
-    resolution: {integrity: sha512-Cdwj8ief8ek5VUWRfSZDqdFzRfC6HVzyoPMIOdWRtEd8KocUGo7BTbwN9ilVJL/vIi52vi6e2A6oPMFNRyuBFw==}
+  '@solana/rpc-spec-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-0aAOaxbBNaJomDDgyY/QoDID/vyVSfzU0/qRFVfWE0DVROGXa9cbGyH2I/FkLrfbuCc0TNi0150NmLLkHJK9VQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-api@2.0.0-rc.0':
-    resolution: {integrity: sha512-Q4/rR4epPud7Z/3lrtGNMJd5oSrrxp/JgJTnkxEzGxs07RHmVfvO/9jrS+dgDtj3epyjD4BhmecO98Bg8bZ2yg==}
+  '@solana/rpc-spec@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-I2XsRVtIU3RqihaVsTZP5itXZQ3mLD90sQ/GBYMSu9TVZfOgLdOFP0RpdQG5wIZvOun05vemon5f3PRIYfJyLQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-spec@2.0.0-rc.0':
-    resolution: {integrity: sha512-ZUxFAGy1nAIpLZ3RgWsRlRvPOLlx/vk1isFo5YcA+GAFZDLIt+jOZJF/J6QUjOohMc5xSkTRmJuMURCDmu+1dg==}
+  '@solana/rpc-subscriptions-api@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-+R/SBC+llwUUMVxolBgxrUWYrB/V6ybRkxF2ERB/ENC5EECM/Z3t8ZzXh6UwI0JTnjFoLivjUeZsrlKkLZC50A==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-subscriptions-transport-websocket@2.0.0-rc.0':
-    resolution: {integrity: sha512-Qg3w/zMAVaXhm/WQYFV0qXUjUDKmSJrRG/CzdjMfiqYPSFX1286uwyq5wnua4NzrbPd+ZtbGKyvdSVRnmy1WkA==}
+  '@solana/rpc-subscriptions-channel-websocket@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-RKIuZVFBTKGivLGiDQDwzu/uIGWMaFYGI4nWHjs0joCLr+Ixh4L7moeoimBUJtg3mWJ9/t8G/58ZcTEhiFrFOg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
-      ws: ^7.5.9
+      ws: ^8.18.0
 
-  '@solana/rpc-subscriptions@2.0.0-rc.0':
-    resolution: {integrity: sha512-ThLHuf6dxpq1RTWu7GAItjLubhcJsBdhGdGGtPjGEBW1zX5YnGLsG2sc16XLgbH5LZhUDQ37wub6iwMTOBqVhA==}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/rpc-transformers@2.0.0-rc.0':
-    resolution: {integrity: sha512-F/aL/ivIh2rPIpAGId8ZC3WG88wv025yLSmAhFZUOSbvF1ZCp8h63TUS5qpRGbDVUNr7PLu2Cm8EMkF6MoDSDA==}
+  '@solana/rpc-subscriptions-spec@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-/566STNmiTDjCIpwHZ7GCW/7qXdCBkE9shgjMFhYEKc1Kx+iOQJkFrHgVpaYH1stfs4+duRO8CYNrpCFkJfqOQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-transport-http@2.0.0-rc.0':
-    resolution: {integrity: sha512-ZuT3nhlfTGcDXjEkVlwG+XeLUKLxZvh/Am1em2vO8zGSQJmtFKlEq+Wk3C55acs0CrH00s29w3TcEcTtltikbg==}
+  '@solana/rpc-subscriptions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-u+GfSMAeLCpljznTJVk2FWOMPak/jYmYgKhH1V/ekIMol/9u7c/DaQmRrfvOjEYzxa3btRfem+kRkuoGw5n3cQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc-types@2.0.0-rc.0':
-    resolution: {integrity: sha512-KFuPmkVlZitZnncDGbwu5FSFXljHQsWb4u6fJbmq0yNGwjAlUspOnl7ufL0bS7e+hh0NKfyNOXWuC4vmYEMThw==}
+  '@solana/rpc-transformers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-rmyuZOYxmj7mmGrkLK9Ksc0GJ8bKACWgtHcgjhmPHJYIvSkFrGRoSxD45Y3d5sYN+cW8lrvQwB7GX6wC0ArFtQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/rpc@2.0.0-rc.0':
-    resolution: {integrity: sha512-isWQk5Cfu3hmjdzMfYLPn65KTkJHARocwx8i1+hF53kqrgvFGgAWtqDJXJfjkEan8ksSRfI5FzZB02YFB4zKSw==}
+  '@solana/rpc-transport-http@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-sE0dNSkOtCQyZa5CD7lGykzFIXxyQ+kPYa8FAnTqeojFGFUsj5nuME9Q+u0KvMPMAcqvWndIC3oxn7zyQuyxpQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/signers@2.0.0-rc.0':
-    resolution: {integrity: sha512-woQAIFe/kVrDPIC45wAt539hXYBOgIcVFuNVn3/aeKBpxosAokX1/NI7lWrIJChPHYB48wdnx6FOdV++EErwdQ==}
+  '@solana/rpc-types@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-2LK04mI0Vhce6OP2oW9adagyOpuEkXC2u48x1XUfGxB5U3Vlyu49noNzMqyPkyyICwSOPOYlRu910LZohLz8xQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/sysvars@2.0.0-rc.0':
-    resolution: {integrity: sha512-re+H9N4jFlFlpVxZt2y7QwWpo1HvqMgxLzJgnJicn6KPTeQX+UgH9+N1yNInLrBWDmgdvw+xjUinojqt3xPlEA==}
+  '@solana/rpc@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-jCxXDq09tIBot6wldr+nFTZ8AkEEEqTAnyJjDfdRm3U2NysOj3w3gv8gUBHo4KDrda3l2zKwAtYvejrakYoWJQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transaction-confirmation@2.0.0-rc.0':
-    resolution: {integrity: sha512-dGHxDaMd+a5BN52IZMiTv0oBcVwvNugGPJdE431ltSY47Q3rMUeGKQ9fj/EMY9WzVGEnbcD4Q67hERz1CRSJTA==}
+  '@solana/signers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-WWlbN8RdKzuk0j6wBnL8MYbU1sDp6mzaHmsIiNU3z057OUpRTDqXbQnHaD5ULortxKkeQnLiisZljtB4dJtqyA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transaction-messages@2.0.0-rc.0':
-    resolution: {integrity: sha512-WY3eQ6z1gsRffwSzRWy8MjJzLlNs47Wd99Up1vQggn9vJtwoGPF1uIYkjkTxsCEBXQOC1Z1RTy87dgcM7US/Jg==}
+  '@solana/subscribable@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-c8QmXCl7R67aMUGmwAvxnEoY38Si5+jnKlCYv8nkWHLqMDsg7kcyubGaDM4KLyR2YgE7wsppt/vEQlULjEb5Xw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/transactions@2.0.0-rc.0':
-    resolution: {integrity: sha512-0+d37gqvxAo172AtRkW2MDT19IYIcapeSZE4/RLa87JFBbouJovDZStDoYpcVCwjv4uxS3Squtc9PyAPhKLSnw==}
+  '@solana/sysvars@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-HUMALRIAKv4CBZ2aZHOGR3XkjdXgXvHKmWkTe5bIIZkWAtm690u7haNhdW64zHsiS+uST5hY7Xmn/83c11WWTw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/web3.js@2.0.0-rc.0':
-    resolution: {integrity: sha512-yJFhDdWM/REW635Cx2pIwa+cXxAEYQwdQ17ZvFO/fUZtU+In/OWYE3fXyC2ShfpUYzeCuMIfxHVPUhmeuSpUyA==}
+  '@solana/transaction-confirmation@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-AXlhSEvQb42EfA8Lei9UFamLiSOmKd7ZwCkPKEYDeQPM7iqAWtlp35jq8+Je3aiWkRUucxNpoYlg27EnkmTXtA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/webcrypto-ed25519-polyfill@2.0.0-rc.0':
-    resolution: {integrity: sha512-Ol5+EexErkKhIprhONGcgjXbUpdAo6zefoA058G7MA7TG98SWTszNg0obDHhHi5IW+r2x5zXc9uOuv55bP9mgw==}
+  '@solana/transaction-messages@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-NuWJxMZZPhuhnI+qPJ7yd2I0ExGDfwUHK44ez+li8rqmUEMndcpdT3BLOlNcr2x1lv0nhxaDTw+Jfl7765FdMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/transactions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-nwzNsl7QsccPBqw8x0YvDeeIPStynJRhRqLzMvTtmwXWvJMeC69YgN75slQZzhClbGva4V9KMY2WL1Q2J0xnMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/web3.js@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-kEL7sl61MX3vO8vSvOjnwGQkdN8jnvS6xUJw6TSSSbPynBNqws27Zn7sHu1n8J9qq+gQNGMy7aJVP8/vsvCpzg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-mtoi+P/3BVRM/L5rReM0K0etTwAP1uGsl6mMcbl647qKMHTaXHwdGCqPO6j1uPkeYnt2hEI49e7iKEtDIRpS3Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
@@ -1845,8 +1891,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.19.5:
-    resolution: {integrity: sha512-VQUzGd+K73uDi/pTqzDBbxZneciOuMRjF0r/Lep2zr/GOnU+cUvfgRu4T5k4TWJfpGdSK5nrzVDoQVoEIAFbmg==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -2167,71 +2213,71 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@solana/accounts@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/accounts@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/addresses@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/assertions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/assertions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/assertions@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-core@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/codecs-core@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-data-structures@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/codecs-data-structures@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-numbers@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/codecs-numbers@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/codecs-strings@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/codecs-strings@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.4.5
 
-  '@solana/codecs@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/codecs@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/options': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/options': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/errors@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
@@ -2249,257 +2295,278 @@ snapshots:
       eslint-plugin-typescript-sort-keys: 3.2.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/fast-stable-stringify@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/fast-stable-stringify@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
-  '@solana/functional@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/functional@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
-  '@solana/instructions@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/instructions@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/keys@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/keys@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/assertions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/options@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/assertions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/options@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-api@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/programs@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-parsed-types': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-parsed-types@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/promises@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       typescript: 5.4.5
 
-  '@solana/rpc-spec-types@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/rpc-api@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      typescript: 5.4.5
-
-  '@solana/rpc-spec@2.0.0-rc.0(typescript@5.4.5)':
-    dependencies:
-      '@solana/rpc-spec-types': 2.0.0-rc.0(typescript@5.4.5)
-      typescript: 5.4.5
-
-  '@solana/rpc-subscriptions-api@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
-    dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-parsed-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-spec@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/rpc-parsed-types@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec-types': 2.0.0-rc.0(typescript@5.4.5)
       typescript: 5.4.5
 
-  '@solana/rpc-subscriptions-transport-websocket@2.0.0-rc.0(typescript@5.4.5)(ws@8.17.0)':
+  '@solana/rpc-spec-types@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@solana/rpc-spec@2.1.0-canary-20241128134801(typescript@5.4.5)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@solana/rpc-subscriptions-api@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-channel-websocket@2.1.0-canary-20241128134801(typescript@5.4.5)(ws@8.17.0)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
       ws: 8.17.0
 
-  '@solana/rpc-subscriptions@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+  '@solana/rpc-subscriptions-spec@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/fast-stable-stringify': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-api': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-transport-websocket': 2.0.0-rc.0(typescript@5.4.5)(ws@8.17.0)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      typescript: 5.4.5
+
+  '@solana/rpc-subscriptions@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+    dependencies:
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/fast-stable-stringify': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-subscriptions-api': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-subscriptions-channel-websocket': 2.1.0-canary-20241128134801(typescript@5.4.5)(ws@8.17.0)
+      '@solana/rpc-subscriptions-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/subscribable': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/rpc-transformers@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/rpc-transformers@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transport-http@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/rpc-transport-http@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
-      undici-types: 6.19.5
+      undici-types: 6.21.0
 
-  '@solana/rpc-types@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/rpc-types@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
-    dependencies:
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/fast-stable-stringify': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-api': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-spec': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-transformers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-transport-http': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/rpc@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/fast-stable-stringify': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-api': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-spec': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-transformers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-transport-http': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/sysvars@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/signers@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/accounts': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+  '@solana/subscribable@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-subscriptions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
       typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
 
-  '@solana/transaction-messages@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/sysvars@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/accounts': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+  '@solana/transaction-confirmation@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
     dependencies:
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs-core': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-data-structures': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-numbers': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/codecs-strings': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/web3.js@2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
-    dependencies:
-      '@solana/accounts': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/addresses': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/codecs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/errors': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/functional': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/instructions': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/keys': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/programs': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/rpc-parsed-types': 2.0.0-rc.0(typescript@5.4.5)
-      '@solana/rpc-subscriptions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/rpc-types': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/signers': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/sysvars': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transaction-confirmation': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/transaction-messages': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
-      '@solana/transactions': 2.0.0-rc.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/promises': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-subscriptions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/webcrypto-ed25519-polyfill@2.0.0-rc.0(typescript@5.4.5)':
+  '@solana/transaction-messages@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)':
+    dependencies:
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/web3.js@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)':
+    dependencies:
+      '@solana/accounts': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/addresses': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/codecs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/functional': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/instructions': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/keys': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/programs': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/rpc-parsed-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-spec-types': 2.1.0-canary-20241128134801(typescript@5.4.5)
+      '@solana/rpc-subscriptions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+      '@solana/rpc-types': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/signers': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/sysvars': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transaction-confirmation': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
+      '@solana/transaction-messages': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      '@solana/transactions': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801(typescript@5.4.5)':
     dependencies:
       '@noble/ed25519': 2.1.0
       typescript: 5.4.5
@@ -3820,7 +3887,7 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  undici-types@6.19.5: {}
+  undici-types@6.21.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/packages/renderers-js/e2e/token/pnpm-lock.yaml
+++ b/packages/renderers-js/e2e/token/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@solana/web3.js':
         specifier: 2.1.0-canary-20241128134801
         version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.4.5)(ws@8.17.0)
-      '@solana/webcrypto-ed25519-polyfill':
-        specifier: 2.1.0-canary-20241128134801
-        version: 2.1.0-canary-20241128134801(typescript@5.4.5)
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.3.1
         version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
@@ -249,9 +246,6 @@ packages:
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
-
-  '@noble/ed25519@2.1.0':
-    resolution: {integrity: sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -579,12 +573,6 @@ packages:
 
   '@solana/web3.js@2.1.0-canary-20241128134801':
     resolution: {integrity: sha512-kEL7sl61MX3vO8vSvOjnwGQkdN8jnvS6xUJw6TSSSbPynBNqws27Zn7sHu1n8J9qq+gQNGMy7aJVP8/vsvCpzg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801':
-    resolution: {integrity: sha512-mtoi+P/3BVRM/L5rReM0K0etTwAP1uGsl6mMcbl647qKMHTaXHwdGCqPO6j1uPkeYnt2hEI49e7iKEtDIRpS3Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
@@ -2141,8 +2129,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@noble/ed25519@2.1.0': {}
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2565,11 +2551,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - ws
-
-  '@solana/webcrypto-ed25519-polyfill@2.1.0-canary-20241128134801(typescript@5.4.5)':
-    dependencies:
-      '@noble/ed25519': 2.1.0
-      typescript: 5.4.5
 
   '@types/estree@1.0.5': {}
 

--- a/packages/renderers-js/e2e/token/src/generated/instructions/amountToUiAmount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/amountToUiAmount.ts
@@ -24,6 +24,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlyAccount,
+  type ReadonlyUint8Array,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -39,7 +40,7 @@ export type AmountToUiAmountInstruction<
   TAccountMint extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountMint extends string
@@ -145,7 +146,7 @@ export function parseAmountToUiAmountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedAmountToUiAmountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/approve.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/approve.ts
@@ -27,6 +27,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -46,7 +47,7 @@ export type ApproveInstruction<
   TAccountOwner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountSource extends string
@@ -203,7 +204,7 @@ export function parseApproveInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedApproveInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/approveChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/approveChecked.ts
@@ -27,6 +27,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -47,7 +48,7 @@ export type ApproveCheckedInstruction<
   TAccountOwner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountSource extends string
@@ -229,7 +230,7 @@ export function parseApproveCheckedInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedApproveCheckedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 4) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/burn.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/burn.ts
@@ -27,6 +27,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -46,7 +47,7 @@ export type BurnInstruction<
   TAccountAuthority extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountAccount extends string
@@ -202,7 +203,7 @@ export function parseBurnInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedBurnInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/burnChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/burnChecked.ts
@@ -27,6 +27,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -46,7 +47,7 @@ export type BurnCheckedInstruction<
   TAccountAuthority extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountAccount extends string
@@ -212,7 +213,7 @@ export function parseBurnCheckedInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedBurnCheckedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/closeAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/closeAccount.ts
@@ -25,6 +25,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -44,7 +45,7 @@ export type CloseAccountInstruction<
   TAccountOwner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountAccount extends string
@@ -185,7 +186,7 @@ export function parseCloseAccountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedCloseAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
@@ -30,6 +30,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type LamportsUnsafeBeyond2Pow53Minus1,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableSignerAccount,
 } from '@solana/web3.js';
@@ -52,7 +53,7 @@ export type CreateAccountInstruction<
   TAccountNewAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountPayer extends string
@@ -194,7 +195,7 @@ export function parseCreateAccountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedCreateAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
@@ -29,7 +29,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
-  type LamportsUnsafeBeyond2Pow53Minus1,
+  type Lamports,
   type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableSignerAccount,
@@ -70,13 +70,13 @@ export type CreateAccountInstruction<
 
 export type CreateAccountInstructionData = {
   discriminator: number;
-  lamports: LamportsUnsafeBeyond2Pow53Minus1;
+  lamports: Lamports;
   space: bigint;
   programAddress: Address;
 };
 
 export type CreateAccountInstructionDataArgs = {
-  lamports: LamportsUnsafeBeyond2Pow53Minus1;
+  lamports: Lamports;
   space: number | bigint;
   programAddress: Address;
 };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedToken.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedToken.ts
@@ -23,6 +23,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlyAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
   type WritableSignerAccount,
@@ -55,7 +56,7 @@ export type CreateAssociatedTokenInstruction<
     | IAccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountPayer extends string
@@ -348,7 +349,7 @@ export function parseCreateAssociatedTokenInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedCreateAssociatedTokenInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 6) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
@@ -23,6 +23,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlyAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
   type WritableSignerAccount,
@@ -57,7 +58,7 @@ export type CreateAssociatedTokenIdempotentInstruction<
     | IAccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountPayer extends string
@@ -352,7 +353,7 @@ export function parseCreateAssociatedTokenIdempotentInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedCreateAssociatedTokenIdempotentInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 6) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/freezeAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/freezeAccount.ts
@@ -25,6 +25,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -44,7 +45,7 @@ export type FreezeAccountInstruction<
   TAccountOwner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountAccount extends string
@@ -185,7 +186,7 @@ export function parseFreezeAccountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedFreezeAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/getAccountDataSize.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/getAccountDataSize.ts
@@ -22,6 +22,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlyAccount,
+  type ReadonlyUint8Array,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -37,7 +38,7 @@ export type GetAccountDataSizeInstruction<
   TAccountMint extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountMint extends string
@@ -127,7 +128,7 @@ export function parseGetAccountDataSizeInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedGetAccountDataSizeInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount.ts
@@ -22,6 +22,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlyAccount,
+  type ReadonlyUint8Array,
   type WritableAccount,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -43,7 +44,7 @@ export type InitializeAccountInstruction<
     | IAccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountAccount extends string
@@ -190,7 +191,7 @@ export function parseInitializeAccountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 4) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount2.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount2.ts
@@ -24,6 +24,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlyAccount,
+  type ReadonlyUint8Array,
   type WritableAccount,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -44,7 +45,7 @@ export type InitializeAccount2Instruction<
     | IAccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountAccount extends string
@@ -192,7 +193,7 @@ export function parseInitializeAccount2Instruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeAccount2Instruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount3.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount3.ts
@@ -24,6 +24,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlyAccount,
+  type ReadonlyUint8Array,
   type WritableAccount,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -41,7 +42,7 @@ export type InitializeAccount3Instruction<
   TAccountMint extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountAccount extends string
@@ -167,7 +168,7 @@ export function parseInitializeAccount3Instruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeAccount3Instruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeImmutableOwner.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeImmutableOwner.ts
@@ -21,6 +21,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyUint8Array,
   type WritableAccount,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -37,7 +38,7 @@ export type InitializeImmutableOwnerInstruction<
   TAccountAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountAccount extends string
@@ -129,7 +130,7 @@ export function parseInitializeImmutableOwnerInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeImmutableOwnerInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint.ts
@@ -29,6 +29,7 @@ import {
   type Option,
   type OptionOrNullable,
   type ReadonlyAccount,
+  type ReadonlyUint8Array,
   type WritableAccount,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -48,7 +49,7 @@ export type InitializeMintInstruction<
     | IAccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountMint extends string
@@ -190,7 +191,7 @@ export function parseInitializeMintInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeMintInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint2.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint2.ts
@@ -28,6 +28,7 @@ import {
   type IInstructionWithData,
   type Option,
   type OptionOrNullable,
+  type ReadonlyUint8Array,
   type WritableAccount,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -44,7 +45,7 @@ export type InitializeMint2Instruction<
   TAccountMint extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountMint extends string
@@ -168,7 +169,7 @@ export function parseInitializeMint2Instruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeMint2Instruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig.ts
@@ -23,6 +23,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlyAccount,
+  type ReadonlyUint8Array,
   type WritableAccount,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -42,7 +43,7 @@ export type InitializeMultisigInstruction<
     | IAccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountMultisig extends string
@@ -185,7 +186,7 @@ export function parseInitializeMultisigInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeMultisigInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig2.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig2.ts
@@ -22,6 +22,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyUint8Array,
   type WritableAccount,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -38,7 +39,7 @@ export type InitializeMultisig2Instruction<
   TAccountMultisig extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountMultisig extends string
@@ -152,7 +153,7 @@ export function parseInitializeMultisig2Instruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeMultisig2Instruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/mintTo.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/mintTo.ts
@@ -27,6 +27,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -46,7 +47,7 @@ export type MintToInstruction<
   TAccountMintAuthority extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountMint extends string
@@ -207,7 +208,7 @@ export function parseMintToInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedMintToInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/mintToChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/mintToChecked.ts
@@ -27,6 +27,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -46,7 +47,7 @@ export type MintToCheckedInstruction<
   TAccountMintAuthority extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountMint extends string
@@ -214,7 +215,7 @@ export function parseMintToCheckedInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedMintToCheckedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
@@ -23,6 +23,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlyAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
   type WritableSignerAccount,
@@ -60,7 +61,7 @@ export type RecoverNestedAssociatedTokenInstruction<
     | IAccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountNestedAssociatedAccountAddress extends string
@@ -420,7 +421,7 @@ export function parseRecoverNestedAssociatedTokenInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedRecoverNestedAssociatedTokenInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 7) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/revoke.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/revoke.ts
@@ -25,6 +25,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -43,7 +44,7 @@ export type RevokeInstruction<
   TAccountOwner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountSource extends string
@@ -171,7 +172,7 @@ export function parseRevokeInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedRevokeInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/setAuthority.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/setAuthority.ts
@@ -31,6 +31,7 @@ import {
   type OptionOrNullable,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -55,7 +56,7 @@ export type SetAuthorityInstruction<
   TAccountOwner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountOwned extends string
@@ -206,7 +207,7 @@ export function parseSetAuthorityInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedSetAuthorityInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/syncNative.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/syncNative.ts
@@ -21,6 +21,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type ReadonlyUint8Array,
   type WritableAccount,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -37,7 +38,7 @@ export type SyncNativeInstruction<
   TAccountAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountAccount extends string
@@ -124,7 +125,7 @@ export function parseSyncNativeInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedSyncNativeInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/thawAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/thawAccount.ts
@@ -25,6 +25,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -44,7 +45,7 @@ export type ThawAccountInstruction<
   TAccountOwner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountAccount extends string
@@ -185,7 +186,7 @@ export function parseThawAccountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedThawAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/transfer.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/transfer.ts
@@ -27,6 +27,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -46,7 +47,7 @@ export type TransferInstruction<
   TAccountAuthority extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountSource extends string
@@ -205,7 +206,7 @@ export function parseTransferInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedTransferInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/transferChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/transferChecked.ts
@@ -27,6 +27,7 @@ import {
   type IInstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
+  type ReadonlyUint8Array,
   type TransactionSigner,
   type WritableAccount,
 } from '@solana/web3.js';
@@ -47,7 +48,7 @@ export type TransferCheckedInstruction<
   TAccountAuthority extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountSource extends string
@@ -231,7 +232,7 @@ export function parseTransferCheckedInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedTransferCheckedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 4) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/uiAmountToAmount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/uiAmountToAmount.ts
@@ -24,6 +24,7 @@ import {
   type IInstructionWithAccounts,
   type IInstructionWithData,
   type ReadonlyAccount,
+  type ReadonlyUint8Array,
 } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
@@ -39,7 +40,7 @@ export type UiAmountToAmountInstruction<
   TAccountMint extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
+  IInstructionWithData<ReadonlyUint8Array> &
   IInstructionWithAccounts<
     [
       TAccountMint extends string
@@ -145,7 +146,7 @@ export function parseUiAmountToAmountInstruction<
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+    IInstructionWithData<ReadonlyUint8Array>
 ): ParsedUiAmountToAmountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/package.json
+++ b/packages/renderers-js/package.json
@@ -48,7 +48,7 @@
         "@codama/nodes-from-anchor": "workspace:*",
         "@codama/renderers-core": "workspace:*",
         "@codama/visitors-core": "workspace:*",
-        "@solana/codecs-strings": "rc",
+        "@solana/codecs-strings": "2.1.0-canary-20241128134801",
         "nunjucks": "^3.2.4",
         "prettier": "^3.4.1"
     },

--- a/packages/renderers-js/public/templates/fragments/instructionParseFunction.njk
+++ b/packages/renderers-js/public/templates/fragments/instructionParseFunction.njk
@@ -33,7 +33,7 @@ export function {{ instructionParseFunction }}<
       & IInstructionWithAccounts<TAccountMetas>
     {% endif %}
     {% if hasData %}
-      & IInstructionWithData<Uint8Array>
+      & IInstructionWithData<ReadonlyUint8Array>
     {% endif %}
 ): {{ instructionParsedType }}<TProgram {{ ', TAccountMetas' if hasAccounts }}> {
   {% if hasAccounts %}

--- a/packages/renderers-js/public/templates/fragments/instructionType.njk
+++ b/packages/renderers-js/public/templates/fragments/instructionType.njk
@@ -8,7 +8,7 @@ export type {{ instructionType }}<
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram>
   {% if hasData %}
-    & IInstructionWithData<Uint8Array>
+    & IInstructionWithData<ReadonlyUint8Array>
   {% endif %}
   {% if hasAccounts %}
     & IInstructionWithAccounts<[{{ accountMetas }}, ...TRemainingAccounts]>

--- a/packages/renderers-js/src/fragments/instructionParseFunction.ts
+++ b/packages/renderers-js/src/fragments/instructionParseFunction.ts
@@ -51,5 +51,6 @@ export function getInstructionParseFunctionFragment(
         .addImports('generatedPrograms', [programAddressConstant])
         .addImports('solanaInstructions', ['type IInstruction'])
         .addImports('solanaInstructions', hasAccounts ? ['type IInstructionWithAccounts', 'type IAccountMeta'] : [])
-        .addImports('solanaInstructions', hasData ? ['type IInstructionWithData'] : []);
+        .addImports('solanaInstructions', hasData ? ['type IInstructionWithData'] : [])
+        .addImports('solanaCodecsCore', hasData ? ['type ReadonlyUint8Array'] : []);
 }

--- a/packages/renderers-js/src/fragments/instructionType.ts
+++ b/packages/renderers-js/src/fragments/instructionType.ts
@@ -56,6 +56,7 @@ export function getInstructionTypeFragment(
     })
         .mergeImportsWith(accountTypeParamsFragment, accountMetasFragment)
         .addImports('generatedPrograms', [programAddressConstant])
+        .addImports('solanaCodecsCore', hasData ? ['type ReadonlyUint8Array'] : [])
         .addImports('solanaInstructions', [
             'type IAccountMeta',
             'type IInstruction',

--- a/packages/renderers-js/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-js/src/getTypeManifestVisitor.ts
@@ -719,11 +719,8 @@ export function getTypeManifestVisitor(input: {
                 visitSolAmountType({ number }, { self }) {
                     const numberManifest = visit(number, self);
 
-                    const lamportsType = 'LamportsUnsafeBeyond2Pow53Minus1';
-                    const lamportsImport = new ImportMap().add(
-                        'solanaRpcTypes',
-                        'type LamportsUnsafeBeyond2Pow53Minus1',
-                    );
+                    const lamportsType = 'Lamports';
+                    const lamportsImport = new ImportMap().add('solanaRpcTypes', 'type Lamports');
 
                     return {
                         ...numberManifest,

--- a/packages/renderers-js/test/types/solAmount.test.ts
+++ b/packages/renderers-js/test/types/solAmount.test.ts
@@ -17,7 +17,7 @@ test('it renders size prefix codecs', async () => {
 
     // Then we expect the following types and codecs to be exported.
     await renderMapContains(renderMap, 'types/myType.ts', [
-        'export type MyType = LamportsUnsafeBeyond2Pow53Minus1',
+        'export type MyType = Lamports',
         'export type MyTypeArgs = MyType',
         'export function getMyTypeEncoder(): Encoder<MyTypeArgs> { return getLamportsEncoder(getU64Encoder()); }',
         'export function getMyTypeDecoder(): Decoder<MyType> { return getLamportsDecoder(getU64Decoder()); }',
@@ -25,12 +25,6 @@ test('it renders size prefix codecs', async () => {
 
     // And we expect the following type and codec imports.
     await renderMapContainsImports(renderMap, 'types/myType.ts', {
-        '@solana/web3.js': [
-            'LamportsUnsafeBeyond2Pow53Minus1',
-            'getLamportsEncoder',
-            'getLamportsDecoder',
-            'getU64Encoder',
-            'getU64Decoder',
-        ],
+        '@solana/web3.js': ['Lamports', 'getLamportsEncoder', 'getLamportsDecoder', 'getU64Encoder', 'getU64Decoder'],
     });
 });

--- a/packages/renderers-rust/package.json
+++ b/packages/renderers-rust/package.json
@@ -46,7 +46,7 @@
         "@codama/nodes": "workspace:*",
         "@codama/renderers-core": "workspace:*",
         "@codama/visitors-core": "workspace:*",
-        "@solana/codecs-strings": "rc",
+        "@solana/codecs-strings": "2.1.0-canary-20241128134801",
         "nunjucks": "^3.2.4"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: workspace:*
         version: link:../visitors-core
       '@solana/codecs':
-        specifier: 2.0.0
-        version: 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
 
   packages/dynamic-parsers:
     dependencies:
@@ -108,12 +108,12 @@ importers:
         specifier: workspace:*
         version: link:../visitors-core
       '@solana/instructions':
-        specifier: 2.0.0
-        version: 2.0.0(typescript@5.7.2)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(typescript@5.7.2)
     devDependencies:
       '@solana/codecs':
-        specifier: 2.0.0
-        version: 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
 
   packages/errors:
     dependencies:
@@ -216,8 +216,8 @@ importers:
         specifier: workspace:*
         version: link:../visitors-core
       '@solana/codecs-strings':
-        specifier: rc
-        version: 2.0.0-rc.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
       nunjucks:
         specifier: ^3.2.4
         version: 3.2.4(chokidar@3.6.0)
@@ -247,8 +247,8 @@ importers:
         specifier: workspace:*
         version: link:../visitors-core
       '@solana/codecs-strings':
-        specifier: rc
-        version: 2.0.0-rc.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
       nunjucks:
         specifier: ^3.2.4
         version: 3.2.4(chokidar@3.6.0)
@@ -275,8 +275,8 @@ importers:
         specifier: workspace:*
         version: link:../visitors-core
       '@solana/codecs-strings':
-        specifier: rc
-        version: 2.0.0-rc.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
+        specifier: 2.1.0-canary-20241128134801
+        version: 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
       nunjucks:
         specifier: ^3.2.4
         version: 3.2.4(chokidar@3.6.0)
@@ -1151,65 +1151,39 @@ packages:
   '@sinonjs/fake-timers@11.3.1':
     resolution: {integrity: sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==}
 
-  '@solana/codecs-core@2.0.0':
-    resolution: {integrity: sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==}
+  '@solana/codecs-core@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-Lgd9IZ7coAc6F/X8RAIR+Sc0jIf8jHzYw/g4eBMcJU/Zjmcmja6l+2LGIpdlkn2+x+lMckK3HO4RHifXUS0ytQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-core@2.0.0-rc.4':
-    resolution: {integrity: sha512-JIrTSps032mSE3wBxW3bXOqWfoy4CMy1CX/XeVCijyh5kLVxZTSDIdRTYdePdL1yzaOZF1Xysvt1DhOUgBdM+A==}
+  '@solana/codecs-data-structures@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-356XK2JCygLz9FZvrSXWLqGhIQZmpKIlwqY8PiZEho4xmWUaupvyvNjWAAohCK8YXhfEMzKOnyoO3yHMLnLJIg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-data-structures@2.0.0':
-    resolution: {integrity: sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==}
+  '@solana/codecs-numbers@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-2PZ/xY8tOUFjgFuga/tAbinrcS2p9YX3RaxbXvMBJYvi3DAcdi0zqTwE4ganEzfQ5Os9o1shw88zYSKk0vy8lQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-numbers@2.0.0':
-    resolution: {integrity: sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/codecs-numbers@2.0.0-rc.4':
-    resolution: {integrity: sha512-ZJR7TaUO65+3Hzo3YOOUCS0wlzh17IW+j0MZC2LCk1R0woaypRpHKj4iSMYeQOZkMxsd9QT3WNvjFrPC2qA6Sw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/codecs-strings@2.0.0':
-    resolution: {integrity: sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==}
+  '@solana/codecs-strings@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-SEmAc9c6692Tm7wEmzot7mxaDsTN3wnA78uDj2IgqXmznLOGfw3kAcA8Xcq6rTL5NhUlePjxaJg6I2T+GRVIRA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
 
-  '@solana/codecs-strings@2.0.0-rc.4':
-    resolution: {integrity: sha512-LGfK2RL0BKjYYUfzu2FG/gTgCsYOMz9FKVs2ntji6WneZygPxJTV5W98K3J8Rl0JewpCSCFQH3xjLSHBJUS0fA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: '>=5'
-
-  '@solana/codecs@2.0.0':
-    resolution: {integrity: sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==}
+  '@solana/codecs@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-uQ9rI7odB91z9jI0lR1LnBMohmk2MnZTYVRl0CDEEfet57UfaFFV0T++x5LV4zpUL8TeBqj1OQQE/zSdl2BRUg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/errors@2.0.0':
-    resolution: {integrity: sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/errors@2.0.0-rc.4':
-    resolution: {integrity: sha512-0PPaMyB81keEHG/1pnyEuiBVKctbXO641M2w3CIOrYT/wzjunfF0FTxsqq9wYJeYo0AyiefCKGgSPs6wiY2PpQ==}
+  '@solana/errors@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-l3bv0rIwhbmumsqIT6j4zxBKdStgfQIfUio85P3lzMCh+0eTp+1hAGvsXQMbXtZ8ovLe5xiV3g1PB8Kr0a2h3w==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
@@ -1231,14 +1205,14 @@ packages:
       typescript: ^5.6
       typescript-eslint: ^8.11.0
 
-  '@solana/instructions@2.0.0':
-    resolution: {integrity: sha512-MiTEiNF7Pzp+Y+x4yadl2VUcNHboaW5WP52psBuhHns3GpbbruRv5efMpM9OEQNe1OsN+Eg39vjEidX55+P+DQ==}
+  '@solana/instructions@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-RCxxH9mMFruqAz3Py1q5GJJECi1KWZiJQpqMiUhDH5f3LkNsDQqmi2VL2ByGnUKSptPRhyEWrpItR3ZQCUmJ4Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/options@2.0.0':
-    resolution: {integrity: sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==}
+  '@solana/options@2.1.0-canary-20241128134801':
+    resolution: {integrity: sha512-f9Zbn1nhG0P3dxjl4LnA9FsJWCeVgSgkeix1hx85p8dbVy3q8NLNVCkyK2osC7KW655f6CL113vyl1dzkscm9w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
@@ -4125,69 +4099,44 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@solana/codecs-core@2.0.0(typescript@5.7.2)':
+  '@solana/codecs-core@2.1.0-canary-20241128134801(typescript@5.7.2)':
     dependencies:
-      '@solana/errors': 2.0.0(typescript@5.7.2)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.7.2)
       typescript: 5.7.2
 
-  '@solana/codecs-core@2.0.0-rc.4(typescript@5.7.2)':
+  '@solana/codecs-data-structures@2.1.0-canary-20241128134801(typescript@5.7.2)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.4(typescript@5.7.2)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.7.2)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.7.2)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.7.2)
       typescript: 5.7.2
 
-  '@solana/codecs-data-structures@2.0.0(typescript@5.7.2)':
+  '@solana/codecs-numbers@2.1.0-canary-20241128134801(typescript@5.7.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0(typescript@5.7.2)
-      '@solana/codecs-numbers': 2.0.0(typescript@5.7.2)
-      '@solana/errors': 2.0.0(typescript@5.7.2)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.7.2)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.7.2)
       typescript: 5.7.2
 
-  '@solana/codecs-numbers@2.0.0(typescript@5.7.2)':
+  '@solana/codecs-strings@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0(typescript@5.7.2)
-      '@solana/errors': 2.0.0(typescript@5.7.2)
-      typescript: 5.7.2
-
-  '@solana/codecs-numbers@2.0.0-rc.4(typescript@5.7.2)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.4(typescript@5.7.2)
-      '@solana/errors': 2.0.0-rc.4(typescript@5.7.2)
-      typescript: 5.7.2
-
-  '@solana/codecs-strings@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0(typescript@5.7.2)
-      '@solana/codecs-numbers': 2.0.0(typescript@5.7.2)
-      '@solana/errors': 2.0.0(typescript@5.7.2)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.7.2)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.7.2)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.7.2)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.7.2
 
-  '@solana/codecs-strings@2.0.0-rc.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)':
+  '@solana/codecs@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.4(typescript@5.7.2)
-      '@solana/codecs-numbers': 2.0.0-rc.4(typescript@5.7.2)
-      '@solana/errors': 2.0.0-rc.4(typescript@5.7.2)
-      fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.7.2
-
-  '@solana/codecs@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0(typescript@5.7.2)
-      '@solana/codecs-data-structures': 2.0.0(typescript@5.7.2)
-      '@solana/codecs-numbers': 2.0.0(typescript@5.7.2)
-      '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
-      '@solana/options': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.7.2)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.7.2)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.7.2)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
+      '@solana/options': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
       typescript: 5.7.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@2.0.0(typescript@5.7.2)':
-    dependencies:
-      chalk: 5.3.0
-      commander: 12.1.0
-      typescript: 5.7.2
-
-  '@solana/errors@2.0.0-rc.4(typescript@5.7.2)':
+  '@solana/errors@2.1.0-canary-20241128134801(typescript@5.7.2)':
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
@@ -4208,18 +4157,19 @@ snapshots:
       typescript: 5.7.2
       typescript-eslint: 8.16.0(eslint@9.15.0)(typescript@5.7.2)
 
-  '@solana/instructions@2.0.0(typescript@5.7.2)':
+  '@solana/instructions@2.1.0-canary-20241128134801(typescript@5.7.2)':
     dependencies:
-      '@solana/errors': 2.0.0(typescript@5.7.2)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.7.2)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.7.2)
       typescript: 5.7.2
 
-  '@solana/options@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)':
+  '@solana/options@2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0(typescript@5.7.2)
-      '@solana/codecs-data-structures': 2.0.0(typescript@5.7.2)
-      '@solana/codecs-numbers': 2.0.0(typescript@5.7.2)
-      '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
-      '@solana/errors': 2.0.0(typescript@5.7.2)
+      '@solana/codecs-core': 2.1.0-canary-20241128134801(typescript@5.7.2)
+      '@solana/codecs-data-structures': 2.1.0-canary-20241128134801(typescript@5.7.2)
+      '@solana/codecs-numbers': 2.1.0-canary-20241128134801(typescript@5.7.2)
+      '@solana/codecs-strings': 2.1.0-canary-20241128134801(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.2)
+      '@solana/errors': 2.1.0-canary-20241128134801(typescript@5.7.2)
       typescript: 5.7.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder


### PR DESCRIPTION
This PR updates Codama and the code it generates for the new web3.js to be compatible with the latest `IInstructionWithData` change introduce in https://github.com/solana-labs/solana-web3.js/pull/3632.

Note that, we need to wait for `2.1.0` to be published before merging this PR since, otherwise, we will be using a canary version in our dependencies.