### PR TITLE
Transform all u8 arrays by default

### DIFF
--- a/.changeset/serious-fireants-rescue.md
+++ b/.changeset/serious-fireants-rescue.md
@@ -1,5 +1,6 @@
 ---
 '@codama/visitors': minor
+'@codama/nodes-from-anchor': minor
 ---
 
 Transform all u8 arrays by default in `transformU8ArraysToBytesVisitor`

--- a/.changeset/serious-fireants-rescue.md
+++ b/.changeset/serious-fireants-rescue.md
@@ -1,0 +1,5 @@
+---
+'@codama/visitors': minor
+---
+
+Transform all u8 arrays by default in `transformU8ArraysToBytesVisitor`

--- a/packages/visitors/src/transformU8ArraysToBytesVisitor.ts
+++ b/packages/visitors/src/transformU8ArraysToBytesVisitor.ts
@@ -9,7 +9,7 @@ import {
 } from '@codama/nodes';
 import { extendVisitor, nonNullableIdentityVisitor, pipe, visit } from '@codama/visitors-core';
 
-export function transformU8ArraysToBytesVisitor(sizes: number[] | '*' = [32, 64]) {
+export function transformU8ArraysToBytesVisitor(sizes: number[] | '*' = '*') {
     const hasRequiredSize = (count: ArrayTypeNode['count']): boolean => {
         if (!isNode(count, 'fixedCountNode')) return false;
         return sizes === '*' || sizes.includes(count.value);


### PR DESCRIPTION
The current behaviour confuses devs because some `u8` arrays are being turned into `BytesTypeNode` but not others based on their size. This PR fixes this by transforming all fixed-size arrays of `u8` numbers into a `FixedSizeTypeNode` of `BytesTypeNode`.