### PR TITLE
renderer-rust: add decode-error trait to errors

### DIFF
--- a/.changeset/rich-nails-talk.md
+++ b/.changeset/rich-nails-talk.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-rust': patch
+---
+
+add decode-error trait to errors

--- a/packages/renderers-rust/e2e/system/src/generated/errors/system.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/errors/system.rs
@@ -44,3 +44,9 @@ impl solana_program::program_error::PrintProgramError for SystemError {
         solana_program::msg!(&self.to_string());
     }
 }
+
+impl<T> solana_program::decode_error::DecodeError<T> for SystemError {
+    fn type_of() -> &'static str {
+        "SystemError"
+    }
+}

--- a/packages/renderers-rust/public/templates/errorsPage.njk
+++ b/packages/renderers-rust/public/templates/errorsPage.njk
@@ -20,4 +20,10 @@ impl solana_program::program_error::PrintProgramError for {{ program.name | pasc
     }
 }
 
+impl<T> solana_program::decode_error::DecodeError<T> for {{ program.name | pascalCase }}Error {
+    fn type_of() -> &'static str {
+        "{{ program.name | pascalCase }}Error"
+    }
+}
+
 {% endblock %}


### PR DESCRIPTION
Many Rust client applications may wish to define functions generic over `solana_program::decode_error::DecodeError`, which conveniently converts from a `ProgramError::Custom` to the respective enum value using `FromPrimitive`.

This change adds that trait implementation to the Rust renderer.