### PR TITLE
bug: serde serialize/deserialize big arrays

### DIFF
--- a/.changeset/tiny-bikes-hug.md
+++ b/.changeset/tiny-bikes-hug.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-rust': patch
+---
+
+bug: serde serialize/deserialize big arrays

--- a/packages/renderers-rust/e2e/dummy/Cargo.lock
+++ b/packages/renderers-rust/e2e/dummy/Cargo.lock
@@ -1047,6 +1047,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "serde",
+ "serde-big-array",
  "serde_with 3.11.0",
  "solana-program",
  "solana-program-test",
@@ -3514,6 +3515,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/packages/renderers-rust/e2e/dummy/Cargo.toml
+++ b/packages/renderers-rust/e2e/dummy/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 anchor = ["dep:anchor-lang"]
 anchor-idl-build = ["anchor", "anchor-lang?/idl-build"]
-serde = ["dep:serde", "dep:serde_with"]
+serde = ["dep:serde", "dep:serde_with", "dep:serde-big-array"]
 test-sbf = []
 
 [dependencies]
@@ -17,6 +17,7 @@ num-derive = "^0.3"
 num-traits = "^0.2"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_with = { version = "^3.0", optional = true }
+serde-big-array = { version = "^0.5", optional = true }
 solana-program = "~1.18"
 thiserror = "^1.0"
 

--- a/packages/renderers-rust/e2e/memo/Cargo.lock
+++ b/packages/renderers-rust/e2e/memo/Cargo.lock
@@ -1035,6 +1035,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "serde",
+ "serde-big-array",
  "serde_with 3.8.0",
  "solana-program",
  "solana-program-test",
@@ -3492,6 +3493,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/packages/renderers-rust/e2e/memo/Cargo.toml
+++ b/packages/renderers-rust/e2e/memo/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 anchor = ["dep:anchor-lang"]
 anchor-idl-build = ["anchor", "anchor-lang?/idl-build"]
-serde = ["dep:serde", "dep:serde_with"]
+serde = ["dep:serde", "dep:serde_with", "dep:serde-big-array"]
 test-sbf = []
 
 [dependencies]
@@ -17,6 +17,7 @@ num-derive = "^0.3"
 num-traits = "^0.2"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_with = { version = "^3.0", optional = true }
+serde-big-array = { version = "^0.5", optional = true }
 solana-program = "~1.18"
 thiserror = "^1.0"
 

--- a/packages/renderers-rust/e2e/system/Cargo.lock
+++ b/packages/renderers-rust/e2e/system/Cargo.lock
@@ -1034,6 +1034,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "serde",
+ "serde-big-array",
  "serde_with 3.8.0",
  "solana-program",
  "solana-program-test",
@@ -3482,6 +3483,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/packages/renderers-rust/e2e/system/Cargo.toml
+++ b/packages/renderers-rust/e2e/system/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 anchor = ["dep:anchor-lang"]
 anchor-idl-build = ["anchor", "anchor-lang?/idl-build"]
-serde = ["dep:serde", "dep:serde_with"]
+serde = ["dep:serde", "dep:serde_with", "dep:serde-big-array"]
 test-sbf = []
 
 [dependencies]
@@ -16,6 +16,7 @@ num-derive = "^0.3"
 num-traits = "^0.2"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_with = { version = "^3.0", optional = true }
+serde-big-array = { version = "^0.5", optional = true }
 solana-program = "~1.18"
 thiserror = "^1.0"
 

--- a/packages/renderers-rust/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-rust/src/getTypeManifestVisitor.ts
@@ -395,12 +395,11 @@ export function getTypeManifestVisitor(options: {
                         isNode(resolvedNestedType.count, 'fixedCountNode') &&
                         resolvedNestedType.count.value > 32
                     ) {
-                        derive =
-                            '#[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]\n';
+                        derive = '#[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]\n';
                     } else if (
                         isNode(resolvedNestedType, ['bytesTypeNode', 'stringTypeNode']) &&
-                            isNode(structFieldType.type, 'fixedSizeTypeNode') &&
-                            structFieldType.type.size > 32
+                        isNode(structFieldType.type, 'fixedSizeTypeNode') &&
+                        structFieldType.type.size > 32
                     ) {
                         derive =
                             '#[cfg_attr(feature = "serde", serde(with = "serde_with::As::<serde_with::Bytes>"))]\n';

--- a/packages/renderers-rust/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-rust/src/getTypeManifestVisitor.ts
@@ -391,12 +391,16 @@ export function getTypeManifestVisitor(options: {
                         derive =
                             '#[cfg_attr(feature = "serde", serde(with = "serde_with::As::<Vec<serde_with::DisplayFromStr>>"))]\n';
                     } else if (
-                        (isNode(resolvedNestedType, 'arrayTypeNode') &&
-                            isNode(resolvedNestedType.count, 'fixedCountNode') &&
-                            resolvedNestedType.count.value > 32) ||
-                        (isNode(resolvedNestedType, ['bytesTypeNode', 'stringTypeNode']) &&
+                        isNode(resolvedNestedType, 'arrayTypeNode') &&
+                        isNode(resolvedNestedType.count, 'fixedCountNode') &&
+                        resolvedNestedType.count.value > 32
+                    ) {
+                        derive =
+                            '#[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]\n';
+                    } else if (
+                        isNode(resolvedNestedType, ['bytesTypeNode', 'stringTypeNode']) &&
                             isNode(structFieldType.type, 'fixedSizeTypeNode') &&
-                            structFieldType.type.size > 32)
+                            structFieldType.type.size > 32
                     ) {
                         derive =
                             '#[cfg_attr(feature = "serde", serde(with = "serde_with::As::<serde_with::Bytes>"))]\n';


### PR DESCRIPTION
resolves #184

`serde(with = "serde_with::As::<serde_with::Bytes>"))` does not work for arrays >32 items but is currently added. This causes a compiler error. Theoretically serde_with's docs state that `serde(with = "serde_with::As::<[_, X]>"))` should work but couldn't get it to compile. I introduced `serde-big-array` to resolve the issues.

Downside of this is that it adds an extra dependency (but only with `serde` feature enabled)