### PR TITLE
Remove redundant pnpm workspace info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
     "name": "codama-monorepo",
     "private": true,
-    "workspaces": [
-        "packages/*"
-    ],
     "scripts": {
         "build": "turbo run build --log-order grouped",
         "lint": "turbo run lint --log-order grouped",


### PR DESCRIPTION
This is set in `pnpm-workspace.yaml`.