### PR TITLE
Setup dependabot on renderers-js e2e dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
       time: '01:00'
       timezone: America/Los_Angeles
     open-pull-requests-limit: 10
+  - package-ecosystem: 'npm'
+    directory: 'packages/renderers-js/e2e'
+    schedule:
+      interval: daily
+      time: '01:00'
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Use dependabot to manage that new e2e workspace for the `renderers-js` package.