### PR TITLE
Update Lamports type from web3.js v2

### DIFF
--- a/.changeset/pretty-walls-hammer.md
+++ b/.changeset/pretty-walls-hammer.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': minor
+---
+
+Update the `Lamports` type to match its latest definition in version `2.0.0` and onwards.

--- a/packages/renderers-js/e2e/system/src/generated/accounts/nonce.ts
+++ b/packages/renderers-js/e2e/system/src/generated/accounts/nonce.ts
@@ -29,7 +29,7 @@ import {
   type Encoder,
   type FetchAccountConfig,
   type FetchAccountsConfig,
-  type LamportsUnsafeBeyond2Pow53Minus1,
+  type Lamports,
   type MaybeAccount,
   type MaybeEncodedAccount,
 } from '@solana/web3.js';
@@ -49,7 +49,7 @@ export type Nonce = {
   state: NonceState;
   authority: Address;
   blockhash: Address;
-  lamportsPerSignature: LamportsUnsafeBeyond2Pow53Minus1;
+  lamportsPerSignature: Lamports;
 };
 
 export type NonceArgs = {
@@ -57,7 +57,7 @@ export type NonceArgs = {
   state: NonceStateArgs;
   authority: Address;
   blockhash: Address;
-  lamportsPerSignature: LamportsUnsafeBeyond2Pow53Minus1;
+  lamportsPerSignature: Lamports;
 };
 
 export function getNonceEncoder(): Encoder<NonceArgs> {

--- a/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
@@ -29,7 +29,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
-  type LamportsUnsafeBeyond2Pow53Minus1,
+  type Lamports,
   type TransactionSigner,
   type WritableSignerAccount,
 } from '@solana/web3.js';
@@ -69,13 +69,13 @@ export type CreateAccountInstruction<
 
 export type CreateAccountInstructionData = {
   discriminator: number;
-  lamports: LamportsUnsafeBeyond2Pow53Minus1;
+  lamports: Lamports;
   space: bigint;
   programAddress: Address;
 };
 
 export type CreateAccountInstructionDataArgs = {
-  lamports: LamportsUnsafeBeyond2Pow53Minus1;
+  lamports: Lamports;
   space: number | bigint;
   programAddress: Address;
 };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
@@ -29,7 +29,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
-  type LamportsUnsafeBeyond2Pow53Minus1,
+  type Lamports,
   type TransactionSigner,
   type WritableSignerAccount,
 } from '@solana/web3.js';
@@ -69,13 +69,13 @@ export type CreateAccountInstruction<
 
 export type CreateAccountInstructionData = {
   discriminator: number;
-  lamports: LamportsUnsafeBeyond2Pow53Minus1;
+  lamports: Lamports;
   space: bigint;
   programAddress: Address;
 };
 
 export type CreateAccountInstructionDataArgs = {
-  lamports: LamportsUnsafeBeyond2Pow53Minus1;
+  lamports: Lamports;
   space: number | bigint;
   programAddress: Address;
 };

--- a/packages/renderers-js/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-js/src/getTypeManifestVisitor.ts
@@ -719,11 +719,8 @@ export function getTypeManifestVisitor(input: {
                 visitSolAmountType({ number }, { self }) {
                     const numberManifest = visit(number, self);
 
-                    const lamportsType = 'LamportsUnsafeBeyond2Pow53Minus1';
-                    const lamportsImport = new ImportMap().add(
-                        'solanaRpcTypes',
-                        'type LamportsUnsafeBeyond2Pow53Minus1',
-                    );
+                    const lamportsType = 'Lamports';
+                    const lamportsImport = new ImportMap().add('solanaRpcTypes', 'type Lamports');
 
                     return {
                         ...numberManifest,

--- a/packages/renderers-js/test/types/solAmount.test.ts
+++ b/packages/renderers-js/test/types/solAmount.test.ts
@@ -17,7 +17,7 @@ test('it renders size prefix codecs', async () => {
 
     // Then we expect the following types and codecs to be exported.
     await renderMapContains(renderMap, 'types/myType.ts', [
-        'export type MyType = LamportsUnsafeBeyond2Pow53Minus1',
+        'export type MyType = Lamports',
         'export type MyTypeArgs = MyType',
         'export function getMyTypeEncoder(): Encoder<MyTypeArgs> { return getLamportsEncoder(getU64Encoder()); }',
         'export function getMyTypeDecoder(): Decoder<MyType> { return getLamportsDecoder(getU64Decoder()); }',
@@ -25,12 +25,6 @@ test('it renders size prefix codecs', async () => {
 
     // And we expect the following type and codec imports.
     await renderMapContainsImports(renderMap, 'types/myType.ts', {
-        '@solana/web3.js': [
-            'LamportsUnsafeBeyond2Pow53Minus1',
-            'getLamportsEncoder',
-            'getLamportsDecoder',
-            'getU64Encoder',
-            'getU64Decoder',
-        ],
+        '@solana/web3.js': ['Lamports', 'getLamportsEncoder', 'getLamportsDecoder', 'getU64Encoder', 'getU64Decoder'],
     });
 });


### PR DESCRIPTION
Since we're now using the latest version of web3.js v2 (instead of `rc`), we need to adjust the `Lamports` type.