### PR TITLE
Update web3.js v2 URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ _Note that some features such as rendering CLIs are not yet available. However, 
 
 - **Rendering client code**. Want people to start interacting with your Solana program? You can use special visitors that go through your Codama IDL and generate client code that you can then publish for your end-users. Currently, we have the following renderers available:
 
-    - `@codama/renderers-js`: Renders a JavaScript client compatible with the soon-to-be-released 2.0 line of [`@solana/web3.js`](https://github.com/solana-labs/solana-web3.js).
+    - `@codama/renderers-js`: Renders a JavaScript client compatible with the soon-to-be-released 2.0 line of [`@solana/web3.js`](https://github.com/anza-xyz/solana-web3.js).
     - `@codama/renderers-js-umi`: Renders a JavaScript client compatible with Metaplex’s [Umi](https://github.com/metaplex-foundation/umi) framework.
     - `@codama/renderers-rust`: Renders a Rust client that removes the need for publishing the program crate and offers a better developer experience.
     - _And more to come._

--- a/packages/errors/src/cli/index.ts
+++ b/packages/errors/src/cli/index.ts
@@ -1,6 +1,6 @@
 /**
  * Heavily inspired by @solana/errors.
- * @see https://github.com/solana-labs/solana-web3.js/blob/master/packages/errors
+ * @see https://github.com/anza-xyz/solana-web3.js/blob/main/packages/errors
  */
 
 import chalk from 'chalk';

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -1,6 +1,6 @@
 /**
  * Heavily inspired by @solana/errors.
- * @see https://github.com/solana-labs/solana-web3.js/blob/master/packages/errors
+ * @see https://github.com/anza-xyz/solana-web3.js/blob/main/packages/errors
  *
  * ---
  *

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -1,6 +1,6 @@
 /**
  * Heavily inspired by @solana/errors.
- * @see https://github.com/solana-labs/solana-web3.js/blob/master/packages/errors
+ * @see https://github.com/anza-xyz/solana-web3.js/blob/main/packages/errors
  */
 
 import {

--- a/packages/errors/src/error.ts
+++ b/packages/errors/src/error.ts
@@ -1,6 +1,6 @@
 /**
  * Heavily inspired by @solana/errors.
- * @see https://github.com/solana-labs/solana-web3.js/blob/master/packages/errors
+ * @see https://github.com/anza-xyz/solana-web3.js/blob/main/packages/errors
  */
 
 import { CodamaErrorCode } from './codes';

--- a/packages/errors/src/message-formatter.ts
+++ b/packages/errors/src/message-formatter.ts
@@ -1,6 +1,6 @@
 /**
  * Heavily inspired by @solana/errors.
- * @see https://github.com/solana-labs/solana-web3.js/blob/master/packages/errors
+ * @see https://github.com/anza-xyz/solana-web3.js/blob/main/packages/errors
  */
 
 import { CodamaErrorCode } from './codes';

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -1,6 +1,6 @@
 /**
  * Heavily inspired by @solana/errors.
- * @see https://github.com/solana-labs/solana-web3.js/blob/master/packages/errors
+ * @see https://github.com/anza-xyz/solana-web3.js/blob/main/packages/errors
  */
 
 import {

--- a/packages/errors/src/stack-trace.ts
+++ b/packages/errors/src/stack-trace.ts
@@ -1,6 +1,6 @@
 /**
  * Heavily inspired by @solana/errors.
- * @see https://github.com/solana-labs/solana-web3.js/blob/master/packages/errors
+ * @see https://github.com/anza-xyz/solana-web3.js/blob/main/packages/errors
  */
 
 export function safeCaptureStackTrace(...args: Parameters<typeof Error.captureStackTrace>): void {

--- a/packages/renderers-js/README.md
+++ b/packages/renderers-js/README.md
@@ -7,7 +7,7 @@
 [npm-image]: https://img.shields.io/npm/v/@codama/renderers-js.svg?style=flat&label=%40codama%2Frenderers-js
 [npm-url]: https://www.npmjs.com/package/@codama/renderers-js
 
-This package generates JavaScript clients from your Codama IDLs. The generated clients are compatible with the soon-to-be-released 2.0 line of [`@solana/web3.js`](https://github.com/solana-labs/solana-web3.js).
+This package generates JavaScript clients from your Codama IDLs. The generated clients are compatible with the soon-to-be-released 2.0 line of [`@solana/web3.js`](https://github.com/anza-xyz/solana-web3.js).
 
 ## Installation
 

--- a/packages/visitors-core/src/pipe.ts
+++ b/packages/visitors-core/src/pipe.ts
@@ -1,6 +1,6 @@
 /**
  * Copied from @solana/functional.
- * @see https://github.com/solana-labs/solana-web3.js/blob/master/packages/functional/src/pipe.ts
+ * @see https://github.com/anza-xyz/solana-web3.js/blob/main/packages/functional/src/pipe.ts
  *
  * ---
  *


### PR DESCRIPTION
Update links to web3.js v2 so they point to the new repo.