### PR TITLE
Improve ESM and CJS support when importing modules in CLI

### DIFF
--- a/.changeset/heavy-moles-smell.md
+++ b/.changeset/heavy-moles-smell.md
@@ -1,0 +1,7 @@
+---
+'codama': patch
+'@codama/errors': patch
+'@codama/cli': patch
+---
+
+Improve ESM and CJS support when importing modules in CLI

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
         "@codama/renderers-rust": "workspace:*",
         "@codama/visitors": "workspace:*",
         "@codama/visitors-core": "workspace:*",
-        "chalk": "^5.4.1",
+        "chalk": "^4.1.2",
         "commander": "^13.1.0",
         "prompts": "^2.4.2"
     },

--- a/packages/cli/src/utils/logs.ts
+++ b/packages/cli/src/utils/logs.ts
@@ -16,6 +16,10 @@ export function logError(...args: unknown[]): void {
     console.log(chalk.red('[Error]'), ...args);
 }
 
+export function logDebug(...args: unknown[]): void {
+    console.log(chalk.magenta('[Debug]'), ...args);
+}
+
 export function logBanner(): void {
     console.log(getBanner());
 }

--- a/packages/errors/bin/cli.cjs
+++ b/packages/errors/bin/cli.cjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env -S node
+
+const run = require('../dist/cli.cjs').run;
+
+run(process.argv);

--- a/packages/errors/bin/cli.mjs
+++ b/packages/errors/bin/cli.mjs
@@ -1,7 +1,0 @@
-#!/usr/bin/env -S node
-
-import process from 'node:process';
-
-import { run } from '../dist/cli.mjs';
-
-run(process.argv);

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -55,7 +55,7 @@
     "dependencies": {
         "@codama/node-types": "workspace:*",
         "commander": "^13.1.0",
-        "chalk": "^5.4.1"
+        "chalk": "^4.1.2"
     },
     "license": "MIT",
     "repository": {

--- a/packages/internals/tsup.config.cli.ts
+++ b/packages/internals/tsup.config.cli.ts
@@ -4,10 +4,10 @@ import { getBuildConfig } from './tsup.config.base';
 
 export default defineConfig([
     {
-        ...getBuildConfig({ format: 'esm', platform: 'node' }),
+        ...getBuildConfig({ format: 'cjs', platform: 'node' }),
         entry: { cli: './src/cli/index.ts' },
         outExtension() {
-            return { js: `.mjs` };
+            return { js: `.cjs` };
         },
     },
 ]);

--- a/packages/library/bin/cli.cjs
+++ b/packages/library/bin/cli.cjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env -S node
+
+const run = require('../dist/cli.cjs').run;
+
+run(process.argv);

--- a/packages/library/bin/cli.mjs
+++ b/packages/library/bin/cli.mjs
@@ -1,7 +1,0 @@
-#!/usr/bin/env -S node
-
-import process from 'node:process';
-
-import { run } from '../dist/cli.mjs';
-
-run(process.argv);

--- a/packages/library/src/cli/index.ts
+++ b/packages/library/src/cli/index.ts
@@ -1,4 +1,4 @@
-import { createProgram, logError } from '@codama/cli';
+import { createProgram, logDebug, logError } from '@codama/cli';
 
 const program = createProgram();
 
@@ -7,7 +7,7 @@ export async function run(argv: readonly string[]) {
         await program.parseAsync(argv);
     } catch (err) {
         if (program.opts().debug) {
-            logError(`${(err as { stack: string }).stack}`);
+            logDebug(`${(err as { stack: string }).stack}`);
         }
         logError((err as { message: string }).message);
         process.exitCode = 1;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: workspace:*
         version: link:../visitors-core
       chalk:
-        specifier: ^5.4.1
-        version: 5.4.1
+        specifier: ^4.1.2
+        version: 4.1.2
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -161,8 +161,8 @@ importers:
         specifier: workspace:*
         version: link:../node-types
       chalk:
-        specifier: ^5.4.1
-        version: 5.4.1
+        specifier: ^4.1.2
+        version: 4.1.2
       commander:
         specifier: ^13.1.0
         version: 13.1.0


### PR DESCRIPTION
This PR changes the way we export CLI binaries by using CJS instead of ESM so that dynamically importing modules (e.g. JavaScript config files or visitors) works for both CJS and ESM modules.

It also improves the error handling when failing to import a module.