### PR TITLE
renderers-rust: Use `borsh::to_vec`

### DIFF
--- a/.changeset/nasty-dots-lie.md
+++ b/.changeset/nasty-dots-lie.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-rust': patch
+---
+
+Use borsh::to_vec in rust renderer

--- a/packages/renderers-rust/e2e/anchor/src/generated/instructions/create_guard.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/instructions/create_guard.rs
@@ -75,8 +75,8 @@ impl CreateGuard {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = CreateGuardInstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&CreateGuardInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -429,8 +429,8 @@ impl<'a, 'b> CreateGuardCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = CreateGuardInstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&CreateGuardInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/anchor/src/generated/instructions/execute.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/instructions/execute.rs
@@ -67,8 +67,8 @@ impl Execute {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = ExecuteInstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&ExecuteInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -352,8 +352,8 @@ impl<'a, 'b> ExecuteCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = ExecuteInstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&ExecuteInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/anchor/src/generated/instructions/initialize.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/instructions/initialize.rs
@@ -56,7 +56,7 @@ impl Initialize {
             self.payer, true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let data = InitializeInstructionData::new().try_to_vec().unwrap();
+        let data = borsh::to_vec(&InitializeInstructionData::new()).unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::WEN_TRANSFER_GUARD_ID,
@@ -300,7 +300,7 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = InitializeInstructionData::new().try_to_vec().unwrap();
+        let data = borsh::to_vec(&InitializeInstructionData::new()).unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::WEN_TRANSFER_GUARD_ID,

--- a/packages/renderers-rust/e2e/anchor/src/generated/instructions/update_guard.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/instructions/update_guard.rs
@@ -64,8 +64,8 @@ impl UpdateGuard {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = UpdateGuardInstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&UpdateGuardInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -349,8 +349,8 @@ impl<'a, 'b> UpdateGuardCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = UpdateGuardInstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&UpdateGuardInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction1.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction1.rs
@@ -23,7 +23,7 @@ impl Instruction1 {
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(remaining_accounts.len());
         accounts.extend_from_slice(remaining_accounts);
-        let data = Instruction1InstructionData::new().try_to_vec().unwrap();
+        let data = borsh::to_vec(&Instruction1InstructionData::new()).unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::DUMMY_ID,
@@ -139,7 +139,7 @@ impl<'a, 'b> Instruction1Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = Instruction1InstructionData::new().try_to_vec().unwrap();
+        let data = borsh::to_vec(&Instruction1InstructionData::new()).unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::DUMMY_ID,

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction2.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction2.rs
@@ -23,7 +23,7 @@ impl Instruction2 {
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(remaining_accounts.len());
         accounts.extend_from_slice(remaining_accounts);
-        let data = Instruction2InstructionData::new().try_to_vec().unwrap();
+        let data = borsh::to_vec(&Instruction2InstructionData::new()).unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::DUMMY_ID,
@@ -139,7 +139,7 @@ impl<'a, 'b> Instruction2Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = Instruction2InstructionData::new().try_to_vec().unwrap();
+        let data = borsh::to_vec(&Instruction2InstructionData::new()).unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::DUMMY_ID,

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction3.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction3.rs
@@ -23,7 +23,7 @@ impl Instruction3 {
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(remaining_accounts.len());
         accounts.extend_from_slice(remaining_accounts);
-        let data = Instruction3InstructionData::new().try_to_vec().unwrap();
+        let data = borsh::to_vec(&Instruction3InstructionData::new()).unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::DUMMY_ID,
@@ -141,7 +141,7 @@ impl<'a, 'b> Instruction3Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = Instruction3InstructionData::new().try_to_vec().unwrap();
+        let data = borsh::to_vec(&Instruction3InstructionData::new()).unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::DUMMY_ID,

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction4.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction4.rs
@@ -27,8 +27,8 @@ impl Instruction4 {
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(remaining_accounts.len());
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = Instruction4InstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&Instruction4InstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -168,8 +168,8 @@ impl<'a, 'b> Instruction4Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = Instruction4InstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&Instruction4InstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction5.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction5.rs
@@ -27,8 +27,8 @@ impl Instruction5 {
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(remaining_accounts.len());
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = Instruction5InstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&Instruction5InstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -169,8 +169,8 @@ impl<'a, 'b> Instruction5Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = Instruction5InstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&Instruction5InstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction6.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction6.rs
@@ -29,7 +29,7 @@ impl Instruction6 {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let data = Instruction6InstructionData::new().try_to_vec().unwrap();
+        let data = borsh::to_vec(&Instruction6InstructionData::new()).unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::DUMMY_ID,
@@ -171,7 +171,7 @@ impl<'a, 'b> Instruction6Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = Instruction6InstructionData::new().try_to_vec().unwrap();
+        let data = borsh::to_vec(&Instruction6InstructionData::new()).unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::DUMMY_ID,

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction7.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction7.rs
@@ -35,7 +35,7 @@ impl Instruction7 {
             ));
         }
         accounts.extend_from_slice(remaining_accounts);
-        let data = Instruction7InstructionData::new().try_to_vec().unwrap();
+        let data = borsh::to_vec(&Instruction7InstructionData::new()).unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::DUMMY_ID,
@@ -185,7 +185,7 @@ impl<'a, 'b> Instruction7Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = Instruction7InstructionData::new().try_to_vec().unwrap();
+        let data = borsh::to_vec(&Instruction7InstructionData::new()).unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::DUMMY_ID,

--- a/packages/renderers-rust/e2e/memo/src/generated/instructions/add_memo.rs
+++ b/packages/renderers-rust/e2e/memo/src/generated/instructions/add_memo.rs
@@ -28,8 +28,8 @@ impl AddMemo {
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(remaining_accounts.len());
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = AddMemoInstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&AddMemoInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -169,8 +169,8 @@ impl<'a, 'b> AddMemoCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = AddMemoInstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&AddMemoInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/advance_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/advance_nonce_account.rs
@@ -41,9 +41,7 @@ impl AdvanceNonceAccount {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let data = AdvanceNonceAccountInstructionData::new()
-            .try_to_vec()
-            .unwrap();
+        let data = borsh::to_vec(&AdvanceNonceAccountInstructionData::new()).unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::SYSTEM_ID,
@@ -230,9 +228,7 @@ impl<'a, 'b> AdvanceNonceAccountCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = AdvanceNonceAccountInstructionData::new()
-            .try_to_vec()
-            .unwrap();
+        let data = borsh::to_vec(&AdvanceNonceAccountInstructionData::new()).unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::SYSTEM_ID,

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/allocate.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/allocate.rs
@@ -33,8 +33,8 @@ impl Allocate {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = AllocateInstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&AllocateInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -198,8 +198,8 @@ impl<'a, 'b> AllocateCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = AllocateInstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&AllocateInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/allocate_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/allocate_with_seed.rs
@@ -40,8 +40,8 @@ impl AllocateWithSeed {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = AllocateWithSeedInstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&AllocateWithSeedInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -249,8 +249,8 @@ impl<'a, 'b> AllocateWithSeedCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = AllocateWithSeedInstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&AllocateWithSeedInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/assign.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/assign.rs
@@ -34,8 +34,8 @@ impl Assign {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = AssignInstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&AssignInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -202,8 +202,8 @@ impl<'a, 'b> AssignCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = AssignInstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&AssignInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/assign_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/assign_with_seed.rs
@@ -40,8 +40,8 @@ impl AssignWithSeed {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = AssignWithSeedInstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&AssignWithSeedInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -241,8 +241,8 @@ impl<'a, 'b> AssignWithSeedCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = AssignWithSeedInstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&AssignWithSeedInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/authorize_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/authorize_nonce_account.rs
@@ -40,10 +40,8 @@ impl AuthorizeNonceAccount {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = AuthorizeNonceAccountInstructionData::new()
-            .try_to_vec()
-            .unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&AuthorizeNonceAccountInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -230,10 +228,8 @@ impl<'a, 'b> AuthorizeNonceAccountCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = AuthorizeNonceAccountInstructionData::new()
-            .try_to_vec()
-            .unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&AuthorizeNonceAccountInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/create_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/create_account.rs
@@ -39,8 +39,8 @@ impl CreateAccount {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = CreateAccountInstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&CreateAccountInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -240,8 +240,8 @@ impl<'a, 'b> CreateAccountCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = CreateAccountInstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&CreateAccountInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/create_account_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/create_account_with_seed.rs
@@ -45,10 +45,8 @@ impl CreateAccountWithSeed {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = CreateAccountWithSeedInstructionData::new()
-            .try_to_vec()
-            .unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&CreateAccountWithSeedInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -281,10 +279,8 @@ impl<'a, 'b> CreateAccountWithSeedCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = CreateAccountWithSeedInstructionData::new()
-            .try_to_vec()
-            .unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&CreateAccountWithSeedInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/initialize_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/initialize_nonce_account.rs
@@ -46,10 +46,8 @@ impl InitializeNonceAccount {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = InitializeNonceAccountInstructionData::new()
-            .try_to_vec()
-            .unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&InitializeNonceAccountInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -259,10 +257,8 @@ impl<'a, 'b> InitializeNonceAccountCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = InitializeNonceAccountInstructionData::new()
-            .try_to_vec()
-            .unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&InitializeNonceAccountInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol.rs
@@ -39,8 +39,8 @@ impl TransferSol {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = TransferSolInstructionData::new().try_to_vec().unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&TransferSolInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -221,8 +221,8 @@ impl<'a, 'b> TransferSolCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = TransferSolInstructionData::new().try_to_vec().unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&TransferSolInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol_with_seed.rs
@@ -46,10 +46,8 @@ impl TransferSolWithSeed {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = TransferSolWithSeedInstructionData::new()
-            .try_to_vec()
-            .unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&TransferSolWithSeedInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -263,10 +261,8 @@ impl<'a, 'b> TransferSolWithSeedCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = TransferSolWithSeedInstructionData::new()
-            .try_to_vec()
-            .unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&TransferSolWithSeedInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/upgrade_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/upgrade_nonce_account.rs
@@ -29,9 +29,7 @@ impl UpgradeNonceAccount {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let data = UpgradeNonceAccountInstructionData::new()
-            .try_to_vec()
-            .unwrap();
+        let data = borsh::to_vec(&UpgradeNonceAccountInstructionData::new()).unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::SYSTEM_ID,
@@ -175,9 +173,7 @@ impl<'a, 'b> UpgradeNonceAccountCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = UpgradeNonceAccountInstructionData::new()
-            .try_to_vec()
-            .unwrap();
+        let data = borsh::to_vec(&UpgradeNonceAccountInstructionData::new()).unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::SYSTEM_ID,

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/withdraw_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/withdraw_nonce_account.rs
@@ -57,10 +57,8 @@ impl WithdrawNonceAccount {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = WithdrawNonceAccountInstructionData::new()
-            .try_to_vec()
-            .unwrap();
-        let mut args = args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&WithdrawNonceAccountInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
         solana_program::instruction::Instruction {
@@ -312,10 +310,8 @@ impl<'a, 'b> WithdrawNonceAccountCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = WithdrawNonceAccountInstructionData::new()
-            .try_to_vec()
-            .unwrap();
-        let mut args = self.__args.try_to_vec().unwrap();
+        let mut data = borsh::to_vec(&WithdrawNonceAccountInstructionData::new()).unwrap();
+        let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {

--- a/packages/renderers-rust/public/templates/instructionsCpiPage.njk
+++ b/packages/renderers-rust/public/templates/instructionsCpiPage.njk
@@ -150,9 +150,9 @@ impl<'a, 'b> {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
           is_writable: remaining_account.2,
       })
     });
-    let {{ 'mut ' if hasArgs }}data = {{ instruction.name | pascalCase }}InstructionData::new().try_to_vec().unwrap();
+    let {{ 'mut ' if hasArgs }}data = borsh::to_vec(&{{ instruction.name | pascalCase }}InstructionData::new()).unwrap();
     {% if hasArgs %}
-      let mut args = self.__args.try_to_vec().unwrap();
+      let mut args = borsh::to_vec(&self.__args).unwrap();
       data.append(&mut args);
     {% endif %}
 

--- a/packages/renderers-rust/public/templates/instructionsPage.njk
+++ b/packages/renderers-rust/public/templates/instructionsPage.njk
@@ -94,9 +94,9 @@ impl {{ instruction.name | pascalCase }} {
       {% endif %}
     {% endfor %}
     accounts.extend_from_slice(remaining_accounts);
-    let {{ 'mut ' if hasArgs }}data = {{ instruction.name | pascalCase }}InstructionData::new().try_to_vec().unwrap();
+    let {{ 'mut ' if hasArgs }}data = borsh::to_vec(&{{ instruction.name | pascalCase }}InstructionData::new()).unwrap();
     {% if hasArgs %}
-      let mut args = args.try_to_vec().unwrap();
+      let mut args = borsh::to_vec(&args).unwrap();
       data.append(&mut args);
     {% endif %}
 


### PR DESCRIPTION
### Problem

As described in #207 , `try_to_vec` was removed from `borsh` in versions `1.x`. This causes problems since the rust renderer generates code using it.

### Solution

Replace the use of `try_to_vec` by `borsh::to_vec`, which is available in versions of `borsh` < `1`.

Fixes #207 