### PR TITLE
fix: allow empty structs in v1 anchor to be parsed

### DIFF
--- a/.changeset/fuzzy-nails-wait.md
+++ b/.changeset/fuzzy-nails-wait.md
@@ -1,0 +1,5 @@
+---
+'@codama/nodes-from-anchor': patch
+---
+
+recognize unit structs types from anchor

--- a/packages/nodes-from-anchor/src/v01/typeNodes/TypeNode.ts
+++ b/packages/nodes-from-anchor/src/v01/typeNodes/TypeNode.ts
@@ -92,7 +92,7 @@ export const typeNodeFromAnchorV01 = (idlType: IdlV01Type | IdlV01TypeDefTy): Ty
     }
 
     // Struct and Tuple.
-    if ('kind' in idlType && idlType.kind === 'struct' && 'fields' in idlType) {
+    if ('kind' in idlType && idlType.kind === 'struct') {
         const fields = idlType.fields ?? [];
         if (isStructFieldArray(fields)) {
             return structTypeNodeFromAnchorV01(idlType);


### PR DESCRIPTION
Anchor will skip serializing the `fields` field in v1 structs if there are no fields. This change allows Codama to recognize those types as struct types. The logic to default the fields is already in place, so this just allows it to be used.