### PR TITLE
Rust Renderer: `fetch` Fixes

### DIFF
--- a/.changeset/short-showers-shout.md
+++ b/.changeset/short-showers-shout.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-rust': patch
+---
+
+Patch a few compile errors in the account `fetch` API.

--- a/packages/renderers-rust/e2e/anchor/src/generated/accounts/guard_v1.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/accounts/guard_v1.rs
@@ -54,7 +54,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for GuardV1 {
 #[cfg(feature = "fetch")]
 pub fn fetch_guard_v1(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &Pubkey,
+    address: &solana_program::pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<GuardV1>, std::io::Error> {
     let accounts = fetch_all_guard_v1(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -63,7 +63,7 @@ pub fn fetch_guard_v1(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_guard_v1(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[Pubkey],
+    addresses: &[solana_program::pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<GuardV1>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(&addresses)
@@ -88,7 +88,7 @@ pub fn fetch_all_guard_v1(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_guard_v1(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &Pubkey,
+    address: &solana_program::pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<GuardV1>, std::io::Error> {
     let accounts = fetch_all_maybe_guard_v1(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -97,7 +97,7 @@ pub fn fetch_maybe_guard_v1(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_guard_v1(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[Pubkey],
+    addresses: &[solana_program::pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<GuardV1>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(&addresses)

--- a/packages/renderers-rust/e2e/anchor/src/generated/accounts/guard_v1.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/accounts/guard_v1.rs
@@ -66,7 +66,7 @@ pub fn fetch_all_guard_v1(
     addresses: &[solana_program::pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<GuardV1>>, std::io::Error> {
     let accounts = rpc
-        .get_multiple_accounts(&addresses)
+        .get_multiple_accounts(addresses)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
     let mut decoded_accounts: Vec<crate::shared::DecodedAccount<GuardV1>> = Vec::new();
     for i in 0..addresses.len() {
@@ -100,7 +100,7 @@ pub fn fetch_all_maybe_guard_v1(
     addresses: &[solana_program::pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<GuardV1>>, std::io::Error> {
     let accounts = rpc
-        .get_multiple_accounts(&addresses)
+        .get_multiple_accounts(addresses)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
     let mut decoded_accounts: Vec<crate::shared::MaybeAccount<GuardV1>> = Vec::new();
     for i in 0..addresses.len() {

--- a/packages/renderers-rust/e2e/system/src/generated/accounts/nonce.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/accounts/nonce.rs
@@ -53,7 +53,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Nonce {
 #[cfg(feature = "fetch")]
 pub fn fetch_nonce(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &Pubkey,
+    address: &solana_program::pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<Nonce>, std::io::Error> {
     let accounts = fetch_all_nonce(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -62,7 +62,7 @@ pub fn fetch_nonce(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_nonce(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[Pubkey],
+    addresses: &[solana_program::pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<Nonce>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(&addresses)
@@ -87,7 +87,7 @@ pub fn fetch_all_nonce(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_nonce(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &Pubkey,
+    address: &solana_program::pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<Nonce>, std::io::Error> {
     let accounts = fetch_all_maybe_nonce(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -96,7 +96,7 @@ pub fn fetch_maybe_nonce(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_nonce(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[Pubkey],
+    addresses: &[solana_program::pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<Nonce>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(&addresses)

--- a/packages/renderers-rust/e2e/system/src/generated/accounts/nonce.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/accounts/nonce.rs
@@ -65,7 +65,7 @@ pub fn fetch_all_nonce(
     addresses: &[solana_program::pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<Nonce>>, std::io::Error> {
     let accounts = rpc
-        .get_multiple_accounts(&addresses)
+        .get_multiple_accounts(addresses)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
     let mut decoded_accounts: Vec<crate::shared::DecodedAccount<Nonce>> = Vec::new();
     for i in 0..addresses.len() {
@@ -99,7 +99,7 @@ pub fn fetch_all_maybe_nonce(
     addresses: &[solana_program::pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<Nonce>>, std::io::Error> {
     let accounts = rpc
-        .get_multiple_accounts(&addresses)
+        .get_multiple_accounts(addresses)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
     let mut decoded_accounts: Vec<crate::shared::MaybeAccount<Nonce>> = Vec::new();
     for i in 0..addresses.len() {

--- a/packages/renderers-rust/public/templates/accountsPage.njk
+++ b/packages/renderers-rust/public/templates/accountsPage.njk
@@ -142,7 +142,7 @@ pub fn fetch_all_{{ account.name | snakeCase }}(
   rpc: &solana_client::rpc_client::RpcClient,
   addresses: &[solana_program::pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<{{ account.name | pascalCase }}>>, std::io::Error> {
-    let accounts = rpc.get_multiple_accounts(&addresses)
+    let accounts = rpc.get_multiple_accounts(addresses)
       .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
     let mut decoded_accounts: Vec<crate::shared::DecodedAccount<{{ account.name | pascalCase }}>> = Vec::new();
     for i in 0..addresses.len() {
@@ -169,7 +169,7 @@ pub fn fetch_all_maybe_{{ account.name | snakeCase }}(
   rpc: &solana_client::rpc_client::RpcClient,
   addresses: &[solana_program::pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<{{ account.name | pascalCase }}>>, std::io::Error> {
-    let accounts = rpc.get_multiple_accounts(&addresses)
+    let accounts = rpc.get_multiple_accounts(addresses)
       .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
     let mut decoded_accounts: Vec<crate::shared::MaybeAccount<{{ account.name | pascalCase }}>> = Vec::new();
     for i in 0..addresses.len() {

--- a/packages/renderers-rust/public/templates/accountsPage.njk
+++ b/packages/renderers-rust/public/templates/accountsPage.njk
@@ -131,7 +131,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for {{ account.
 #[cfg(feature = "fetch")]
 pub fn fetch_{{ account.name | snakeCase }}(
   rpc: &solana_client::rpc_client::RpcClient,
-  address: &Pubkey,
+  address: &solana_program::pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<{{ account.name | pascalCase }}>, std::io::Error> {
   let accounts = fetch_all_{{ account.name | snakeCase }}(rpc, &[*address])?;
   Ok(accounts[0].clone())
@@ -140,7 +140,7 @@ pub fn fetch_{{ account.name | snakeCase }}(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_{{ account.name | snakeCase }}(
   rpc: &solana_client::rpc_client::RpcClient,
-  addresses: &[Pubkey],
+  addresses: &[solana_program::pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<{{ account.name | pascalCase }}>>, std::io::Error> {
     let accounts = rpc.get_multiple_accounts(&addresses)
       .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
@@ -158,7 +158,7 @@ pub fn fetch_all_{{ account.name | snakeCase }}(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_{{ account.name | snakeCase }}(
   rpc: &solana_client::rpc_client::RpcClient,
-  address: &Pubkey,
+  address: &solana_program::pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<{{ account.name | pascalCase }}>, std::io::Error> {
     let accounts = fetch_all_maybe_{{ account.name | snakeCase }}(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -167,7 +167,7 @@ pub fn fetch_maybe_{{ account.name | snakeCase }}(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_{{ account.name | snakeCase }}(
   rpc: &solana_client::rpc_client::RpcClient,
-  addresses: &[Pubkey],
+  addresses: &[solana_program::pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<{{ account.name | pascalCase }}>>, std::io::Error> {
     let accounts = rpc.get_multiple_accounts(&addresses)
       .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;


### PR DESCRIPTION
Fixes a few compiler errors from the `fetch` API for account state, produced by the Rust Renderer.

* If `Pubkey` is not imported in the base module, it's not available to the `fetch` feature either. Like other account state methods, use the full path qualifier.
* Fix a few clippy nits about unnecessary borrows.