### PR TITLE
fix anchor00_alias

### DIFF
--- a/.changeset/sharp-pens-buy.md
+++ b/.changeset/sharp-pens-buy.md
@@ -1,0 +1,5 @@
+---
+"@codama/nodes-from-anchor": patch
+---
+
+Add support for Anchor alias types

--- a/packages/nodes-from-anchor/src/v00/typeNodes/TypeNode.ts
+++ b/packages/nodes-from-anchor/src/v00/typeNodes/TypeNode.ts
@@ -75,7 +75,8 @@ export const typeNodeFromAnchorV00 = (idlType: IdlV00Type | IdlV00TypeDefTy): Ty
     if ('kind' in idlType && idlType.kind === 'enum' && 'variants' in idlType) {
         return enumTypeNodeFromAnchorV00(idlType);
     }
-    //alias
+
+    // Alias.
     if ('kind' in idlType && idlType.kind === 'alias' && 'value' in idlType) {
         return typeNodeFromAnchorV00(idlType.value);
     }

--- a/packages/nodes-from-anchor/src/v00/typeNodes/TypeNode.ts
+++ b/packages/nodes-from-anchor/src/v00/typeNodes/TypeNode.ts
@@ -75,6 +75,10 @@ export const typeNodeFromAnchorV00 = (idlType: IdlV00Type | IdlV00TypeDefTy): Ty
     if ('kind' in idlType && idlType.kind === 'enum' && 'variants' in idlType) {
         return enumTypeNodeFromAnchorV00(idlType);
     }
+    //alias
+    if ('kind' in idlType && idlType.kind === 'alias' && 'value' in idlType) {
+        return typeNodeFromAnchorV00(idlType.value);
+    }
 
     // Map.
     if (

--- a/packages/nodes-from-anchor/src/v01/idl.ts
+++ b/packages/nodes-from-anchor/src/v01/idl.ts
@@ -154,7 +154,7 @@ export type IdlV01TypeDefGenericConst = {
     type: string;
 };
 
-export type IdlV01TypeDefTy = IdlV01TypeDefTyEnum |IdlV01TypeDefTyAlias| IdlV01TypeDefTyStruct | IdlV01TypeDefTyType;
+export type IdlV01TypeDefTy = IdlV01TypeDefTyEnum | IdlV01TypeDefTyAlias | IdlV01TypeDefTyStruct | IdlV01TypeDefTyType;
 
 export type IdlV01TypeDefTyStruct = {
     fields?: IdlV01DefinedFields;

--- a/packages/nodes-from-anchor/src/v01/idl.ts
+++ b/packages/nodes-from-anchor/src/v01/idl.ts
@@ -154,7 +154,7 @@ export type IdlV01TypeDefGenericConst = {
     type: string;
 };
 
-export type IdlV01TypeDefTy = IdlV01TypeDefTyEnum | IdlV01TypeDefTyStruct | IdlV01TypeDefTyType;
+export type IdlV01TypeDefTy = IdlV01TypeDefTyEnum |IdlV01TypeDefTyAlias| IdlV01TypeDefTyStruct | IdlV01TypeDefTyType;
 
 export type IdlV01TypeDefTyStruct = {
     fields?: IdlV01DefinedFields;
@@ -164,6 +164,10 @@ export type IdlV01TypeDefTyStruct = {
 export type IdlV01TypeDefTyEnum = {
     kind: 'enum';
     variants: IdlV01EnumVariant[];
+};
+export type IdlV01TypeDefTyAlias = {
+    kind: 'alias';
+    value: IdlV01Type;
 };
 
 export type IdlV01TypeDefTyType = {

--- a/packages/nodes-from-anchor/src/v01/idl.ts
+++ b/packages/nodes-from-anchor/src/v01/idl.ts
@@ -165,6 +165,7 @@ export type IdlV01TypeDefTyEnum = {
     kind: 'enum';
     variants: IdlV01EnumVariant[];
 };
+
 export type IdlV01TypeDefTyAlias = {
     kind: 'alias';
     value: IdlV01Type;

--- a/packages/nodes-from-anchor/src/v01/idl.ts
+++ b/packages/nodes-from-anchor/src/v01/idl.ts
@@ -154,7 +154,7 @@ export type IdlV01TypeDefGenericConst = {
     type: string;
 };
 
-export type IdlV01TypeDefTy = IdlV01TypeDefTyEnum | IdlV01TypeDefTyAlias | IdlV01TypeDefTyStruct | IdlV01TypeDefTyType;
+export type IdlV01TypeDefTy = IdlV01TypeDefTyAlias | IdlV01TypeDefTyEnum | IdlV01TypeDefTyStruct | IdlV01TypeDefTyType;
 
 export type IdlV01TypeDefTyStruct = {
     fields?: IdlV01DefinedFields;

--- a/packages/nodes-from-anchor/src/v01/typeNodes/TypeNode.ts
+++ b/packages/nodes-from-anchor/src/v01/typeNodes/TypeNode.ts
@@ -81,6 +81,10 @@ export const typeNodeFromAnchorV01 = (idlType: IdlV01Type | IdlV01TypeDefTy): Ty
     if ('kind' in idlType && idlType.kind === 'enum' && 'variants' in idlType) {
         return enumTypeNodeFromAnchorV01(idlType);
     }
+    //alias
+    if ('kind' in idlType && idlType.kind === 'alias' && 'value' in idlType) {
+        return typeNodeFromAnchorV01(idlType.value);
+    }
 
     // Option.
     if ('option' in idlType) {

--- a/packages/nodes-from-anchor/src/v01/typeNodes/TypeNode.ts
+++ b/packages/nodes-from-anchor/src/v01/typeNodes/TypeNode.ts
@@ -81,7 +81,8 @@ export const typeNodeFromAnchorV01 = (idlType: IdlV01Type | IdlV01TypeDefTy): Ty
     if ('kind' in idlType && idlType.kind === 'enum' && 'variants' in idlType) {
         return enumTypeNodeFromAnchorV01(idlType);
     }
-    //alias
+
+    // Alias.
     if ('kind' in idlType && idlType.kind === 'alias' && 'value' in idlType) {
         return typeNodeFromAnchorV01(idlType.value);
     }


### PR DESCRIPTION
I was using the latest version of Ray AMM（CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK） and found that it was not parsing this IDL correctly. The error is as follows:
```
/Users/ttt/code/jsrc/c001/node_modules/.pnpm/@codama+nodes-from-anchor@1.1.11_fastestsmallesttextencoderdecoder@1.0.22_typescript@5.8.3/node_modules/@codama/nodes-from-anchor/src/v00/typeNodes/TypeNode.ts:107
    throw new CodamaError(CODAMA_ERROR__ANCHOR__UNRECOGNIZED_IDL_TYPE, {
          ^

CodamaError: Unrecognized Anchor IDL type [{"kind":"alias","value":{"array":["u64",8]}}].
    at typeNodeFromAnchorV00 (/Users/ttt/code/jsrc/c001/node_modules/.pnpm/@codama+nodes-from-anchor@1.1.11_fastestsmallesttextencoderdecoder@1.0.22_typescript@5.8.3/node_modules/@codama/nodes-from-anchor/src/v00/typeNodes/TypeNode.ts:107:11)
    at definedTypeNodeFromAnchorV00 (/Users/ttt/code/jsrc/c001/node_modules/.pnpm/@codama+nodes-from-anchor@1.1.11_fastestsmallesttextencoderdecoder@1.0.22_typescript@5.8.3/node_modules/@codama/nodes-from-anchor/src/v00/DefinedTypeNode.ts:9:18)
    at Array.map (<anonymous>)
    at programNodeFromAnchorV00 (/Users/ttt/code/jsrc/c001/node_modules/.pnpm/@codama+nodes-from-anchor@1.1.11_fastestsmallesttextencoderdecoder@1.0.22_typescript@5.8.3/node_modules/@codama/nodes-from-anchor/src/v00/ProgramNode.ts:17:42)
    at rootNodeFromAnchorV00 (/Users/ttt/code/jsrc/c001/node_modules/.pnpm/@codama+nodes-from-anchor@1.1.11_fastestsmallesttextencoderdecoder@1.0.22_typescript@5.8.3/node_modules/@codama/nodes-from-anchor/src/v00/RootNode.ts:7:25)
    at rootNodeFromAnchorWithoutDefaultVisitor (/Users/ttt/code/jsrc/c001/node_modules/.pnpm/@codama+nodes-from-anchor@1.1.11_fastestsmallesttextencoderdecoder@1.0.22_typescript@5.8.3/node_modules/@codama/nodes-from-anchor/src/index.ts:23:12)
    at rootNodeFromAnchor (/Users/ttt/code/jsrc/c001/node_modules/.pnpm/@codama+nodes-from-anchor@1.1.11_fastestsmallesttextencoderdecoder@1.0.22_typescript@5.8.3/node_modules/@codama/nodes-from-anchor/src/index.ts:15:18)
    at anchorIdl (/Users/ttt/code/jsrc/c001/app.ts:11:18)
    at Object.<anonymous> (/Users/ttt/code/jsrc/c001/app.ts:15:60)
    at Module._compile (node:internal/modules/cjs/loader:1554:14) {
  context: {
    __code: 2100000,
    idlType: '{"kind":"alias","value":{"array":["u64",8]}}'
  }
```
Then, I fixed the issue in packages/nodes-from-anchor/src/v00/typeNodes/TypeNode.ts by adding support for the alias type in typeNodeFromAnchorV00:
```
// alias
if ('kind' in idlType && idlType.kind === 'alias' && 'value' in idlType) {
    return typeNodeFromAnchorV00(idlType.value);
}
```
