### PR TITLE
add gill support to the cli `init` command

### DIFF
--- a/.changeset/busy-pots-cough.md
+++ b/.changeset/busy-pots-cough.md
@@ -1,0 +1,5 @@
+---
+'@codama/cli': minor
+---
+
+add the `--gill` flag to the CLI allowing easy generation of gill based config files

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,6 +20,12 @@ pnpm codama init
 
 You will be prompted for the path of your IDL and asked to select any script presets you would like to use.
 
+To initialize a [gill based Codama](https://gill.site/docs/guides/codama) configuration file, run the `init` command with the `--gill` flag like so:
+
+```sh
+pnpm codama init --gill
+```
+
 ## `codama run`
 
 Once you have your codama config file, you can run your Codama scripts using the `codama run` command as follows:


### PR DESCRIPTION
added the ability for the codama cli to initialize a gill based codama config file using the `createCodamaConfig` function in gill. see gill docs here: https://gill.site/docs/guides/codama#create-a-codama-config