### PR TITLE
refactor(renderers-vixen-parser): replace `solana-program` with more granular crates

### DIFF
--- a/.changeset/eleven-radios-obey.md
+++ b/.changeset/eleven-radios-obey.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-vixen-parser': minor
+---
+
+use granular solana-\* crates

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/Cargo.lock
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/Cargo.lock
@@ -45,18 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,12 +162,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -198,29 +180,6 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-
-[[package]]
-name = "blake3"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -315,33 +274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "bv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8834bb1d8ee5dc048ee3124f2c7c1afcc6bc9aed03f11e9dfd8c69470a5db340"
-dependencies = [
- "feature-probe",
- "serde",
-]
-
-[[package]]
-name = "bytemuck"
-version = "1.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,32 +303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "console_log"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89f72f65e8501878b8a004d5a1afb780987e2ce2b4532c562e367a72c57499f"
-dependencies = [
- "log",
- "web-sys",
-]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,12 +319,6 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -439,9 +339,9 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
- "rand_core 0.6.4",
+ "rand_core",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -460,22 +360,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -505,12 +395,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "feature-probe"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "fiat-crypto"
@@ -602,17 +486,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -854,71 +727,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "libsecp256k1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
-dependencies = [
- "arrayref",
- "base64 0.12.3",
- "digest 0.9.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
-dependencies = [
- "libsecp256k1-core",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -955,15 +767,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,16 +799,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,15 +807,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1048,12 +832,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "parking_lot"
@@ -1256,36 +1034,13 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1295,16 +1050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1314,15 +1060,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1419,15 +1156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,36 +1168,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest 0.10.7",
- "keccak",
+ "digest",
 ]
 
 [[package]]
@@ -1504,46 +1209,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-account"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f949fe4edaeaea78c844023bfc1c898e0b1f5a100f8a8d2d0f85d0a7b090258"
-dependencies = [
- "solana-account-info",
- "solana-clock",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
 name = "solana-account-info"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c17d606a298a205fae325489fbed88ee6dc4463c111672172327e741c8905d"
 dependencies = [
- "bincode",
- "serde",
  "solana-program-error",
  "solana-program-memory",
  "solana-pubkey",
-]
-
-[[package]]
-name = "solana-address-lookup-table-interface"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1673f67efe870b64a65cb39e6194be5b26527691ce5922909939961a6e6b395"
-dependencies = [
- "bincode",
- "bytemuck",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-slot-hashes",
 ]
 
 [[package]]
@@ -1553,63 +1226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52e52720efe60465b052b9e7445a01c17550666beec855cce66f44766697bc2"
 dependencies = [
  "parking_lot",
-]
-
-[[package]]
-name = "solana-big-mod-exp"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db7f2bbac3e62cfd139065d15bcda9e2428883ba61fc8d27ccb251081e7567"
-dependencies = [
- "num-bigint",
- "num-traits",
- "solana-define-syscall",
-]
-
-[[package]]
-name = "solana-bincode"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a3787b8cf9c9fe3dd360800e8b70982b9e5a8af9e11c354b6665dd4a003adc"
-dependencies = [
- "bincode",
- "serde",
- "solana-instruction",
-]
-
-[[package]]
-name = "solana-blake3-hasher"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0801e25a1b31a14494fc80882a036be0ffd290efc4c2d640bfcca120a4672"
-dependencies = [
- "blake3",
- "solana-define-syscall",
- "solana-hash",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-borsh"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718333bcd0a1a7aed6655aa66bef8d7fb047944922b2d3a18f49cbc13e73d004"
-dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.7",
-]
-
-[[package]]
-name = "solana-clock"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c2177a1b9fe8326004f1151a5acd124420b737811080b1035df31349e4d892"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
 ]
 
 [[package]]
@@ -1642,96 +1258,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf784bb2cb3e02cac9801813c30187344228d2ae952534902108f6150573a33d"
 
 [[package]]
-name = "solana-epoch-rewards"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b575d3dd323b9ea10bb6fe89bf6bf93e249b215ba8ed7f68f1a3633f384db7"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-hash",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-epoch-schedule"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce071fbddecc55d727b1d7ed16a629afe4f6e4c217bc8d00af3b785f6f67ed"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-example-mocks"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84461d56cbb8bb8d539347151e0525b53910102e4bced875d49d5139708e39d3"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-address-lookup-table-interface",
- "solana-clock",
- "solana-hash",
- "solana-instruction",
- "solana-keccak-hasher",
- "solana-message",
- "solana-nonce",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-feature-gate-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9c7fbf3e58b64a667c5f35e90af580538a95daea7001ff7806c0662d301bdf"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-fee-calculator"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89bc408da0fb3812bc3008189d148b4d3e08252c79ad810b245482a3f70cd8d"
-dependencies = [
- "log",
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "solana-hash"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf7bcb14392900fe02e4e34e90234fbf0c673d4e327888410ba99fa2ba0f4e99"
 dependencies = [
- "borsh 1.5.7",
  "bs58",
- "bytemuck",
- "bytemuck_derive",
  "js-sys",
- "serde",
- "serde_derive",
  "solana-atomic-u64",
  "solana-sanitize",
  "wasm-bindgen",
@@ -1743,124 +1276,11 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce496a475e5062ba5de97215ab39d9c358f9c9df4bb7f3a45a1f1a8bd9065ed"
 dependencies = [
- "bincode",
- "borsh 1.5.7",
  "getrandom 0.2.16",
  "js-sys",
  "num-traits",
- "serde",
- "serde_derive",
  "solana-define-syscall",
  "solana-pubkey",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-instructions-sysvar"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427f2d0d6dc0bb49f16cef5e7f975180d2e80aab9bdd3b2af68e2d029ec63f43"
-dependencies = [
- "bitflags",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-serialize-utils",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-keccak-hasher"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7aeb957fbd42a451b99235df4942d96db7ef678e8d5061ef34c9b34cae12f79"
-dependencies = [
- "sha3",
- "solana-define-syscall",
- "solana-hash",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-last-restart-slot"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6360ac2fdc72e7463565cd256eedcf10d7ef0c28a1249d261ec168c1b55cdd"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-loader-v2-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ab08006dad78ae7cd30df8eea0539e207d08d91eaefb3e1d49a446e1c49654"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-loader-v3-interface"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4be76cfa9afd84ca2f35ebc09f0da0f0092935ccdac0595d98447f259538c2"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-loader-v4-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706a777242f1f39a83e2a96a2a6cb034cb41169c6ecbee2cf09cb873d9659e7e"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-message"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6bf99c4570173710107a1f233f3bee226feea5fc817308707d4f7cb100a72d"
-dependencies = [
- "bincode",
- "blake3",
- "lazy_static",
- "serde",
- "serde_derive",
- "solana-bincode",
- "solana-hash",
- "solana-instruction",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-short-vec",
- "solana-system-interface",
- "solana-transaction-error",
  "wasm-bindgen",
 ]
 
@@ -1871,106 +1291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36a1a14399afaabc2781a1db09cb14ee4cc4ee5c7a5a3cfcc601811379a8092"
 dependencies = [
  "solana-define-syscall",
-]
-
-[[package]]
-name = "solana-native-token"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307fb2f78060995979e9b4f68f833623565ed4e55d3725f100454ce78a99a1a3"
-
-[[package]]
-name = "solana-nonce"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703e22eb185537e06204a5bd9d509b948f0066f2d1d814a6f475dafb3ddf1325"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-fee-calculator",
- "solana-hash",
- "solana-pubkey",
- "solana-sha256-hasher",
-]
-
-[[package]]
-name = "solana-program"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "586469467e93ceb79048f8d8e3a619bf61d05396ee7de95cb40280301a589d05"
-dependencies = [
- "bincode",
- "blake3",
- "borsh 0.10.4",
- "borsh 1.5.7",
- "bs58",
- "bytemuck",
- "console_error_panic_hook",
- "console_log",
- "getrandom 0.2.16",
- "lazy_static",
- "log",
- "memoffset",
- "num-bigint",
- "num-derive",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-account-info",
- "solana-address-lookup-table-interface",
- "solana-atomic-u64",
- "solana-big-mod-exp",
- "solana-bincode",
- "solana-blake3-hasher",
- "solana-borsh",
- "solana-clock",
- "solana-cpi",
- "solana-decode-error",
- "solana-define-syscall",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-example-mocks",
- "solana-feature-gate-interface",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-keccak-hasher",
- "solana-last-restart-slot",
- "solana-loader-v2-interface",
- "solana-loader-v3-interface",
- "solana-loader-v4-interface",
- "solana-message",
- "solana-msg",
- "solana-native-token",
- "solana-nonce",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-secp256k1-recover",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-sha256-hasher",
- "solana-short-vec",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stable-layout",
- "solana-stake-interface",
- "solana-system-interface",
- "solana-sysvar",
- "solana-sysvar-id",
- "solana-vote-interface",
- "thiserror 2.0.12",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1991,10 +1311,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8ae2c1a8d0d4ae865882d5770a7ebca92bab9c685e43f0461682c6c05a35bfa"
 dependencies = [
- "borsh 1.5.7",
  "num-traits",
- "serde",
- "serde_derive",
  "solana-decode-error",
  "solana-instruction",
  "solana-msg",
@@ -2012,21 +1329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-program-option"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc677a2e9bc616eda6dbdab834d463372b92848b2bfe4a1ed4e4b4adba3397d0"
-
-[[package]]
-name = "solana-program-pack"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319f0ef15e6e12dc37c597faccb7d62525a509fec5f6975ecb9419efddeb277b"
-dependencies = [
- "solana-program-error",
-]
-
-[[package]]
 name = "solana-pubkey"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,15 +1337,11 @@ dependencies = [
  "borsh 0.10.4",
  "borsh 1.5.7",
  "bs58",
- "bytemuck",
- "bytemuck_derive",
  "curve25519-dalek",
  "five8_const",
  "getrandom 0.2.16",
  "js-sys",
  "num-traits",
- "serde",
- "serde_derive",
  "solana-atomic-u64",
  "solana-decode-error",
  "solana-define-syscall",
@@ -2053,75 +1351,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-rent"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1aea8fdea9de98ca6e8c2da5827707fb3842833521b528a713810ca685d2480"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
 name = "solana-sanitize"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
-
-[[package]]
-name = "solana-sdk-ids"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5d8b9cc68d5c88b062a33e23a6466722467dde0035152d8fb1afbcdf350a5f"
-dependencies = [
- "solana-pubkey",
-]
-
-[[package]]
-name = "solana-sdk-macro"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86280da8b99d03560f6ab5aca9de2e38805681df34e0bb8f238e69b29433b9df"
-dependencies = [
- "bs58",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "solana-secp256k1-recover"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa3120b6cdaa270f39444f5093a90a7b03d296d362878f7a6991d6de3bbe496"
-dependencies = [
- "libsecp256k1",
- "solana-define-syscall",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-serde-varint"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc07d00200d82e6def2f7f7a45738e3406b17fe54a18adcf0defa16a97ccadb"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "solana-serialize-utils"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817a284b63197d2b27afdba829c5ab34231da4a9b4e763466a003c40ca4f535e"
-dependencies = [
- "solana-instruction",
- "solana-pubkey",
- "solana-sanitize",
-]
 
 [[package]]
 name = "solana-sha256-hasher"
@@ -2129,44 +1362,9 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0037386961c0d633421f53560ad7c80675c0447cba4d1bb66d60974dd486c7ea"
 dependencies = [
- "sha2 0.10.9",
+ "sha2",
  "solana-define-syscall",
  "solana-hash",
-]
-
-[[package]]
-name = "solana-short-vec"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c54c66f19b9766a56fa0057d060de8378676cb64987533fa088861858fc5a69"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "solana-slot-hashes"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8691982114513763e88d04094c9caa0376b867a29577939011331134c301ce"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-hash",
- "solana-sdk-ids",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-slot-history"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ccc1b2067ca22754d5283afb2b0126d61eae734fc616d23871b0943b0d935e"
-dependencies = [
- "bv",
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sysvar-id",
 ]
 
 [[package]]
@@ -2177,124 +1375,6 @@ checksum = "9f14f7d02af8f2bc1b5efeeae71bc1c2b7f0f65cd75bcc7d8180f2c762a57f54"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
-]
-
-[[package]]
-name = "solana-stake-interface"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5269e89fde216b4d7e1d1739cf5303f8398a1ff372a81232abbee80e554a838c"
-dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.7",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-system-interface",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-system-interface"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7c18cb1a91c6be5f5a8ac9276a1d7c737e39a21beba9ea710ab4b9c63bc90"
-dependencies = [
- "js-sys",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-decode-error",
- "solana-instruction",
- "solana-pubkey",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-sysvar"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6b44740d7f0c9f375d045c165bc0aab4a90658f92d6835aeb0649afaeaff9a"
-dependencies = [
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "lazy_static",
- "serde",
- "serde_derive",
- "solana-account-info",
- "solana-clock",
- "solana-define-syscall",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-last-restart-slot",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stake-interface",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-sysvar-id"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5762b273d3325b047cfda250787f8d796d781746860d5d0a746ee29f3e8812c1"
-dependencies = [
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-transaction-error"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a9dc8fdb61c6088baab34fc3a8b8473a03a7a5fd404ed8dd502fa79b67cb1"
-dependencies = [
- "solana-instruction",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-vote-interface"
-version = "2.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f039b0788337bedc6c5450d2f237718f938defb5ce0e0ad8ef507e78dcd370"
-dependencies = [
- "bincode",
- "num-derive",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-decode-error",
- "solana-hash",
- "solana-instruction",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-short-vec",
- "solana-system-interface",
 ]
 
 [[package]]
@@ -2369,16 +1449,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2386,17 +1457,6 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2504,7 +1564,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "flate2",
  "h2",
@@ -2552,7 +1612,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -2653,12 +1713,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2728,16 +1782,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2860,7 +1904,7 @@ version = "0.3.0"
 source = "git+https://github.com/rpcpool/yellowstone-vixen?branch=main#05ba40b34045f19ef81bfaf1d1ea6865590acb0c"
 dependencies = [
  "bs58",
- "thiserror 1.0.69",
+ "thiserror",
  "yellowstone-grpc-proto",
  "yellowstone-vixen-proto",
 ]
@@ -2874,10 +1918,17 @@ dependencies = [
  "num-traits",
  "prost",
  "prost-build",
- "solana-program",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey",
  "strum",
  "strum_macros",
- "thiserror 1.0.69",
+ "thiserror",
  "tonic",
  "tracing",
  "yellowstone-vixen-core",

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/Cargo.toml
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/Cargo.toml
@@ -9,7 +9,14 @@ edition = "2021"
 [dependencies]
 prost = "0.13.1"
 tonic = { version = "0.12.1", features = ["gzip", "zstd"] }
-solana-program = "^2.1.6"
+solana-account-info = "2.2.1"
+solana-cpi = "2.2.1"
+solana-decode-error = "2.2.1"
+solana-pubkey = { version = "2.2.1", features = ["curve25519", "borsh"] }
+solana-instruction = "2.2.1"
+solana-msg = "2.2.1"
+solana-program-entrypoint = "2.2.1"
+solana-program-error = "2.2.1"
 borsh = "^0.10"
 yellowstone-vixen-core = { git = "https://github.com/rpcpool/yellowstone-vixen", branch = "main",features = ["proto"] }
 num-derive = "0.4"

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_parser/accounts_parser.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_parser/accounts_parser.rs
@@ -121,7 +121,7 @@ impl yellowstone_vixen_core::Parser for AccountParser {
         let inner = acct
             .account
             .as_ref()
-            .ok_or(solana_program::program_error::ProgramError::InvalidArgument)?;
+            .ok_or(solana_program_error::ProgramError::InvalidArgument)?;
         WhirlpoolProgramState::try_unpack(&inner.data)
     }
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/fee_tier.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/fee_tier.rs
@@ -7,7 +7,7 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -32,12 +32,10 @@ impl FeeTier {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for FeeTier {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for FeeTier {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -46,7 +44,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for FeeTier {
 #[cfg(feature = "fetch")]
 pub fn fetch_fee_tier(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<FeeTier>, std::io::Error> {
     let accounts = fetch_all_fee_tier(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -55,7 +53,7 @@ pub fn fetch_fee_tier(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_fee_tier(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<FeeTier>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -80,7 +78,7 @@ pub fn fetch_all_fee_tier(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_fee_tier(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<FeeTier>, std::io::Error> {
     let accounts = fetch_all_maybe_fee_tier(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -89,7 +87,7 @@ pub fn fetch_maybe_fee_tier(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_fee_tier(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<FeeTier>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/lock_config.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/lock_config.rs
@@ -8,7 +8,7 @@
 use crate::generated::types::LockTypeLabel;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -43,12 +43,10 @@ impl LockConfig {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for LockConfig {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for LockConfig {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -57,7 +55,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for LockConfig 
 #[cfg(feature = "fetch")]
 pub fn fetch_lock_config(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<LockConfig>, std::io::Error> {
     let accounts = fetch_all_lock_config(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -66,7 +64,7 @@ pub fn fetch_lock_config(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_lock_config(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<LockConfig>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -91,7 +89,7 @@ pub fn fetch_all_lock_config(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_lock_config(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<LockConfig>, std::io::Error> {
     let accounts = fetch_all_maybe_lock_config(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -100,7 +98,7 @@ pub fn fetch_maybe_lock_config(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_lock_config(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<LockConfig>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/position.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/position.rs
@@ -8,7 +8,7 @@
 use crate::generated::types::PositionRewardInfo;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -44,12 +44,10 @@ impl Position {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Position {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for Position {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -58,7 +56,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Position {
 #[cfg(feature = "fetch")]
 pub fn fetch_position(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<Position>, std::io::Error> {
     let accounts = fetch_all_position(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -67,7 +65,7 @@ pub fn fetch_position(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_position(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<Position>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -92,7 +90,7 @@ pub fn fetch_all_position(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_position(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<Position>, std::io::Error> {
     let accounts = fetch_all_maybe_position(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -101,7 +99,7 @@ pub fn fetch_maybe_position(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_position(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<Position>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/position_bundle.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/position_bundle.rs
@@ -7,7 +7,7 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -31,12 +31,10 @@ impl PositionBundle {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for PositionBundle {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for PositionBundle {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -45,7 +43,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for PositionBun
 #[cfg(feature = "fetch")]
 pub fn fetch_position_bundle(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<PositionBundle>, std::io::Error> {
     let accounts = fetch_all_position_bundle(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -54,7 +52,7 @@ pub fn fetch_position_bundle(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_position_bundle(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<PositionBundle>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -79,7 +77,7 @@ pub fn fetch_all_position_bundle(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_position_bundle(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<PositionBundle>, std::io::Error> {
     let accounts = fetch_all_maybe_position_bundle(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -88,7 +86,7 @@ pub fn fetch_maybe_position_bundle(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_position_bundle(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<PositionBundle>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/tick_array.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/tick_array.rs
@@ -8,7 +8,7 @@
 use crate::generated::types::Tick;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -34,12 +34,10 @@ impl TickArray {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for TickArray {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for TickArray {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -48,7 +46,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for TickArray {
 #[cfg(feature = "fetch")]
 pub fn fetch_tick_array(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<TickArray>, std::io::Error> {
     let accounts = fetch_all_tick_array(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -57,7 +55,7 @@ pub fn fetch_tick_array(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_tick_array(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<TickArray>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -82,7 +80,7 @@ pub fn fetch_all_tick_array(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_tick_array(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<TickArray>, std::io::Error> {
     let accounts = fetch_all_maybe_tick_array(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -91,7 +89,7 @@ pub fn fetch_maybe_tick_array(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_tick_array(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<TickArray>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/token_badge.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/token_badge.rs
@@ -7,7 +7,7 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -35,12 +35,10 @@ impl TokenBadge {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for TokenBadge {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for TokenBadge {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -49,7 +47,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for TokenBadge 
 #[cfg(feature = "fetch")]
 pub fn fetch_token_badge(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<TokenBadge>, std::io::Error> {
     let accounts = fetch_all_token_badge(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -58,7 +56,7 @@ pub fn fetch_token_badge(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_token_badge(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<TokenBadge>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -83,7 +81,7 @@ pub fn fetch_all_token_badge(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_token_badge(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<TokenBadge>, std::io::Error> {
     let accounts = fetch_all_maybe_token_badge(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -92,7 +90,7 @@ pub fn fetch_maybe_token_badge(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_token_badge(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<TokenBadge>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/whirlpool.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/whirlpool.rs
@@ -8,7 +8,7 @@
 use crate::generated::types::WhirlpoolRewardInfo;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -65,12 +65,10 @@ impl Whirlpool {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Whirlpool {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for Whirlpool {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -79,7 +77,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Whirlpool {
 #[cfg(feature = "fetch")]
 pub fn fetch_whirlpool(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<Whirlpool>, std::io::Error> {
     let accounts = fetch_all_whirlpool(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -88,7 +86,7 @@ pub fn fetch_whirlpool(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_whirlpool(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<Whirlpool>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -113,7 +111,7 @@ pub fn fetch_all_whirlpool(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_whirlpool(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<Whirlpool>, std::io::Error> {
     let accounts = fetch_all_maybe_whirlpool(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -122,7 +120,7 @@ pub fn fetch_maybe_whirlpool(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_whirlpool(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<Whirlpool>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/whirlpools_config.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/whirlpools_config.rs
@@ -7,7 +7,7 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -41,12 +41,10 @@ impl WhirlpoolsConfig {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for WhirlpoolsConfig {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for WhirlpoolsConfig {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -55,7 +53,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for WhirlpoolsC
 #[cfg(feature = "fetch")]
 pub fn fetch_whirlpools_config(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<WhirlpoolsConfig>, std::io::Error> {
     let accounts = fetch_all_whirlpools_config(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -64,7 +62,7 @@ pub fn fetch_whirlpools_config(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_whirlpools_config(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<WhirlpoolsConfig>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -89,7 +87,7 @@ pub fn fetch_all_whirlpools_config(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_whirlpools_config(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<WhirlpoolsConfig>, std::io::Error> {
     let accounts = fetch_all_maybe_whirlpools_config(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -98,7 +96,7 @@ pub fn fetch_maybe_whirlpools_config(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_whirlpools_config(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<WhirlpoolsConfig>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/whirlpools_config_extension.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/accounts/whirlpools_config_extension.rs
@@ -7,7 +7,7 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -40,12 +40,10 @@ impl WhirlpoolsConfigExtension {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for WhirlpoolsConfigExtension {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for WhirlpoolsConfigExtension {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -54,7 +52,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for WhirlpoolsC
 #[cfg(feature = "fetch")]
 pub fn fetch_whirlpools_config_extension(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<WhirlpoolsConfigExtension>, std::io::Error> {
     let accounts = fetch_all_whirlpools_config_extension(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -63,7 +61,7 @@ pub fn fetch_whirlpools_config_extension(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_whirlpools_config_extension(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<WhirlpoolsConfigExtension>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -89,7 +87,7 @@ pub fn fetch_all_whirlpools_config_extension(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_whirlpools_config_extension(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<WhirlpoolsConfigExtension>, std::io::Error> {
     let accounts = fetch_all_maybe_whirlpools_config_extension(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -98,7 +96,7 @@ pub fn fetch_maybe_whirlpools_config_extension(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_whirlpools_config_extension(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<WhirlpoolsConfigExtension>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/errors/whirlpool.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/errors/whirlpool.rs
@@ -192,13 +192,13 @@ pub enum WhirlpoolError {
     OperationNotAllowedOnLockedPosition = 0x17AB,
 }
 
-impl solana_program::program_error::PrintProgramError for WhirlpoolError {
+impl solana_program_error::PrintProgramError for WhirlpoolError {
     fn print<E>(&self) {
-        solana_program::msg!(&self.to_string());
+        solana_msg::msg!(&self.to_string());
     }
 }
 
-impl<T> solana_program::decode_error::DecodeError<T> for WhirlpoolError {
+impl<T> solana_decode_error::DecodeError<T> for WhirlpoolError {
     fn type_of() -> &'static str {
         "WhirlpoolError"
     }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/close_bundled_position.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/close_bundled_position.rs
@@ -11,22 +11,22 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct CloseBundledPosition {
-    pub bundled_position: solana_program::pubkey::Pubkey,
+    pub bundled_position: solana_pubkey::Pubkey,
 
-    pub position_bundle: solana_program::pubkey::Pubkey,
+    pub position_bundle: solana_pubkey::Pubkey,
 
-    pub position_bundle_token_account: solana_program::pubkey::Pubkey,
+    pub position_bundle_token_account: solana_pubkey::Pubkey,
 
-    pub position_bundle_authority: solana_program::pubkey::Pubkey,
+    pub position_bundle_authority: solana_pubkey::Pubkey,
 
-    pub receiver: solana_program::pubkey::Pubkey,
+    pub receiver: solana_pubkey::Pubkey,
 }
 
 impl CloseBundledPosition {
     pub fn instruction(
         &self,
         args: CloseBundledPositionInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -34,35 +34,32 @@ impl CloseBundledPosition {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: CloseBundledPositionInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.bundled_position,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_bundle,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_bundle_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_bundle_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.receiver,
-            false,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.receiver, false));
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&CloseBundledPositionInstructionData::new()).unwrap();
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -107,13 +104,13 @@ pub struct CloseBundledPositionInstructionArgs {
 ///   4. `[writable]` receiver
 #[derive(Clone, Debug, Default)]
 pub struct CloseBundledPositionBuilder {
-    bundled_position: Option<solana_program::pubkey::Pubkey>,
-    position_bundle: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_token_account: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_authority: Option<solana_program::pubkey::Pubkey>,
-    receiver: Option<solana_program::pubkey::Pubkey>,
+    bundled_position: Option<solana_pubkey::Pubkey>,
+    position_bundle: Option<solana_pubkey::Pubkey>,
+    position_bundle_token_account: Option<solana_pubkey::Pubkey>,
+    position_bundle_authority: Option<solana_pubkey::Pubkey>,
+    receiver: Option<solana_pubkey::Pubkey>,
     bundle_index: Option<u16>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl CloseBundledPositionBuilder {
@@ -121,25 +118,19 @@ impl CloseBundledPositionBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn bundled_position(
-        &mut self,
-        bundled_position: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn bundled_position(&mut self, bundled_position: solana_pubkey::Pubkey) -> &mut Self {
         self.bundled_position = Some(bundled_position);
         self
     }
     #[inline(always)]
-    pub fn position_bundle(
-        &mut self,
-        position_bundle: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_bundle(&mut self, position_bundle: solana_pubkey::Pubkey) -> &mut Self {
         self.position_bundle = Some(position_bundle);
         self
     }
     #[inline(always)]
     pub fn position_bundle_token_account(
         &mut self,
-        position_bundle_token_account: solana_program::pubkey::Pubkey,
+        position_bundle_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_token_account = Some(position_bundle_token_account);
         self
@@ -147,13 +138,13 @@ impl CloseBundledPositionBuilder {
     #[inline(always)]
     pub fn position_bundle_authority(
         &mut self,
-        position_bundle_authority: solana_program::pubkey::Pubkey,
+        position_bundle_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_authority = Some(position_bundle_authority);
         self
     }
     #[inline(always)]
-    pub fn receiver(&mut self, receiver: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn receiver(&mut self, receiver: solana_pubkey::Pubkey) -> &mut Self {
         self.receiver = Some(receiver);
         self
     }
@@ -164,10 +155,7 @@ impl CloseBundledPositionBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -175,13 +163,13 @@ impl CloseBundledPositionBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = CloseBundledPosition {
             bundled_position: self.bundled_position.expect("bundled_position is not set"),
             position_bundle: self.position_bundle.expect("position_bundle is not set"),
@@ -203,38 +191,38 @@ impl CloseBundledPositionBuilder {
 
 /// `close_bundled_position` CPI accounts.
 pub struct CloseBundledPositionCpiAccounts<'a, 'b> {
-    pub bundled_position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub bundled_position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub receiver: &'b solana_program::account_info::AccountInfo<'a>,
+    pub receiver: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `close_bundled_position` CPI instruction.
 pub struct CloseBundledPositionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub bundled_position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub bundled_position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub receiver: &'b solana_program::account_info::AccountInfo<'a>,
+    pub receiver: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CloseBundledPositionInstructionArgs,
 }
 
 impl<'a, 'b> CloseBundledPositionCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: CloseBundledPositionCpiAccounts<'a, 'b>,
         args: CloseBundledPositionInstructionArgs,
     ) -> Self {
@@ -249,25 +237,21 @@ impl<'a, 'b> CloseBundledPositionCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -276,35 +260,31 @@ impl<'a, 'b> CloseBundledPositionCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.bundled_position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_bundle.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_bundle_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_bundle_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.receiver.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -314,7 +294,7 @@ impl<'a, 'b> CloseBundledPositionCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -331,9 +311,9 @@ impl<'a, 'b> CloseBundledPositionCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -353,7 +333,7 @@ pub struct CloseBundledPositionCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> CloseBundledPositionCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CloseBundledPositionCpiBuilderInstruction {
             __program: program,
             bundled_position: None,
@@ -369,7 +349,7 @@ impl<'a, 'b> CloseBundledPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn bundled_position(
         &mut self,
-        bundled_position: &'b solana_program::account_info::AccountInfo<'a>,
+        bundled_position: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.bundled_position = Some(bundled_position);
         self
@@ -377,7 +357,7 @@ impl<'a, 'b> CloseBundledPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle(
         &mut self,
-        position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle = Some(position_bundle);
         self
@@ -385,7 +365,7 @@ impl<'a, 'b> CloseBundledPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_token_account(
         &mut self,
-        position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_token_account = Some(position_bundle_token_account);
         self
@@ -393,16 +373,13 @@ impl<'a, 'b> CloseBundledPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_authority(
         &mut self,
-        position_bundle_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_authority = Some(position_bundle_authority);
         self
     }
     #[inline(always)]
-    pub fn receiver(
-        &mut self,
-        receiver: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn receiver(&mut self, receiver: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.receiver = Some(receiver);
         self
     }
@@ -415,7 +392,7 @@ impl<'a, 'b> CloseBundledPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -431,11 +408,7 @@ impl<'a, 'b> CloseBundledPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -443,7 +416,7 @@ impl<'a, 'b> CloseBundledPositionCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -451,7 +424,7 @@ impl<'a, 'b> CloseBundledPositionCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = CloseBundledPositionInstructionArgs {
             bundle_index: self
                 .instruction
@@ -494,17 +467,13 @@ impl<'a, 'b> CloseBundledPositionCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct CloseBundledPositionCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    bundled_position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    receiver: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    bundled_position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    receiver: Option<&'b solana_account_info::AccountInfo<'a>>,
     bundle_index: Option<u16>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/close_position.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/close_position.rs
@@ -11,58 +11,52 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct ClosePosition {
-    pub position_authority: solana_program::pubkey::Pubkey,
+    pub position_authority: solana_pubkey::Pubkey,
 
-    pub receiver: solana_program::pubkey::Pubkey,
+    pub receiver: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_mint: solana_program::pubkey::Pubkey,
+    pub position_mint: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 }
 
 impl ClosePosition {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.receiver,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.receiver, false));
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_mint,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&ClosePositionInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -102,13 +96,13 @@ impl Default for ClosePositionInstructionData {
 ///   5. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 #[derive(Clone, Debug, Default)]
 pub struct ClosePositionBuilder {
-    position_authority: Option<solana_program::pubkey::Pubkey>,
-    receiver: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_mint: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    position_authority: Option<solana_pubkey::Pubkey>,
+    receiver: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_mint: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl ClosePositionBuilder {
@@ -116,48 +110,42 @@ impl ClosePositionBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn position_authority(
-        &mut self,
-        position_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_authority(&mut self, position_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn receiver(&mut self, receiver: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn receiver(&mut self, receiver: solana_pubkey::Pubkey) -> &mut Self {
         self.receiver = Some(receiver);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
-    pub fn position_mint(&mut self, position_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position_mint(&mut self, position_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.position_mint = Some(position_mint);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -165,13 +153,13 @@ impl ClosePositionBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = ClosePosition {
             position_authority: self
                 .position_authority
@@ -182,7 +170,7 @@ impl ClosePositionBuilder {
             position_token_account: self
                 .position_token_account
                 .expect("position_token_account is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
         };
@@ -193,40 +181,40 @@ impl ClosePositionBuilder {
 
 /// `close_position` CPI accounts.
 pub struct ClosePositionCpiAccounts<'a, 'b> {
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub receiver: &'b solana_program::account_info::AccountInfo<'a>,
+    pub receiver: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `close_position` CPI instruction.
 pub struct ClosePositionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub receiver: &'b solana_program::account_info::AccountInfo<'a>,
+    pub receiver: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> ClosePositionCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: ClosePositionCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -240,25 +228,21 @@ impl<'a, 'b> ClosePositionCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -267,39 +251,35 @@ impl<'a, 'b> ClosePositionCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.receiver.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -307,7 +287,7 @@ impl<'a, 'b> ClosePositionCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&ClosePositionInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -325,9 +305,9 @@ impl<'a, 'b> ClosePositionCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -348,7 +328,7 @@ pub struct ClosePositionCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> ClosePositionCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(ClosePositionCpiBuilderInstruction {
             __program: program,
             position_authority: None,
@@ -364,31 +344,25 @@ impl<'a, 'b> ClosePositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_authority(
         &mut self,
-        position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn receiver(
-        &mut self,
-        receiver: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn receiver(&mut self, receiver: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.receiver = Some(receiver);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_mint(
         &mut self,
-        position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        position_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_mint = Some(position_mint);
         self
@@ -396,7 +370,7 @@ impl<'a, 'b> ClosePositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
@@ -404,7 +378,7 @@ impl<'a, 'b> ClosePositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -413,7 +387,7 @@ impl<'a, 'b> ClosePositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -429,11 +403,7 @@ impl<'a, 'b> ClosePositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -441,7 +411,7 @@ impl<'a, 'b> ClosePositionCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -449,7 +419,7 @@ impl<'a, 'b> ClosePositionCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = ClosePositionCpi {
             __program: self.instruction.__program,
 
@@ -486,17 +456,13 @@ impl<'a, 'b> ClosePositionCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct ClosePositionCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    position_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    receiver: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    position_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    receiver: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/close_position_with_token_extensions.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/close_position_with_token_extensions.rs
@@ -11,58 +11,52 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct ClosePositionWithTokenExtensions {
-    pub position_authority: solana_program::pubkey::Pubkey,
+    pub position_authority: solana_pubkey::Pubkey,
 
-    pub receiver: solana_program::pubkey::Pubkey,
+    pub receiver: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_mint: solana_program::pubkey::Pubkey,
+    pub position_mint: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub token2022_program: solana_program::pubkey::Pubkey,
+    pub token2022_program: solana_pubkey::Pubkey,
 }
 
 impl ClosePositionWithTokenExtensions {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.receiver,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.receiver, false));
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_mint,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token2022_program,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&ClosePositionWithTokenExtensionsInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -102,13 +96,13 @@ impl Default for ClosePositionWithTokenExtensionsInstructionData {
 ///   5. `[]` token2022_program
 #[derive(Clone, Debug, Default)]
 pub struct ClosePositionWithTokenExtensionsBuilder {
-    position_authority: Option<solana_program::pubkey::Pubkey>,
-    receiver: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_mint: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    token2022_program: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    position_authority: Option<solana_pubkey::Pubkey>,
+    receiver: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_mint: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    token2022_program: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl ClosePositionWithTokenExtensionsBuilder {
@@ -116,50 +110,41 @@ impl ClosePositionWithTokenExtensionsBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn position_authority(
-        &mut self,
-        position_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_authority(&mut self, position_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn receiver(&mut self, receiver: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn receiver(&mut self, receiver: solana_pubkey::Pubkey) -> &mut Self {
         self.receiver = Some(receiver);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
-    pub fn position_mint(&mut self, position_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position_mint(&mut self, position_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.position_mint = Some(position_mint);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
     }
     #[inline(always)]
-    pub fn token2022_program(
-        &mut self,
-        token2022_program: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token2022_program(&mut self, token2022_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token2022_program = Some(token2022_program);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -167,13 +152,13 @@ impl ClosePositionWithTokenExtensionsBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = ClosePositionWithTokenExtensions {
             position_authority: self
                 .position_authority
@@ -195,40 +180,40 @@ impl ClosePositionWithTokenExtensionsBuilder {
 
 /// `close_position_with_token_extensions` CPI accounts.
 pub struct ClosePositionWithTokenExtensionsCpiAccounts<'a, 'b> {
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub receiver: &'b solana_program::account_info::AccountInfo<'a>,
+    pub receiver: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token2022_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token2022_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `close_position_with_token_extensions` CPI instruction.
 pub struct ClosePositionWithTokenExtensionsCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub receiver: &'b solana_program::account_info::AccountInfo<'a>,
+    pub receiver: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token2022_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token2022_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> ClosePositionWithTokenExtensionsCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: ClosePositionWithTokenExtensionsCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -242,25 +227,21 @@ impl<'a, 'b> ClosePositionWithTokenExtensionsCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -269,39 +250,35 @@ impl<'a, 'b> ClosePositionWithTokenExtensionsCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.receiver.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token2022_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -309,7 +286,7 @@ impl<'a, 'b> ClosePositionWithTokenExtensionsCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&ClosePositionWithTokenExtensionsInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -327,9 +304,9 @@ impl<'a, 'b> ClosePositionWithTokenExtensionsCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -350,7 +327,7 @@ pub struct ClosePositionWithTokenExtensionsCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> ClosePositionWithTokenExtensionsCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(ClosePositionWithTokenExtensionsCpiBuilderInstruction {
             __program: program,
             position_authority: None,
@@ -366,31 +343,25 @@ impl<'a, 'b> ClosePositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_authority(
         &mut self,
-        position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn receiver(
-        &mut self,
-        receiver: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn receiver(&mut self, receiver: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.receiver = Some(receiver);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_mint(
         &mut self,
-        position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        position_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_mint = Some(position_mint);
         self
@@ -398,7 +369,7 @@ impl<'a, 'b> ClosePositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
@@ -406,7 +377,7 @@ impl<'a, 'b> ClosePositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token2022_program(
         &mut self,
-        token2022_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token2022_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token2022_program = Some(token2022_program);
         self
@@ -415,7 +386,7 @@ impl<'a, 'b> ClosePositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -431,11 +402,7 @@ impl<'a, 'b> ClosePositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -443,7 +410,7 @@ impl<'a, 'b> ClosePositionWithTokenExtensionsCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -451,7 +418,7 @@ impl<'a, 'b> ClosePositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = ClosePositionWithTokenExtensionsCpi {
             __program: self.instruction.__program,
 
@@ -488,17 +455,13 @@ impl<'a, 'b> ClosePositionWithTokenExtensionsCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct ClosePositionWithTokenExtensionsCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    position_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    receiver: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token2022_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    position_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    receiver: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token2022_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/collect_fees.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/collect_fees.rs
@@ -11,76 +11,73 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct CollectFees {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub position_authority: solana_program::pubkey::Pubkey,
+    pub position_authority: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub token_owner_account_a: solana_program::pubkey::Pubkey,
+    pub token_owner_account_a: solana_pubkey::Pubkey,
 
-    pub token_vault_a: solana_program::pubkey::Pubkey,
+    pub token_vault_a: solana_pubkey::Pubkey,
 
-    pub token_owner_account_b: solana_program::pubkey::Pubkey,
+    pub token_owner_account_b: solana_pubkey::Pubkey,
 
-    pub token_vault_b: solana_program::pubkey::Pubkey,
+    pub token_vault_b: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 }
 
 impl CollectFees {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpool,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&CollectFeesInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -123,16 +120,16 @@ impl Default for CollectFeesInstructionData {
 ///   8. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 #[derive(Clone, Debug, Default)]
 pub struct CollectFeesBuilder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    position_authority: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_a: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_b: Option<solana_program::pubkey::Pubkey>,
-    token_vault_b: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    position_authority: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    token_owner_account_a: Option<solana_pubkey::Pubkey>,
+    token_vault_a: Option<solana_pubkey::Pubkey>,
+    token_owner_account_b: Option<solana_pubkey::Pubkey>,
+    token_vault_b: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl CollectFeesBuilder {
@@ -140,27 +137,24 @@ impl CollectFeesBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn position_authority(
-        &mut self,
-        position_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_authority(&mut self, position_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
@@ -168,41 +162,38 @@ impl CollectFeesBuilder {
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: solana_program::pubkey::Pubkey,
+        token_owner_account_a: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_a = Some(token_owner_account_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_a(&mut self, token_vault_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_a(&mut self, token_vault_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_a = Some(token_vault_a);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: solana_program::pubkey::Pubkey,
+        token_owner_account_b: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_b = Some(token_owner_account_b);
         self
     }
     #[inline(always)]
-    pub fn token_vault_b(&mut self, token_vault_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_b(&mut self, token_vault_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_b = Some(token_vault_b);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -210,13 +201,13 @@ impl CollectFeesBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = CollectFees {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
             position_authority: self
@@ -234,7 +225,7 @@ impl CollectFeesBuilder {
                 .token_owner_account_b
                 .expect("token_owner_account_b is not set"),
             token_vault_b: self.token_vault_b.expect("token_vault_b is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
         };
@@ -245,52 +236,52 @@ impl CollectFeesBuilder {
 
 /// `collect_fees` CPI accounts.
 pub struct CollectFeesCpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `collect_fees` CPI instruction.
 pub struct CollectFeesCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> CollectFeesCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: CollectFeesCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -307,25 +298,21 @@ impl<'a, 'b> CollectFeesCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -334,51 +321,47 @@ impl<'a, 'b> CollectFeesCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -386,7 +369,7 @@ impl<'a, 'b> CollectFeesCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&CollectFeesInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -407,9 +390,9 @@ impl<'a, 'b> CollectFeesCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -433,7 +416,7 @@ pub struct CollectFeesCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> CollectFeesCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CollectFeesCpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -450,33 +433,27 @@ impl<'a, 'b> CollectFeesCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn position_authority(
         &mut self,
-        position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
@@ -484,7 +461,7 @@ impl<'a, 'b> CollectFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_a = Some(token_owner_account_a);
         self
@@ -492,7 +469,7 @@ impl<'a, 'b> CollectFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_a(
         &mut self,
-        token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_a = Some(token_vault_a);
         self
@@ -500,7 +477,7 @@ impl<'a, 'b> CollectFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_b = Some(token_owner_account_b);
         self
@@ -508,7 +485,7 @@ impl<'a, 'b> CollectFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_b(
         &mut self,
-        token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_b = Some(token_vault_b);
         self
@@ -516,7 +493,7 @@ impl<'a, 'b> CollectFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -525,7 +502,7 @@ impl<'a, 'b> CollectFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -541,11 +518,7 @@ impl<'a, 'b> CollectFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -553,7 +526,7 @@ impl<'a, 'b> CollectFeesCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -561,7 +534,7 @@ impl<'a, 'b> CollectFeesCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = CollectFeesCpi {
             __program: self.instruction.__program,
 
@@ -613,20 +586,16 @@ impl<'a, 'b> CollectFeesCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct CollectFeesCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/collect_fees_v2.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/collect_fees_v2.rs
@@ -12,38 +12,38 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct CollectFeesV2 {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub position_authority: solana_program::pubkey::Pubkey,
+    pub position_authority: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub token_mint_a: solana_program::pubkey::Pubkey,
+    pub token_mint_a: solana_pubkey::Pubkey,
 
-    pub token_mint_b: solana_program::pubkey::Pubkey,
+    pub token_mint_b: solana_pubkey::Pubkey,
 
-    pub token_owner_account_a: solana_program::pubkey::Pubkey,
+    pub token_owner_account_a: solana_pubkey::Pubkey,
 
-    pub token_vault_a: solana_program::pubkey::Pubkey,
+    pub token_vault_a: solana_pubkey::Pubkey,
 
-    pub token_owner_account_b: solana_program::pubkey::Pubkey,
+    pub token_owner_account_b: solana_pubkey::Pubkey,
 
-    pub token_vault_b: solana_program::pubkey::Pubkey,
+    pub token_vault_b: solana_pubkey::Pubkey,
 
-    pub token_program_a: solana_program::pubkey::Pubkey,
+    pub token_program_a: solana_pubkey::Pubkey,
 
-    pub token_program_b: solana_program::pubkey::Pubkey,
+    pub token_program_b: solana_pubkey::Pubkey,
 
-    pub memo_program: solana_program::pubkey::Pubkey,
+    pub memo_program: solana_pubkey::Pubkey,
 }
 
 impl CollectFeesV2 {
     pub fn instruction(
         &self,
         args: CollectFeesV2InstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -51,58 +51,55 @@ impl CollectFeesV2 {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: CollectFeesV2InstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(13 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpool,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.memo_program,
             false,
         ));
@@ -111,7 +108,7 @@ impl CollectFeesV2 {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -164,21 +161,21 @@ pub struct CollectFeesV2InstructionArgs {
 ///   12. `[]` memo_program
 #[derive(Clone, Debug, Default)]
 pub struct CollectFeesV2Builder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    position_authority: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    token_mint_a: Option<solana_program::pubkey::Pubkey>,
-    token_mint_b: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_a: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_b: Option<solana_program::pubkey::Pubkey>,
-    token_vault_b: Option<solana_program::pubkey::Pubkey>,
-    token_program_a: Option<solana_program::pubkey::Pubkey>,
-    token_program_b: Option<solana_program::pubkey::Pubkey>,
-    memo_program: Option<solana_program::pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    position_authority: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    token_mint_a: Option<solana_pubkey::Pubkey>,
+    token_mint_b: Option<solana_pubkey::Pubkey>,
+    token_owner_account_a: Option<solana_pubkey::Pubkey>,
+    token_vault_a: Option<solana_pubkey::Pubkey>,
+    token_owner_account_b: Option<solana_pubkey::Pubkey>,
+    token_vault_b: Option<solana_pubkey::Pubkey>,
+    token_program_a: Option<solana_pubkey::Pubkey>,
+    token_program_b: Option<solana_pubkey::Pubkey>,
+    memo_program: Option<solana_pubkey::Pubkey>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl CollectFeesV2Builder {
@@ -186,85 +183,76 @@ impl CollectFeesV2Builder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn position_authority(
-        &mut self,
-        position_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_authority(&mut self, position_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
     }
     #[inline(always)]
-    pub fn token_mint_a(&mut self, token_mint_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_a(&mut self, token_mint_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_a = Some(token_mint_a);
         self
     }
     #[inline(always)]
-    pub fn token_mint_b(&mut self, token_mint_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_b(&mut self, token_mint_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_b = Some(token_mint_b);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: solana_program::pubkey::Pubkey,
+        token_owner_account_a: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_a = Some(token_owner_account_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_a(&mut self, token_vault_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_a(&mut self, token_vault_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_a = Some(token_vault_a);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: solana_program::pubkey::Pubkey,
+        token_owner_account_b: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_b = Some(token_owner_account_b);
         self
     }
     #[inline(always)]
-    pub fn token_vault_b(&mut self, token_vault_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_b(&mut self, token_vault_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn token_program_a(
-        &mut self,
-        token_program_a: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_a(&mut self, token_program_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_a = Some(token_program_a);
         self
     }
     #[inline(always)]
-    pub fn token_program_b(
-        &mut self,
-        token_program_b: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_b(&mut self, token_program_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_b = Some(token_program_b);
         self
     }
     #[inline(always)]
-    pub fn memo_program(&mut self, memo_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn memo_program(&mut self, memo_program: solana_pubkey::Pubkey) -> &mut Self {
         self.memo_program = Some(memo_program);
         self
     }
@@ -279,10 +267,7 @@ impl CollectFeesV2Builder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -290,13 +275,13 @@ impl CollectFeesV2Builder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = CollectFeesV2 {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
             position_authority: self
@@ -330,70 +315,70 @@ impl CollectFeesV2Builder {
 
 /// `collect_fees_v2` CPI accounts.
 pub struct CollectFeesV2CpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `collect_fees_v2` CPI instruction.
 pub struct CollectFeesV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CollectFeesV2InstructionArgs,
 }
 
 impl<'a, 'b> CollectFeesV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: CollectFeesV2CpiAccounts<'a, 'b>,
         args: CollectFeesV2InstructionArgs,
     ) -> Self {
@@ -416,25 +401,21 @@ impl<'a, 'b> CollectFeesV2Cpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -443,67 +424,63 @@ impl<'a, 'b> CollectFeesV2Cpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(13 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.memo_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -513,7 +490,7 @@ impl<'a, 'b> CollectFeesV2Cpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -538,9 +515,9 @@ impl<'a, 'b> CollectFeesV2Cpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -568,7 +545,7 @@ pub struct CollectFeesV2CpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CollectFeesV2CpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -590,33 +567,27 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn position_authority(
         &mut self,
-        position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
@@ -624,7 +595,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_a(
         &mut self,
-        token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_a = Some(token_mint_a);
         self
@@ -632,7 +603,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_b(
         &mut self,
-        token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_b = Some(token_mint_b);
         self
@@ -640,7 +611,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_a = Some(token_owner_account_a);
         self
@@ -648,7 +619,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_a(
         &mut self,
-        token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_a = Some(token_vault_a);
         self
@@ -656,7 +627,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_b = Some(token_owner_account_b);
         self
@@ -664,7 +635,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_b(
         &mut self,
-        token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_b = Some(token_vault_b);
         self
@@ -672,7 +643,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program_a(
         &mut self,
-        token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_a = Some(token_program_a);
         self
@@ -680,7 +651,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program_b(
         &mut self,
-        token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_b = Some(token_program_b);
         self
@@ -688,7 +659,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn memo_program(
         &mut self,
-        memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+        memo_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.memo_program = Some(memo_program);
         self
@@ -706,7 +677,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -722,11 +693,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -734,7 +701,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -742,7 +709,7 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = CollectFeesV2InstructionArgs {
             remaining_accounts_info: self.instruction.remaining_accounts_info.clone(),
         };
@@ -818,25 +785,21 @@ impl<'a, 'b> CollectFeesV2CpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct CollectFeesV2CpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    memo_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    memo_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/collect_protocol_fees.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/collect_protocol_fees.rs
@@ -11,70 +11,67 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct CollectProtocolFees {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub collect_protocol_fees_authority: solana_program::pubkey::Pubkey,
+    pub collect_protocol_fees_authority: solana_pubkey::Pubkey,
 
-    pub token_vault_a: solana_program::pubkey::Pubkey,
+    pub token_vault_a: solana_pubkey::Pubkey,
 
-    pub token_vault_b: solana_program::pubkey::Pubkey,
+    pub token_vault_b: solana_pubkey::Pubkey,
 
-    pub token_destination_a: solana_program::pubkey::Pubkey,
+    pub token_destination_a: solana_pubkey::Pubkey,
 
-    pub token_destination_b: solana_program::pubkey::Pubkey,
+    pub token_destination_b: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 }
 
 impl CollectProtocolFees {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.collect_protocol_fees_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_destination_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_destination_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&CollectProtocolFeesInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -116,15 +113,15 @@ impl Default for CollectProtocolFeesInstructionData {
 ///   7. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 #[derive(Clone, Debug, Default)]
 pub struct CollectProtocolFeesBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    collect_protocol_fees_authority: Option<solana_program::pubkey::Pubkey>,
-    token_vault_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_b: Option<solana_program::pubkey::Pubkey>,
-    token_destination_a: Option<solana_program::pubkey::Pubkey>,
-    token_destination_b: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    collect_protocol_fees_authority: Option<solana_pubkey::Pubkey>,
+    token_vault_a: Option<solana_pubkey::Pubkey>,
+    token_vault_b: Option<solana_pubkey::Pubkey>,
+    token_destination_a: Option<solana_pubkey::Pubkey>,
+    token_destination_b: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl CollectProtocolFeesBuilder {
@@ -132,64 +129,52 @@ impl CollectProtocolFeesBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn collect_protocol_fees_authority(
         &mut self,
-        collect_protocol_fees_authority: solana_program::pubkey::Pubkey,
+        collect_protocol_fees_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.collect_protocol_fees_authority = Some(collect_protocol_fees_authority);
         self
     }
     #[inline(always)]
-    pub fn token_vault_a(&mut self, token_vault_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_a(&mut self, token_vault_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_a = Some(token_vault_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_b(&mut self, token_vault_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_b(&mut self, token_vault_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn token_destination_a(
-        &mut self,
-        token_destination_a: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_destination_a(&mut self, token_destination_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_destination_a = Some(token_destination_a);
         self
     }
     #[inline(always)]
-    pub fn token_destination_b(
-        &mut self,
-        token_destination_b: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_destination_b(&mut self, token_destination_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_destination_b = Some(token_destination_b);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -197,13 +182,13 @@ impl CollectProtocolFeesBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = CollectProtocolFees {
             whirlpools_config: self
                 .whirlpools_config
@@ -220,7 +205,7 @@ impl CollectProtocolFeesBuilder {
             token_destination_b: self
                 .token_destination_b
                 .expect("token_destination_b is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
         };
@@ -231,48 +216,48 @@ impl CollectProtocolFeesBuilder {
 
 /// `collect_protocol_fees` CPI accounts.
 pub struct CollectProtocolFeesCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub collect_protocol_fees_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub collect_protocol_fees_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_destination_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_destination_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_destination_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_destination_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `collect_protocol_fees` CPI instruction.
 pub struct CollectProtocolFeesCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub collect_protocol_fees_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub collect_protocol_fees_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_destination_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_destination_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_destination_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_destination_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> CollectProtocolFeesCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: CollectProtocolFeesCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -288,25 +273,21 @@ impl<'a, 'b> CollectProtocolFeesCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -315,47 +296,43 @@ impl<'a, 'b> CollectProtocolFeesCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.collect_protocol_fees_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_destination_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_destination_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -363,7 +340,7 @@ impl<'a, 'b> CollectProtocolFeesCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&CollectProtocolFeesInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -383,9 +360,9 @@ impl<'a, 'b> CollectProtocolFeesCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -408,7 +385,7 @@ pub struct CollectProtocolFeesCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> CollectProtocolFeesCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CollectProtocolFeesCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -426,23 +403,20 @@ impl<'a, 'b> CollectProtocolFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn collect_protocol_fees_authority(
         &mut self,
-        collect_protocol_fees_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        collect_protocol_fees_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collect_protocol_fees_authority = Some(collect_protocol_fees_authority);
         self
@@ -450,7 +424,7 @@ impl<'a, 'b> CollectProtocolFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_a(
         &mut self,
-        token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_a = Some(token_vault_a);
         self
@@ -458,7 +432,7 @@ impl<'a, 'b> CollectProtocolFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_b(
         &mut self,
-        token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_b = Some(token_vault_b);
         self
@@ -466,7 +440,7 @@ impl<'a, 'b> CollectProtocolFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_destination_a(
         &mut self,
-        token_destination_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_destination_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_destination_a = Some(token_destination_a);
         self
@@ -474,7 +448,7 @@ impl<'a, 'b> CollectProtocolFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_destination_b(
         &mut self,
-        token_destination_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_destination_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_destination_b = Some(token_destination_b);
         self
@@ -482,7 +456,7 @@ impl<'a, 'b> CollectProtocolFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -491,7 +465,7 @@ impl<'a, 'b> CollectProtocolFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -507,11 +481,7 @@ impl<'a, 'b> CollectProtocolFeesCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -519,7 +489,7 @@ impl<'a, 'b> CollectProtocolFeesCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -527,7 +497,7 @@ impl<'a, 'b> CollectProtocolFeesCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = CollectProtocolFeesCpi {
             __program: self.instruction.__program,
 
@@ -577,19 +547,15 @@ impl<'a, 'b> CollectProtocolFeesCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct CollectProtocolFeesCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    collect_protocol_fees_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_destination_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_destination_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    collect_protocol_fees_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_destination_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_destination_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/collect_protocol_fees_v2.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/collect_protocol_fees_v2.rs
@@ -12,36 +12,36 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct CollectProtocolFeesV2 {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub collect_protocol_fees_authority: solana_program::pubkey::Pubkey,
+    pub collect_protocol_fees_authority: solana_pubkey::Pubkey,
 
-    pub token_mint_a: solana_program::pubkey::Pubkey,
+    pub token_mint_a: solana_pubkey::Pubkey,
 
-    pub token_mint_b: solana_program::pubkey::Pubkey,
+    pub token_mint_b: solana_pubkey::Pubkey,
 
-    pub token_vault_a: solana_program::pubkey::Pubkey,
+    pub token_vault_a: solana_pubkey::Pubkey,
 
-    pub token_vault_b: solana_program::pubkey::Pubkey,
+    pub token_vault_b: solana_pubkey::Pubkey,
 
-    pub token_destination_a: solana_program::pubkey::Pubkey,
+    pub token_destination_a: solana_pubkey::Pubkey,
 
-    pub token_destination_b: solana_program::pubkey::Pubkey,
+    pub token_destination_b: solana_pubkey::Pubkey,
 
-    pub token_program_a: solana_program::pubkey::Pubkey,
+    pub token_program_a: solana_pubkey::Pubkey,
 
-    pub token_program_b: solana_program::pubkey::Pubkey,
+    pub token_program_b: solana_pubkey::Pubkey,
 
-    pub memo_program: solana_program::pubkey::Pubkey,
+    pub memo_program: solana_pubkey::Pubkey,
 }
 
 impl CollectProtocolFeesV2 {
     pub fn instruction(
         &self,
         args: CollectProtocolFeesV2InstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -49,54 +49,51 @@ impl CollectProtocolFeesV2 {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: CollectProtocolFeesV2InstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(12 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.collect_protocol_fees_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_destination_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_destination_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.memo_program,
             false,
         ));
@@ -105,7 +102,7 @@ impl CollectProtocolFeesV2 {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -157,20 +154,20 @@ pub struct CollectProtocolFeesV2InstructionArgs {
 ///   11. `[]` memo_program
 #[derive(Clone, Debug, Default)]
 pub struct CollectProtocolFeesV2Builder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    collect_protocol_fees_authority: Option<solana_program::pubkey::Pubkey>,
-    token_mint_a: Option<solana_program::pubkey::Pubkey>,
-    token_mint_b: Option<solana_program::pubkey::Pubkey>,
-    token_vault_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_b: Option<solana_program::pubkey::Pubkey>,
-    token_destination_a: Option<solana_program::pubkey::Pubkey>,
-    token_destination_b: Option<solana_program::pubkey::Pubkey>,
-    token_program_a: Option<solana_program::pubkey::Pubkey>,
-    token_program_b: Option<solana_program::pubkey::Pubkey>,
-    memo_program: Option<solana_program::pubkey::Pubkey>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    collect_protocol_fees_authority: Option<solana_pubkey::Pubkey>,
+    token_mint_a: Option<solana_pubkey::Pubkey>,
+    token_mint_b: Option<solana_pubkey::Pubkey>,
+    token_vault_a: Option<solana_pubkey::Pubkey>,
+    token_vault_b: Option<solana_pubkey::Pubkey>,
+    token_destination_a: Option<solana_pubkey::Pubkey>,
+    token_destination_b: Option<solana_pubkey::Pubkey>,
+    token_program_a: Option<solana_pubkey::Pubkey>,
+    token_program_b: Option<solana_pubkey::Pubkey>,
+    memo_program: Option<solana_pubkey::Pubkey>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl CollectProtocolFeesV2Builder {
@@ -178,80 +175,65 @@ impl CollectProtocolFeesV2Builder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn collect_protocol_fees_authority(
         &mut self,
-        collect_protocol_fees_authority: solana_program::pubkey::Pubkey,
+        collect_protocol_fees_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.collect_protocol_fees_authority = Some(collect_protocol_fees_authority);
         self
     }
     #[inline(always)]
-    pub fn token_mint_a(&mut self, token_mint_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_a(&mut self, token_mint_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_a = Some(token_mint_a);
         self
     }
     #[inline(always)]
-    pub fn token_mint_b(&mut self, token_mint_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_b(&mut self, token_mint_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_b = Some(token_mint_b);
         self
     }
     #[inline(always)]
-    pub fn token_vault_a(&mut self, token_vault_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_a(&mut self, token_vault_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_a = Some(token_vault_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_b(&mut self, token_vault_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_b(&mut self, token_vault_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn token_destination_a(
-        &mut self,
-        token_destination_a: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_destination_a(&mut self, token_destination_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_destination_a = Some(token_destination_a);
         self
     }
     #[inline(always)]
-    pub fn token_destination_b(
-        &mut self,
-        token_destination_b: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_destination_b(&mut self, token_destination_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_destination_b = Some(token_destination_b);
         self
     }
     #[inline(always)]
-    pub fn token_program_a(
-        &mut self,
-        token_program_a: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_a(&mut self, token_program_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_a = Some(token_program_a);
         self
     }
     #[inline(always)]
-    pub fn token_program_b(
-        &mut self,
-        token_program_b: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_b(&mut self, token_program_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_b = Some(token_program_b);
         self
     }
     #[inline(always)]
-    pub fn memo_program(&mut self, memo_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn memo_program(&mut self, memo_program: solana_pubkey::Pubkey) -> &mut Self {
         self.memo_program = Some(memo_program);
         self
     }
@@ -266,10 +248,7 @@ impl CollectProtocolFeesV2Builder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -277,13 +256,13 @@ impl CollectProtocolFeesV2Builder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = CollectProtocolFeesV2 {
             whirlpools_config: self
                 .whirlpools_config
@@ -316,66 +295,66 @@ impl CollectProtocolFeesV2Builder {
 
 /// `collect_protocol_fees_v2` CPI accounts.
 pub struct CollectProtocolFeesV2CpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub collect_protocol_fees_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub collect_protocol_fees_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_destination_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_destination_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_destination_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_destination_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `collect_protocol_fees_v2` CPI instruction.
 pub struct CollectProtocolFeesV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub collect_protocol_fees_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub collect_protocol_fees_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_destination_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_destination_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_destination_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_destination_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CollectProtocolFeesV2InstructionArgs,
 }
 
 impl<'a, 'b> CollectProtocolFeesV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: CollectProtocolFeesV2CpiAccounts<'a, 'b>,
         args: CollectProtocolFeesV2InstructionArgs,
     ) -> Self {
@@ -397,25 +376,21 @@ impl<'a, 'b> CollectProtocolFeesV2Cpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -424,63 +399,59 @@ impl<'a, 'b> CollectProtocolFeesV2Cpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(12 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.collect_protocol_fees_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_destination_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_destination_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.memo_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -490,7 +461,7 @@ impl<'a, 'b> CollectProtocolFeesV2Cpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -514,9 +485,9 @@ impl<'a, 'b> CollectProtocolFeesV2Cpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -543,7 +514,7 @@ pub struct CollectProtocolFeesV2CpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CollectProtocolFeesV2CpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -566,23 +537,20 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn collect_protocol_fees_authority(
         &mut self,
-        collect_protocol_fees_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        collect_protocol_fees_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collect_protocol_fees_authority = Some(collect_protocol_fees_authority);
         self
@@ -590,7 +558,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_a(
         &mut self,
-        token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_a = Some(token_mint_a);
         self
@@ -598,7 +566,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_b(
         &mut self,
-        token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_b = Some(token_mint_b);
         self
@@ -606,7 +574,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_a(
         &mut self,
-        token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_a = Some(token_vault_a);
         self
@@ -614,7 +582,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_b(
         &mut self,
-        token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_b = Some(token_vault_b);
         self
@@ -622,7 +590,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_destination_a(
         &mut self,
-        token_destination_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_destination_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_destination_a = Some(token_destination_a);
         self
@@ -630,7 +598,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_destination_b(
         &mut self,
-        token_destination_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_destination_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_destination_b = Some(token_destination_b);
         self
@@ -638,7 +606,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program_a(
         &mut self,
-        token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_a = Some(token_program_a);
         self
@@ -646,7 +614,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program_b(
         &mut self,
-        token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_b = Some(token_program_b);
         self
@@ -654,7 +622,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn memo_program(
         &mut self,
-        memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+        memo_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.memo_program = Some(memo_program);
         self
@@ -672,7 +640,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -688,11 +656,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -700,7 +664,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -708,7 +672,7 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = CollectProtocolFeesV2InstructionArgs {
             remaining_accounts_info: self.instruction.remaining_accounts_info.clone(),
         };
@@ -782,24 +746,20 @@ impl<'a, 'b> CollectProtocolFeesV2CpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct CollectProtocolFeesV2CpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    collect_protocol_fees_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_destination_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_destination_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    memo_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    collect_protocol_fees_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_destination_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_destination_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    memo_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/collect_reward.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/collect_reward.rs
@@ -11,26 +11,26 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct CollectReward {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub position_authority: solana_program::pubkey::Pubkey,
+    pub position_authority: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub reward_owner_account: solana_program::pubkey::Pubkey,
+    pub reward_owner_account: solana_pubkey::Pubkey,
 
-    pub reward_vault: solana_program::pubkey::Pubkey,
+    pub reward_vault: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 }
 
 impl CollectReward {
     pub fn instruction(
         &self,
         args: CollectRewardInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -38,34 +38,31 @@ impl CollectReward {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: CollectRewardInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpool,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.reward_owner_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.reward_vault,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
@@ -74,7 +71,7 @@ impl CollectReward {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -121,15 +118,15 @@ pub struct CollectRewardInstructionArgs {
 ///   6. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 #[derive(Clone, Debug, Default)]
 pub struct CollectRewardBuilder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    position_authority: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    reward_owner_account: Option<solana_program::pubkey::Pubkey>,
-    reward_vault: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    position_authority: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    reward_owner_account: Option<solana_pubkey::Pubkey>,
+    reward_vault: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
     reward_index: Option<u8>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl CollectRewardBuilder {
@@ -137,27 +134,24 @@ impl CollectRewardBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn position_authority(
-        &mut self,
-        position_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_authority(&mut self, position_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
@@ -165,19 +159,19 @@ impl CollectRewardBuilder {
     #[inline(always)]
     pub fn reward_owner_account(
         &mut self,
-        reward_owner_account: solana_program::pubkey::Pubkey,
+        reward_owner_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.reward_owner_account = Some(reward_owner_account);
         self
     }
     #[inline(always)]
-    pub fn reward_vault(&mut self, reward_vault: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn reward_vault(&mut self, reward_vault: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_vault = Some(reward_vault);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
@@ -188,10 +182,7 @@ impl CollectRewardBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -199,13 +190,13 @@ impl CollectRewardBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = CollectReward {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
             position_authority: self
@@ -219,7 +210,7 @@ impl CollectRewardBuilder {
                 .reward_owner_account
                 .expect("reward_owner_account is not set"),
             reward_vault: self.reward_vault.expect("reward_vault is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
         };
@@ -233,46 +224,46 @@ impl CollectRewardBuilder {
 
 /// `collect_reward` CPI accounts.
 pub struct CollectRewardCpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_owner_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `collect_reward` CPI instruction.
 pub struct CollectRewardCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_owner_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CollectRewardInstructionArgs,
 }
 
 impl<'a, 'b> CollectRewardCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: CollectRewardCpiAccounts<'a, 'b>,
         args: CollectRewardInstructionArgs,
     ) -> Self {
@@ -289,25 +280,21 @@ impl<'a, 'b> CollectRewardCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -316,43 +303,39 @@ impl<'a, 'b> CollectRewardCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.reward_owner_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.reward_vault.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -362,7 +345,7 @@ impl<'a, 'b> CollectRewardCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -381,9 +364,9 @@ impl<'a, 'b> CollectRewardCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -405,7 +388,7 @@ pub struct CollectRewardCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> CollectRewardCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CollectRewardCpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -421,33 +404,27 @@ impl<'a, 'b> CollectRewardCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn position_authority(
         &mut self,
-        position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
@@ -455,7 +432,7 @@ impl<'a, 'b> CollectRewardCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_owner_account(
         &mut self,
-        reward_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_owner_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_owner_account = Some(reward_owner_account);
         self
@@ -463,7 +440,7 @@ impl<'a, 'b> CollectRewardCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_vault(
         &mut self,
-        reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_vault: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_vault = Some(reward_vault);
         self
@@ -471,7 +448,7 @@ impl<'a, 'b> CollectRewardCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -485,7 +462,7 @@ impl<'a, 'b> CollectRewardCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -501,11 +478,7 @@ impl<'a, 'b> CollectRewardCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -513,7 +486,7 @@ impl<'a, 'b> CollectRewardCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -521,7 +494,7 @@ impl<'a, 'b> CollectRewardCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = CollectRewardInstructionArgs {
             reward_index: self
                 .instruction
@@ -571,19 +544,15 @@ impl<'a, 'b> CollectRewardCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct CollectRewardCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_owner_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_owner_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_vault: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     reward_index: Option<u8>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/collect_reward_v2.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/collect_reward_v2.rs
@@ -12,30 +12,30 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct CollectRewardV2 {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub position_authority: solana_program::pubkey::Pubkey,
+    pub position_authority: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub reward_owner_account: solana_program::pubkey::Pubkey,
+    pub reward_owner_account: solana_pubkey::Pubkey,
 
-    pub reward_mint: solana_program::pubkey::Pubkey,
+    pub reward_mint: solana_pubkey::Pubkey,
 
-    pub reward_vault: solana_program::pubkey::Pubkey,
+    pub reward_vault: solana_pubkey::Pubkey,
 
-    pub reward_token_program: solana_program::pubkey::Pubkey,
+    pub reward_token_program: solana_pubkey::Pubkey,
 
-    pub memo_program: solana_program::pubkey::Pubkey,
+    pub memo_program: solana_pubkey::Pubkey,
 }
 
 impl CollectRewardV2 {
     pub fn instruction(
         &self,
         args: CollectRewardV2InstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -43,42 +43,39 @@ impl CollectRewardV2 {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: CollectRewardV2InstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpool,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.reward_owner_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_mint,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.reward_vault,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.memo_program,
             false,
         ));
@@ -87,7 +84,7 @@ impl CollectRewardV2 {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -137,18 +134,18 @@ pub struct CollectRewardV2InstructionArgs {
 ///   8. `[]` memo_program
 #[derive(Clone, Debug, Default)]
 pub struct CollectRewardV2Builder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    position_authority: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    reward_owner_account: Option<solana_program::pubkey::Pubkey>,
-    reward_mint: Option<solana_program::pubkey::Pubkey>,
-    reward_vault: Option<solana_program::pubkey::Pubkey>,
-    reward_token_program: Option<solana_program::pubkey::Pubkey>,
-    memo_program: Option<solana_program::pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    position_authority: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    reward_owner_account: Option<solana_pubkey::Pubkey>,
+    reward_mint: Option<solana_pubkey::Pubkey>,
+    reward_vault: Option<solana_pubkey::Pubkey>,
+    reward_token_program: Option<solana_pubkey::Pubkey>,
+    memo_program: Option<solana_pubkey::Pubkey>,
     reward_index: Option<u8>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl CollectRewardV2Builder {
@@ -156,27 +153,24 @@ impl CollectRewardV2Builder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn position_authority(
-        &mut self,
-        position_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_authority(&mut self, position_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
@@ -184,31 +178,31 @@ impl CollectRewardV2Builder {
     #[inline(always)]
     pub fn reward_owner_account(
         &mut self,
-        reward_owner_account: solana_program::pubkey::Pubkey,
+        reward_owner_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.reward_owner_account = Some(reward_owner_account);
         self
     }
     #[inline(always)]
-    pub fn reward_mint(&mut self, reward_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn reward_mint(&mut self, reward_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_mint = Some(reward_mint);
         self
     }
     #[inline(always)]
-    pub fn reward_vault(&mut self, reward_vault: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn reward_vault(&mut self, reward_vault: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_vault = Some(reward_vault);
         self
     }
     #[inline(always)]
     pub fn reward_token_program(
         &mut self,
-        reward_token_program: solana_program::pubkey::Pubkey,
+        reward_token_program: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.reward_token_program = Some(reward_token_program);
         self
     }
     #[inline(always)]
-    pub fn memo_program(&mut self, memo_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn memo_program(&mut self, memo_program: solana_pubkey::Pubkey) -> &mut Self {
         self.memo_program = Some(memo_program);
         self
     }
@@ -228,10 +222,7 @@ impl CollectRewardV2Builder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -239,13 +230,13 @@ impl CollectRewardV2Builder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = CollectRewardV2 {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
             position_authority: self
@@ -276,54 +267,54 @@ impl CollectRewardV2Builder {
 
 /// `collect_reward_v2` CPI accounts.
 pub struct CollectRewardV2CpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_owner_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `collect_reward_v2` CPI instruction.
 pub struct CollectRewardV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_owner_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CollectRewardV2InstructionArgs,
 }
 
 impl<'a, 'b> CollectRewardV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: CollectRewardV2CpiAccounts<'a, 'b>,
         args: CollectRewardV2InstructionArgs,
     ) -> Self {
@@ -342,25 +333,21 @@ impl<'a, 'b> CollectRewardV2Cpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -369,51 +356,47 @@ impl<'a, 'b> CollectRewardV2Cpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.reward_owner_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.reward_vault.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.memo_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -423,7 +406,7 @@ impl<'a, 'b> CollectRewardV2Cpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -444,9 +427,9 @@ impl<'a, 'b> CollectRewardV2Cpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -470,7 +453,7 @@ pub struct CollectRewardV2CpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> CollectRewardV2CpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CollectRewardV2CpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -489,33 +472,27 @@ impl<'a, 'b> CollectRewardV2CpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn position_authority(
         &mut self,
-        position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
@@ -523,7 +500,7 @@ impl<'a, 'b> CollectRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_owner_account(
         &mut self,
-        reward_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_owner_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_owner_account = Some(reward_owner_account);
         self
@@ -531,7 +508,7 @@ impl<'a, 'b> CollectRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_mint(
         &mut self,
-        reward_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_mint = Some(reward_mint);
         self
@@ -539,7 +516,7 @@ impl<'a, 'b> CollectRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_vault(
         &mut self,
-        reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_vault: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_vault = Some(reward_vault);
         self
@@ -547,7 +524,7 @@ impl<'a, 'b> CollectRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_token_program(
         &mut self,
-        reward_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_token_program = Some(reward_token_program);
         self
@@ -555,7 +532,7 @@ impl<'a, 'b> CollectRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn memo_program(
         &mut self,
-        memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+        memo_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.memo_program = Some(memo_program);
         self
@@ -578,7 +555,7 @@ impl<'a, 'b> CollectRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -594,11 +571,7 @@ impl<'a, 'b> CollectRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -606,7 +579,7 @@ impl<'a, 'b> CollectRewardV2CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -614,7 +587,7 @@ impl<'a, 'b> CollectRewardV2CpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = CollectRewardV2InstructionArgs {
             reward_index: self
                 .instruction
@@ -675,22 +648,18 @@ impl<'a, 'b> CollectRewardV2CpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct CollectRewardV2CpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_owner_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    memo_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_owner_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_vault: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    memo_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     reward_index: Option<u8>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/decrease_liquidity.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/decrease_liquidity.rs
@@ -11,34 +11,34 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct DecreaseLiquidity {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub position_authority: solana_program::pubkey::Pubkey,
+    pub position_authority: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub token_owner_account_a: solana_program::pubkey::Pubkey,
+    pub token_owner_account_a: solana_pubkey::Pubkey,
 
-    pub token_owner_account_b: solana_program::pubkey::Pubkey,
+    pub token_owner_account_b: solana_pubkey::Pubkey,
 
-    pub token_vault_a: solana_program::pubkey::Pubkey,
+    pub token_vault_a: solana_pubkey::Pubkey,
 
-    pub token_vault_b: solana_program::pubkey::Pubkey,
+    pub token_vault_b: solana_pubkey::Pubkey,
 
-    pub tick_array_lower: solana_program::pubkey::Pubkey,
+    pub tick_array_lower: solana_pubkey::Pubkey,
 
-    pub tick_array_upper: solana_program::pubkey::Pubkey,
+    pub tick_array_upper: solana_pubkey::Pubkey,
 }
 
 impl DecreaseLiquidity {
     pub fn instruction(
         &self,
         args: DecreaseLiquidityInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -46,50 +46,44 @@ impl DecreaseLiquidity {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: DecreaseLiquidityInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_lower,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_upper,
             false,
         ));
@@ -98,7 +92,7 @@ impl DecreaseLiquidity {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -151,21 +145,21 @@ pub struct DecreaseLiquidityInstructionArgs {
 ///   10. `[writable]` tick_array_upper
 #[derive(Clone, Debug, Default)]
 pub struct DecreaseLiquidityBuilder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    position_authority: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_a: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_b: Option<solana_program::pubkey::Pubkey>,
-    token_vault_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_b: Option<solana_program::pubkey::Pubkey>,
-    tick_array_lower: Option<solana_program::pubkey::Pubkey>,
-    tick_array_upper: Option<solana_program::pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    position_authority: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    token_owner_account_a: Option<solana_pubkey::Pubkey>,
+    token_owner_account_b: Option<solana_pubkey::Pubkey>,
+    token_vault_a: Option<solana_pubkey::Pubkey>,
+    token_vault_b: Option<solana_pubkey::Pubkey>,
+    tick_array_lower: Option<solana_pubkey::Pubkey>,
+    tick_array_upper: Option<solana_pubkey::Pubkey>,
     liquidity_amount: Option<u128>,
     token_min_a: Option<u64>,
     token_min_b: Option<u64>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl DecreaseLiquidityBuilder {
@@ -173,33 +167,30 @@ impl DecreaseLiquidityBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn position_authority(
-        &mut self,
-        position_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_authority(&mut self, position_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
@@ -207,7 +198,7 @@ impl DecreaseLiquidityBuilder {
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: solana_program::pubkey::Pubkey,
+        token_owner_account_a: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_a = Some(token_owner_account_a);
         self
@@ -215,34 +206,28 @@ impl DecreaseLiquidityBuilder {
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: solana_program::pubkey::Pubkey,
+        token_owner_account_b: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_b = Some(token_owner_account_b);
         self
     }
     #[inline(always)]
-    pub fn token_vault_a(&mut self, token_vault_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_a(&mut self, token_vault_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_a = Some(token_vault_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_b(&mut self, token_vault_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_b(&mut self, token_vault_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn tick_array_lower(
-        &mut self,
-        tick_array_lower: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_lower(&mut self, tick_array_lower: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_lower = Some(tick_array_lower);
         self
     }
     #[inline(always)]
-    pub fn tick_array_upper(
-        &mut self,
-        tick_array_upper: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_upper(&mut self, tick_array_upper: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_upper = Some(tick_array_upper);
         self
     }
@@ -263,10 +248,7 @@ impl DecreaseLiquidityBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -274,16 +256,16 @@ impl DecreaseLiquidityBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = DecreaseLiquidity {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             position_authority: self
@@ -319,62 +301,62 @@ impl DecreaseLiquidityBuilder {
 
 /// `decrease_liquidity` CPI accounts.
 pub struct DecreaseLiquidityCpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `decrease_liquidity` CPI instruction.
 pub struct DecreaseLiquidityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: DecreaseLiquidityInstructionArgs,
 }
 
 impl<'a, 'b> DecreaseLiquidityCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: DecreaseLiquidityCpiAccounts<'a, 'b>,
         args: DecreaseLiquidityInstructionArgs,
     ) -> Self {
@@ -395,25 +377,21 @@ impl<'a, 'b> DecreaseLiquidityCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -422,59 +400,55 @@ impl<'a, 'b> DecreaseLiquidityCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_lower.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_upper.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -484,7 +458,7 @@ impl<'a, 'b> DecreaseLiquidityCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -507,9 +481,9 @@ impl<'a, 'b> DecreaseLiquidityCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -535,7 +509,7 @@ pub struct DecreaseLiquidityCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DecreaseLiquidityCpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -557,17 +531,14 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -575,23 +546,20 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_authority(
         &mut self,
-        position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
@@ -599,7 +567,7 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_a = Some(token_owner_account_a);
         self
@@ -607,7 +575,7 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_b = Some(token_owner_account_b);
         self
@@ -615,7 +583,7 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_a(
         &mut self,
-        token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_a = Some(token_vault_a);
         self
@@ -623,7 +591,7 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_b(
         &mut self,
-        token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_b = Some(token_vault_b);
         self
@@ -631,7 +599,7 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_lower(
         &mut self,
-        tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_lower = Some(tick_array_lower);
         self
@@ -639,7 +607,7 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_upper(
         &mut self,
-        tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_upper = Some(tick_array_upper);
         self
@@ -663,7 +631,7 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -679,11 +647,7 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -691,7 +655,7 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -699,7 +663,7 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = DecreaseLiquidityInstructionArgs {
             liquidity_amount: self
                 .instruction
@@ -779,25 +743,21 @@ impl<'a, 'b> DecreaseLiquidityCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct DecreaseLiquidityCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_lower: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_upper: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_lower: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_upper: Option<&'b solana_account_info::AccountInfo<'a>>,
     liquidity_amount: Option<u128>,
     token_min_a: Option<u64>,
     token_min_b: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/decrease_liquidity_v2.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/decrease_liquidity_v2.rs
@@ -12,42 +12,42 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct DecreaseLiquidityV2 {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub token_program_a: solana_program::pubkey::Pubkey,
+    pub token_program_a: solana_pubkey::Pubkey,
 
-    pub token_program_b: solana_program::pubkey::Pubkey,
+    pub token_program_b: solana_pubkey::Pubkey,
 
-    pub memo_program: solana_program::pubkey::Pubkey,
+    pub memo_program: solana_pubkey::Pubkey,
 
-    pub position_authority: solana_program::pubkey::Pubkey,
+    pub position_authority: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub token_mint_a: solana_program::pubkey::Pubkey,
+    pub token_mint_a: solana_pubkey::Pubkey,
 
-    pub token_mint_b: solana_program::pubkey::Pubkey,
+    pub token_mint_b: solana_pubkey::Pubkey,
 
-    pub token_owner_account_a: solana_program::pubkey::Pubkey,
+    pub token_owner_account_a: solana_pubkey::Pubkey,
 
-    pub token_owner_account_b: solana_program::pubkey::Pubkey,
+    pub token_owner_account_b: solana_pubkey::Pubkey,
 
-    pub token_vault_a: solana_program::pubkey::Pubkey,
+    pub token_vault_a: solana_pubkey::Pubkey,
 
-    pub token_vault_b: solana_program::pubkey::Pubkey,
+    pub token_vault_b: solana_pubkey::Pubkey,
 
-    pub tick_array_lower: solana_program::pubkey::Pubkey,
+    pub tick_array_lower: solana_pubkey::Pubkey,
 
-    pub tick_array_upper: solana_program::pubkey::Pubkey,
+    pub tick_array_upper: solana_pubkey::Pubkey,
 }
 
 impl DecreaseLiquidityV2 {
     pub fn instruction(
         &self,
         args: DecreaseLiquidityV2InstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -55,66 +55,60 @@ impl DecreaseLiquidityV2 {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: DecreaseLiquidityV2InstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(15 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.memo_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_lower,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_upper,
             false,
         ));
@@ -123,7 +117,7 @@ impl DecreaseLiquidityV2 {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -181,26 +175,26 @@ pub struct DecreaseLiquidityV2InstructionArgs {
 ///   14. `[writable]` tick_array_upper
 #[derive(Clone, Debug, Default)]
 pub struct DecreaseLiquidityV2Builder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    token_program_a: Option<solana_program::pubkey::Pubkey>,
-    token_program_b: Option<solana_program::pubkey::Pubkey>,
-    memo_program: Option<solana_program::pubkey::Pubkey>,
-    position_authority: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    token_mint_a: Option<solana_program::pubkey::Pubkey>,
-    token_mint_b: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_a: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_b: Option<solana_program::pubkey::Pubkey>,
-    token_vault_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_b: Option<solana_program::pubkey::Pubkey>,
-    tick_array_lower: Option<solana_program::pubkey::Pubkey>,
-    tick_array_upper: Option<solana_program::pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    token_program_a: Option<solana_pubkey::Pubkey>,
+    token_program_b: Option<solana_pubkey::Pubkey>,
+    memo_program: Option<solana_pubkey::Pubkey>,
+    position_authority: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    token_mint_a: Option<solana_pubkey::Pubkey>,
+    token_mint_b: Option<solana_pubkey::Pubkey>,
+    token_owner_account_a: Option<solana_pubkey::Pubkey>,
+    token_owner_account_b: Option<solana_pubkey::Pubkey>,
+    token_vault_a: Option<solana_pubkey::Pubkey>,
+    token_vault_b: Option<solana_pubkey::Pubkey>,
+    tick_array_lower: Option<solana_pubkey::Pubkey>,
+    tick_array_upper: Option<solana_pubkey::Pubkey>,
     liquidity_amount: Option<u128>,
     token_min_a: Option<u64>,
     token_min_b: Option<u64>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl DecreaseLiquidityV2Builder {
@@ -208,66 +202,57 @@ impl DecreaseLiquidityV2Builder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn token_program_a(
-        &mut self,
-        token_program_a: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_a(&mut self, token_program_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_a = Some(token_program_a);
         self
     }
     #[inline(always)]
-    pub fn token_program_b(
-        &mut self,
-        token_program_b: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_b(&mut self, token_program_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_b = Some(token_program_b);
         self
     }
     #[inline(always)]
-    pub fn memo_program(&mut self, memo_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn memo_program(&mut self, memo_program: solana_pubkey::Pubkey) -> &mut Self {
         self.memo_program = Some(memo_program);
         self
     }
     #[inline(always)]
-    pub fn position_authority(
-        &mut self,
-        position_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_authority(&mut self, position_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
     }
     #[inline(always)]
-    pub fn token_mint_a(&mut self, token_mint_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_a(&mut self, token_mint_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_a = Some(token_mint_a);
         self
     }
     #[inline(always)]
-    pub fn token_mint_b(&mut self, token_mint_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_b(&mut self, token_mint_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_b = Some(token_mint_b);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: solana_program::pubkey::Pubkey,
+        token_owner_account_a: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_a = Some(token_owner_account_a);
         self
@@ -275,34 +260,28 @@ impl DecreaseLiquidityV2Builder {
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: solana_program::pubkey::Pubkey,
+        token_owner_account_b: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_b = Some(token_owner_account_b);
         self
     }
     #[inline(always)]
-    pub fn token_vault_a(&mut self, token_vault_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_a(&mut self, token_vault_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_a = Some(token_vault_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_b(&mut self, token_vault_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_b(&mut self, token_vault_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn tick_array_lower(
-        &mut self,
-        tick_array_lower: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_lower(&mut self, tick_array_lower: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_lower = Some(tick_array_lower);
         self
     }
     #[inline(always)]
-    pub fn tick_array_upper(
-        &mut self,
-        tick_array_upper: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_upper(&mut self, tick_array_upper: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_upper = Some(tick_array_upper);
         self
     }
@@ -332,10 +311,7 @@ impl DecreaseLiquidityV2Builder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -343,13 +319,13 @@ impl DecreaseLiquidityV2Builder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = DecreaseLiquidityV2 {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
             token_program_a: self.token_program_a.expect("token_program_a is not set"),
@@ -391,78 +367,78 @@ impl DecreaseLiquidityV2Builder {
 
 /// `decrease_liquidity_v2` CPI accounts.
 pub struct DecreaseLiquidityV2CpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `decrease_liquidity_v2` CPI instruction.
 pub struct DecreaseLiquidityV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: DecreaseLiquidityV2InstructionArgs,
 }
 
 impl<'a, 'b> DecreaseLiquidityV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: DecreaseLiquidityV2CpiAccounts<'a, 'b>,
         args: DecreaseLiquidityV2InstructionArgs,
     ) -> Self {
@@ -487,25 +463,21 @@ impl<'a, 'b> DecreaseLiquidityV2Cpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -514,75 +486,71 @@ impl<'a, 'b> DecreaseLiquidityV2Cpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(15 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.memo_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_lower.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_upper.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -592,7 +560,7 @@ impl<'a, 'b> DecreaseLiquidityV2Cpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -619,9 +587,9 @@ impl<'a, 'b> DecreaseLiquidityV2Cpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -651,7 +619,7 @@ pub struct DecreaseLiquidityV2CpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DecreaseLiquidityV2CpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -678,17 +646,14 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token_program_a(
         &mut self,
-        token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_a = Some(token_program_a);
         self
@@ -696,7 +661,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program_b(
         &mut self,
-        token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_b = Some(token_program_b);
         self
@@ -704,7 +669,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn memo_program(
         &mut self,
-        memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+        memo_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.memo_program = Some(memo_program);
         self
@@ -712,23 +677,20 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_authority(
         &mut self,
-        position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
@@ -736,7 +698,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_a(
         &mut self,
-        token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_a = Some(token_mint_a);
         self
@@ -744,7 +706,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_b(
         &mut self,
-        token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_b = Some(token_mint_b);
         self
@@ -752,7 +714,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_a = Some(token_owner_account_a);
         self
@@ -760,7 +722,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_b = Some(token_owner_account_b);
         self
@@ -768,7 +730,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_a(
         &mut self,
-        token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_a = Some(token_vault_a);
         self
@@ -776,7 +738,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_b(
         &mut self,
-        token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_b = Some(token_vault_b);
         self
@@ -784,7 +746,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_lower(
         &mut self,
-        tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_lower = Some(tick_array_lower);
         self
@@ -792,7 +754,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_upper(
         &mut self,
-        tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_upper = Some(tick_array_upper);
         self
@@ -825,7 +787,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -841,11 +803,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -853,7 +811,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -861,7 +819,7 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = DecreaseLiquidityV2InstructionArgs {
             liquidity_amount: self
                 .instruction
@@ -962,30 +920,26 @@ impl<'a, 'b> DecreaseLiquidityV2CpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct DecreaseLiquidityV2CpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    memo_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_lower: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_upper: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    memo_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_lower: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_upper: Option<&'b solana_account_info::AccountInfo<'a>>,
     liquidity_amount: Option<u128>,
     token_min_a: Option<u64>,
     token_min_b: Option<u64>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/delete_position_bundle.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/delete_position_bundle.rs
@@ -11,58 +11,55 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct DeletePositionBundle {
-    pub position_bundle: solana_program::pubkey::Pubkey,
+    pub position_bundle: solana_pubkey::Pubkey,
 
-    pub position_bundle_mint: solana_program::pubkey::Pubkey,
+    pub position_bundle_mint: solana_pubkey::Pubkey,
 
-    pub position_bundle_token_account: solana_program::pubkey::Pubkey,
+    pub position_bundle_token_account: solana_pubkey::Pubkey,
 
-    pub position_bundle_owner: solana_program::pubkey::Pubkey,
+    pub position_bundle_owner: solana_pubkey::Pubkey,
 
-    pub receiver: solana_program::pubkey::Pubkey,
+    pub receiver: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 }
 
 impl DeletePositionBundle {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_bundle,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_bundle_mint,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_bundle_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_bundle_owner,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.receiver,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.receiver, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&DeletePositionBundleInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -102,13 +99,13 @@ impl Default for DeletePositionBundleInstructionData {
 ///   5. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 #[derive(Clone, Debug, Default)]
 pub struct DeletePositionBundleBuilder {
-    position_bundle: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_mint: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_token_account: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_owner: Option<solana_program::pubkey::Pubkey>,
-    receiver: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    position_bundle: Option<solana_pubkey::Pubkey>,
+    position_bundle_mint: Option<solana_pubkey::Pubkey>,
+    position_bundle_token_account: Option<solana_pubkey::Pubkey>,
+    position_bundle_owner: Option<solana_pubkey::Pubkey>,
+    receiver: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl DeletePositionBundleBuilder {
@@ -116,17 +113,14 @@ impl DeletePositionBundleBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn position_bundle(
-        &mut self,
-        position_bundle: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_bundle(&mut self, position_bundle: solana_pubkey::Pubkey) -> &mut Self {
         self.position_bundle = Some(position_bundle);
         self
     }
     #[inline(always)]
     pub fn position_bundle_mint(
         &mut self,
-        position_bundle_mint: solana_program::pubkey::Pubkey,
+        position_bundle_mint: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_mint = Some(position_bundle_mint);
         self
@@ -134,7 +128,7 @@ impl DeletePositionBundleBuilder {
     #[inline(always)]
     pub fn position_bundle_token_account(
         &mut self,
-        position_bundle_token_account: solana_program::pubkey::Pubkey,
+        position_bundle_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_token_account = Some(position_bundle_token_account);
         self
@@ -142,28 +136,25 @@ impl DeletePositionBundleBuilder {
     #[inline(always)]
     pub fn position_bundle_owner(
         &mut self,
-        position_bundle_owner: solana_program::pubkey::Pubkey,
+        position_bundle_owner: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_owner = Some(position_bundle_owner);
         self
     }
     #[inline(always)]
-    pub fn receiver(&mut self, receiver: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn receiver(&mut self, receiver: solana_pubkey::Pubkey) -> &mut Self {
         self.receiver = Some(receiver);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -171,13 +162,13 @@ impl DeletePositionBundleBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = DeletePositionBundle {
             position_bundle: self.position_bundle.expect("position_bundle is not set"),
             position_bundle_mint: self
@@ -190,7 +181,7 @@ impl DeletePositionBundleBuilder {
                 .position_bundle_owner
                 .expect("position_bundle_owner is not set"),
             receiver: self.receiver.expect("receiver is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
         };
@@ -201,40 +192,40 @@ impl DeletePositionBundleBuilder {
 
 /// `delete_position_bundle` CPI accounts.
 pub struct DeletePositionBundleCpiAccounts<'a, 'b> {
-    pub position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub receiver: &'b solana_program::account_info::AccountInfo<'a>,
+    pub receiver: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `delete_position_bundle` CPI instruction.
 pub struct DeletePositionBundleCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub receiver: &'b solana_program::account_info::AccountInfo<'a>,
+    pub receiver: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> DeletePositionBundleCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: DeletePositionBundleCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -248,25 +239,21 @@ impl<'a, 'b> DeletePositionBundleCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -275,39 +262,35 @@ impl<'a, 'b> DeletePositionBundleCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_bundle.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_bundle_mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_bundle_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_bundle_owner.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.receiver.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -315,7 +298,7 @@ impl<'a, 'b> DeletePositionBundleCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&DeletePositionBundleInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -333,9 +316,9 @@ impl<'a, 'b> DeletePositionBundleCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -356,7 +339,7 @@ pub struct DeletePositionBundleCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> DeletePositionBundleCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DeletePositionBundleCpiBuilderInstruction {
             __program: program,
             position_bundle: None,
@@ -372,7 +355,7 @@ impl<'a, 'b> DeletePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle(
         &mut self,
-        position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle = Some(position_bundle);
         self
@@ -380,7 +363,7 @@ impl<'a, 'b> DeletePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_mint(
         &mut self,
-        position_bundle_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_mint = Some(position_bundle_mint);
         self
@@ -388,7 +371,7 @@ impl<'a, 'b> DeletePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_token_account(
         &mut self,
-        position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_token_account = Some(position_bundle_token_account);
         self
@@ -396,23 +379,20 @@ impl<'a, 'b> DeletePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_owner(
         &mut self,
-        position_bundle_owner: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_owner: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_owner = Some(position_bundle_owner);
         self
     }
     #[inline(always)]
-    pub fn receiver(
-        &mut self,
-        receiver: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn receiver(&mut self, receiver: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.receiver = Some(receiver);
         self
     }
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -421,7 +401,7 @@ impl<'a, 'b> DeletePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -437,11 +417,7 @@ impl<'a, 'b> DeletePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -449,7 +425,7 @@ impl<'a, 'b> DeletePositionBundleCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -457,7 +433,7 @@ impl<'a, 'b> DeletePositionBundleCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = DeletePositionBundleCpi {
             __program: self.instruction.__program,
 
@@ -497,17 +473,13 @@ impl<'a, 'b> DeletePositionBundleCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct DeletePositionBundleCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    position_bundle: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    receiver: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    position_bundle: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_owner: Option<&'b solana_account_info::AccountInfo<'a>>,
+    receiver: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/delete_token_badge.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/delete_token_badge.rs
@@ -11,58 +11,55 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct DeleteTokenBadge {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub whirlpools_config_extension: solana_program::pubkey::Pubkey,
+    pub whirlpools_config_extension: solana_pubkey::Pubkey,
 
-    pub token_badge_authority: solana_program::pubkey::Pubkey,
+    pub token_badge_authority: solana_pubkey::Pubkey,
 
-    pub token_mint: solana_program::pubkey::Pubkey,
+    pub token_mint: solana_pubkey::Pubkey,
 
-    pub token_badge: solana_program::pubkey::Pubkey,
+    pub token_badge: solana_pubkey::Pubkey,
 
-    pub receiver: solana_program::pubkey::Pubkey,
+    pub receiver: solana_pubkey::Pubkey,
 }
 
 impl DeleteTokenBadge {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config_extension,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_badge_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_badge,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.receiver,
-            false,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.receiver, false));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&DeleteTokenBadgeInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -102,13 +99,13 @@ impl Default for DeleteTokenBadgeInstructionData {
 ///   5. `[writable]` receiver
 #[derive(Clone, Debug, Default)]
 pub struct DeleteTokenBadgeBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    whirlpools_config_extension: Option<solana_program::pubkey::Pubkey>,
-    token_badge_authority: Option<solana_program::pubkey::Pubkey>,
-    token_mint: Option<solana_program::pubkey::Pubkey>,
-    token_badge: Option<solana_program::pubkey::Pubkey>,
-    receiver: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    whirlpools_config_extension: Option<solana_pubkey::Pubkey>,
+    token_badge_authority: Option<solana_pubkey::Pubkey>,
+    token_mint: Option<solana_pubkey::Pubkey>,
+    token_badge: Option<solana_pubkey::Pubkey>,
+    receiver: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl DeleteTokenBadgeBuilder {
@@ -116,17 +113,14 @@ impl DeleteTokenBadgeBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
     pub fn whirlpools_config_extension(
         &mut self,
-        whirlpools_config_extension: solana_program::pubkey::Pubkey,
+        whirlpools_config_extension: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.whirlpools_config_extension = Some(whirlpools_config_extension);
         self
@@ -134,32 +128,29 @@ impl DeleteTokenBadgeBuilder {
     #[inline(always)]
     pub fn token_badge_authority(
         &mut self,
-        token_badge_authority: solana_program::pubkey::Pubkey,
+        token_badge_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_badge_authority = Some(token_badge_authority);
         self
     }
     #[inline(always)]
-    pub fn token_mint(&mut self, token_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint(&mut self, token_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint = Some(token_mint);
         self
     }
     #[inline(always)]
-    pub fn token_badge(&mut self, token_badge: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_badge(&mut self, token_badge: solana_pubkey::Pubkey) -> &mut Self {
         self.token_badge = Some(token_badge);
         self
     }
     #[inline(always)]
-    pub fn receiver(&mut self, receiver: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn receiver(&mut self, receiver: solana_pubkey::Pubkey) -> &mut Self {
         self.receiver = Some(receiver);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -167,13 +158,13 @@ impl DeleteTokenBadgeBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = DeleteTokenBadge {
             whirlpools_config: self
                 .whirlpools_config
@@ -195,40 +186,40 @@ impl DeleteTokenBadgeBuilder {
 
 /// `delete_token_badge` CPI accounts.
 pub struct DeleteTokenBadgeCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config_extension: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_badge_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_badge_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_badge: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_badge: &'b solana_account_info::AccountInfo<'a>,
 
-    pub receiver: &'b solana_program::account_info::AccountInfo<'a>,
+    pub receiver: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `delete_token_badge` CPI instruction.
 pub struct DeleteTokenBadgeCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config_extension: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_badge_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_badge_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_badge: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_badge: &'b solana_account_info::AccountInfo<'a>,
 
-    pub receiver: &'b solana_program::account_info::AccountInfo<'a>,
+    pub receiver: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> DeleteTokenBadgeCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: DeleteTokenBadgeCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -242,25 +233,21 @@ impl<'a, 'b> DeleteTokenBadgeCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -269,39 +256,35 @@ impl<'a, 'b> DeleteTokenBadgeCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config_extension.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_badge_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_badge.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.receiver.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -309,7 +292,7 @@ impl<'a, 'b> DeleteTokenBadgeCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&DeleteTokenBadgeInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -327,9 +310,9 @@ impl<'a, 'b> DeleteTokenBadgeCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -350,7 +333,7 @@ pub struct DeleteTokenBadgeCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> DeleteTokenBadgeCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DeleteTokenBadgeCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -366,7 +349,7 @@ impl<'a, 'b> DeleteTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
@@ -374,7 +357,7 @@ impl<'a, 'b> DeleteTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config_extension(
         &mut self,
-        whirlpools_config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config_extension: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config_extension = Some(whirlpools_config_extension);
         self
@@ -382,7 +365,7 @@ impl<'a, 'b> DeleteTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_badge_authority(
         &mut self,
-        token_badge_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        token_badge_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_badge_authority = Some(token_badge_authority);
         self
@@ -390,7 +373,7 @@ impl<'a, 'b> DeleteTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint(
         &mut self,
-        token_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint = Some(token_mint);
         self
@@ -398,16 +381,13 @@ impl<'a, 'b> DeleteTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_badge(
         &mut self,
-        token_badge: &'b solana_program::account_info::AccountInfo<'a>,
+        token_badge: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_badge = Some(token_badge);
         self
     }
     #[inline(always)]
-    pub fn receiver(
-        &mut self,
-        receiver: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn receiver(&mut self, receiver: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.receiver = Some(receiver);
         self
     }
@@ -415,7 +395,7 @@ impl<'a, 'b> DeleteTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -431,11 +411,7 @@ impl<'a, 'b> DeleteTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -443,7 +419,7 @@ impl<'a, 'b> DeleteTokenBadgeCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -451,7 +427,7 @@ impl<'a, 'b> DeleteTokenBadgeCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = DeleteTokenBadgeCpi {
             __program: self.instruction.__program,
 
@@ -488,17 +464,13 @@ impl<'a, 'b> DeleteTokenBadgeCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct DeleteTokenBadgeCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpools_config_extension: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_badge_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_badge: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    receiver: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpools_config_extension: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_badge_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_badge: Option<&'b solana_account_info::AccountInfo<'a>>,
+    receiver: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/increase_liquidity.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/increase_liquidity.rs
@@ -11,34 +11,34 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct IncreaseLiquidity {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub position_authority: solana_program::pubkey::Pubkey,
+    pub position_authority: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub token_owner_account_a: solana_program::pubkey::Pubkey,
+    pub token_owner_account_a: solana_pubkey::Pubkey,
 
-    pub token_owner_account_b: solana_program::pubkey::Pubkey,
+    pub token_owner_account_b: solana_pubkey::Pubkey,
 
-    pub token_vault_a: solana_program::pubkey::Pubkey,
+    pub token_vault_a: solana_pubkey::Pubkey,
 
-    pub token_vault_b: solana_program::pubkey::Pubkey,
+    pub token_vault_b: solana_pubkey::Pubkey,
 
-    pub tick_array_lower: solana_program::pubkey::Pubkey,
+    pub tick_array_lower: solana_pubkey::Pubkey,
 
-    pub tick_array_upper: solana_program::pubkey::Pubkey,
+    pub tick_array_upper: solana_pubkey::Pubkey,
 }
 
 impl IncreaseLiquidity {
     pub fn instruction(
         &self,
         args: IncreaseLiquidityInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -46,50 +46,44 @@ impl IncreaseLiquidity {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: IncreaseLiquidityInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_lower,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_upper,
             false,
         ));
@@ -98,7 +92,7 @@ impl IncreaseLiquidity {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -151,21 +145,21 @@ pub struct IncreaseLiquidityInstructionArgs {
 ///   10. `[writable]` tick_array_upper
 #[derive(Clone, Debug, Default)]
 pub struct IncreaseLiquidityBuilder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    position_authority: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_a: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_b: Option<solana_program::pubkey::Pubkey>,
-    token_vault_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_b: Option<solana_program::pubkey::Pubkey>,
-    tick_array_lower: Option<solana_program::pubkey::Pubkey>,
-    tick_array_upper: Option<solana_program::pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    position_authority: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    token_owner_account_a: Option<solana_pubkey::Pubkey>,
+    token_owner_account_b: Option<solana_pubkey::Pubkey>,
+    token_vault_a: Option<solana_pubkey::Pubkey>,
+    token_vault_b: Option<solana_pubkey::Pubkey>,
+    tick_array_lower: Option<solana_pubkey::Pubkey>,
+    tick_array_upper: Option<solana_pubkey::Pubkey>,
     liquidity_amount: Option<u128>,
     token_max_a: Option<u64>,
     token_max_b: Option<u64>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl IncreaseLiquidityBuilder {
@@ -173,33 +167,30 @@ impl IncreaseLiquidityBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn position_authority(
-        &mut self,
-        position_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_authority(&mut self, position_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
@@ -207,7 +198,7 @@ impl IncreaseLiquidityBuilder {
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: solana_program::pubkey::Pubkey,
+        token_owner_account_a: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_a = Some(token_owner_account_a);
         self
@@ -215,34 +206,28 @@ impl IncreaseLiquidityBuilder {
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: solana_program::pubkey::Pubkey,
+        token_owner_account_b: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_b = Some(token_owner_account_b);
         self
     }
     #[inline(always)]
-    pub fn token_vault_a(&mut self, token_vault_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_a(&mut self, token_vault_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_a = Some(token_vault_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_b(&mut self, token_vault_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_b(&mut self, token_vault_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn tick_array_lower(
-        &mut self,
-        tick_array_lower: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_lower(&mut self, tick_array_lower: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_lower = Some(tick_array_lower);
         self
     }
     #[inline(always)]
-    pub fn tick_array_upper(
-        &mut self,
-        tick_array_upper: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_upper(&mut self, tick_array_upper: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_upper = Some(tick_array_upper);
         self
     }
@@ -263,10 +248,7 @@ impl IncreaseLiquidityBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -274,16 +256,16 @@ impl IncreaseLiquidityBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = IncreaseLiquidity {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             position_authority: self
@@ -319,62 +301,62 @@ impl IncreaseLiquidityBuilder {
 
 /// `increase_liquidity` CPI accounts.
 pub struct IncreaseLiquidityCpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `increase_liquidity` CPI instruction.
 pub struct IncreaseLiquidityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: IncreaseLiquidityInstructionArgs,
 }
 
 impl<'a, 'b> IncreaseLiquidityCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: IncreaseLiquidityCpiAccounts<'a, 'b>,
         args: IncreaseLiquidityInstructionArgs,
     ) -> Self {
@@ -395,25 +377,21 @@ impl<'a, 'b> IncreaseLiquidityCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -422,59 +400,55 @@ impl<'a, 'b> IncreaseLiquidityCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_lower.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_upper.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -484,7 +458,7 @@ impl<'a, 'b> IncreaseLiquidityCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -507,9 +481,9 @@ impl<'a, 'b> IncreaseLiquidityCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -535,7 +509,7 @@ pub struct IncreaseLiquidityCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(IncreaseLiquidityCpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -557,17 +531,14 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -575,23 +546,20 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_authority(
         &mut self,
-        position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
@@ -599,7 +567,7 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_a = Some(token_owner_account_a);
         self
@@ -607,7 +575,7 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_b = Some(token_owner_account_b);
         self
@@ -615,7 +583,7 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_a(
         &mut self,
-        token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_a = Some(token_vault_a);
         self
@@ -623,7 +591,7 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_b(
         &mut self,
-        token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_b = Some(token_vault_b);
         self
@@ -631,7 +599,7 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_lower(
         &mut self,
-        tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_lower = Some(tick_array_lower);
         self
@@ -639,7 +607,7 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_upper(
         &mut self,
-        tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_upper = Some(tick_array_upper);
         self
@@ -663,7 +631,7 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -679,11 +647,7 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -691,7 +655,7 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -699,7 +663,7 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = IncreaseLiquidityInstructionArgs {
             liquidity_amount: self
                 .instruction
@@ -779,25 +743,21 @@ impl<'a, 'b> IncreaseLiquidityCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct IncreaseLiquidityCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_lower: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_upper: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_lower: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_upper: Option<&'b solana_account_info::AccountInfo<'a>>,
     liquidity_amount: Option<u128>,
     token_max_a: Option<u64>,
     token_max_b: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/increase_liquidity_v2.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/increase_liquidity_v2.rs
@@ -12,42 +12,42 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct IncreaseLiquidityV2 {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub token_program_a: solana_program::pubkey::Pubkey,
+    pub token_program_a: solana_pubkey::Pubkey,
 
-    pub token_program_b: solana_program::pubkey::Pubkey,
+    pub token_program_b: solana_pubkey::Pubkey,
 
-    pub memo_program: solana_program::pubkey::Pubkey,
+    pub memo_program: solana_pubkey::Pubkey,
 
-    pub position_authority: solana_program::pubkey::Pubkey,
+    pub position_authority: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub token_mint_a: solana_program::pubkey::Pubkey,
+    pub token_mint_a: solana_pubkey::Pubkey,
 
-    pub token_mint_b: solana_program::pubkey::Pubkey,
+    pub token_mint_b: solana_pubkey::Pubkey,
 
-    pub token_owner_account_a: solana_program::pubkey::Pubkey,
+    pub token_owner_account_a: solana_pubkey::Pubkey,
 
-    pub token_owner_account_b: solana_program::pubkey::Pubkey,
+    pub token_owner_account_b: solana_pubkey::Pubkey,
 
-    pub token_vault_a: solana_program::pubkey::Pubkey,
+    pub token_vault_a: solana_pubkey::Pubkey,
 
-    pub token_vault_b: solana_program::pubkey::Pubkey,
+    pub token_vault_b: solana_pubkey::Pubkey,
 
-    pub tick_array_lower: solana_program::pubkey::Pubkey,
+    pub tick_array_lower: solana_pubkey::Pubkey,
 
-    pub tick_array_upper: solana_program::pubkey::Pubkey,
+    pub tick_array_upper: solana_pubkey::Pubkey,
 }
 
 impl IncreaseLiquidityV2 {
     pub fn instruction(
         &self,
         args: IncreaseLiquidityV2InstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -55,66 +55,60 @@ impl IncreaseLiquidityV2 {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: IncreaseLiquidityV2InstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(15 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.memo_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_lower,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_upper,
             false,
         ));
@@ -123,7 +117,7 @@ impl IncreaseLiquidityV2 {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -181,26 +175,26 @@ pub struct IncreaseLiquidityV2InstructionArgs {
 ///   14. `[writable]` tick_array_upper
 #[derive(Clone, Debug, Default)]
 pub struct IncreaseLiquidityV2Builder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    token_program_a: Option<solana_program::pubkey::Pubkey>,
-    token_program_b: Option<solana_program::pubkey::Pubkey>,
-    memo_program: Option<solana_program::pubkey::Pubkey>,
-    position_authority: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    token_mint_a: Option<solana_program::pubkey::Pubkey>,
-    token_mint_b: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_a: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_b: Option<solana_program::pubkey::Pubkey>,
-    token_vault_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_b: Option<solana_program::pubkey::Pubkey>,
-    tick_array_lower: Option<solana_program::pubkey::Pubkey>,
-    tick_array_upper: Option<solana_program::pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    token_program_a: Option<solana_pubkey::Pubkey>,
+    token_program_b: Option<solana_pubkey::Pubkey>,
+    memo_program: Option<solana_pubkey::Pubkey>,
+    position_authority: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    token_mint_a: Option<solana_pubkey::Pubkey>,
+    token_mint_b: Option<solana_pubkey::Pubkey>,
+    token_owner_account_a: Option<solana_pubkey::Pubkey>,
+    token_owner_account_b: Option<solana_pubkey::Pubkey>,
+    token_vault_a: Option<solana_pubkey::Pubkey>,
+    token_vault_b: Option<solana_pubkey::Pubkey>,
+    tick_array_lower: Option<solana_pubkey::Pubkey>,
+    tick_array_upper: Option<solana_pubkey::Pubkey>,
     liquidity_amount: Option<u128>,
     token_max_a: Option<u64>,
     token_max_b: Option<u64>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl IncreaseLiquidityV2Builder {
@@ -208,66 +202,57 @@ impl IncreaseLiquidityV2Builder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn token_program_a(
-        &mut self,
-        token_program_a: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_a(&mut self, token_program_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_a = Some(token_program_a);
         self
     }
     #[inline(always)]
-    pub fn token_program_b(
-        &mut self,
-        token_program_b: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_b(&mut self, token_program_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_b = Some(token_program_b);
         self
     }
     #[inline(always)]
-    pub fn memo_program(&mut self, memo_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn memo_program(&mut self, memo_program: solana_pubkey::Pubkey) -> &mut Self {
         self.memo_program = Some(memo_program);
         self
     }
     #[inline(always)]
-    pub fn position_authority(
-        &mut self,
-        position_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_authority(&mut self, position_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
     }
     #[inline(always)]
-    pub fn token_mint_a(&mut self, token_mint_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_a(&mut self, token_mint_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_a = Some(token_mint_a);
         self
     }
     #[inline(always)]
-    pub fn token_mint_b(&mut self, token_mint_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_b(&mut self, token_mint_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_b = Some(token_mint_b);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: solana_program::pubkey::Pubkey,
+        token_owner_account_a: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_a = Some(token_owner_account_a);
         self
@@ -275,34 +260,28 @@ impl IncreaseLiquidityV2Builder {
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: solana_program::pubkey::Pubkey,
+        token_owner_account_b: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_b = Some(token_owner_account_b);
         self
     }
     #[inline(always)]
-    pub fn token_vault_a(&mut self, token_vault_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_a(&mut self, token_vault_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_a = Some(token_vault_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_b(&mut self, token_vault_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_b(&mut self, token_vault_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn tick_array_lower(
-        &mut self,
-        tick_array_lower: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_lower(&mut self, tick_array_lower: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_lower = Some(tick_array_lower);
         self
     }
     #[inline(always)]
-    pub fn tick_array_upper(
-        &mut self,
-        tick_array_upper: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_upper(&mut self, tick_array_upper: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_upper = Some(tick_array_upper);
         self
     }
@@ -332,10 +311,7 @@ impl IncreaseLiquidityV2Builder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -343,13 +319,13 @@ impl IncreaseLiquidityV2Builder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = IncreaseLiquidityV2 {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
             token_program_a: self.token_program_a.expect("token_program_a is not set"),
@@ -391,78 +367,78 @@ impl IncreaseLiquidityV2Builder {
 
 /// `increase_liquidity_v2` CPI accounts.
 pub struct IncreaseLiquidityV2CpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `increase_liquidity_v2` CPI instruction.
 pub struct IncreaseLiquidityV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: IncreaseLiquidityV2InstructionArgs,
 }
 
 impl<'a, 'b> IncreaseLiquidityV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: IncreaseLiquidityV2CpiAccounts<'a, 'b>,
         args: IncreaseLiquidityV2InstructionArgs,
     ) -> Self {
@@ -487,25 +463,21 @@ impl<'a, 'b> IncreaseLiquidityV2Cpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -514,75 +486,71 @@ impl<'a, 'b> IncreaseLiquidityV2Cpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(15 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.memo_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_lower.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_upper.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -592,7 +560,7 @@ impl<'a, 'b> IncreaseLiquidityV2Cpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -619,9 +587,9 @@ impl<'a, 'b> IncreaseLiquidityV2Cpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -651,7 +619,7 @@ pub struct IncreaseLiquidityV2CpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(IncreaseLiquidityV2CpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -678,17 +646,14 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token_program_a(
         &mut self,
-        token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_a = Some(token_program_a);
         self
@@ -696,7 +661,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program_b(
         &mut self,
-        token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_b = Some(token_program_b);
         self
@@ -704,7 +669,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn memo_program(
         &mut self,
-        memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+        memo_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.memo_program = Some(memo_program);
         self
@@ -712,23 +677,20 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_authority(
         &mut self,
-        position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
@@ -736,7 +698,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_a(
         &mut self,
-        token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_a = Some(token_mint_a);
         self
@@ -744,7 +706,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_b(
         &mut self,
-        token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_b = Some(token_mint_b);
         self
@@ -752,7 +714,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_a = Some(token_owner_account_a);
         self
@@ -760,7 +722,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_b = Some(token_owner_account_b);
         self
@@ -768,7 +730,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_a(
         &mut self,
-        token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_a = Some(token_vault_a);
         self
@@ -776,7 +738,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_b(
         &mut self,
-        token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_b = Some(token_vault_b);
         self
@@ -784,7 +746,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_lower(
         &mut self,
-        tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_lower = Some(tick_array_lower);
         self
@@ -792,7 +754,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_upper(
         &mut self,
-        tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_upper = Some(tick_array_upper);
         self
@@ -825,7 +787,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -841,11 +803,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -853,7 +811,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -861,7 +819,7 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = IncreaseLiquidityV2InstructionArgs {
             liquidity_amount: self
                 .instruction
@@ -962,30 +920,26 @@ impl<'a, 'b> IncreaseLiquidityV2CpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct IncreaseLiquidityV2CpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    memo_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_lower: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_upper: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    memo_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_lower: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_upper: Option<&'b solana_account_info::AccountInfo<'a>>,
     liquidity_amount: Option<u128>,
     token_max_a: Option<u64>,
     token_max_b: Option<u64>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_config.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_config.rs
@@ -7,23 +7,23 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializeConfig {
-    pub config: solana_program::pubkey::Pubkey,
+    pub config: solana_pubkey::Pubkey,
 
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 }
 
 impl InitializeConfig {
     pub fn instruction(
         &self,
         args: InitializeConfigInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -31,18 +31,12 @@ impl InitializeConfig {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: InitializeConfigInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.config,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.config, true));
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
@@ -51,7 +45,7 @@ impl InitializeConfig {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -97,14 +91,14 @@ pub struct InitializeConfigInstructionArgs {
 ///   2. `[optional]` system_program (default to `11111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializeConfigBuilder {
-    config: Option<solana_program::pubkey::Pubkey>,
-    funder: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
+    config: Option<solana_pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
     fee_authority: Option<Pubkey>,
     collect_protocol_fees_authority: Option<Pubkey>,
     reward_emissions_super_authority: Option<Pubkey>,
     default_protocol_fee_rate: Option<u16>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializeConfigBuilder {
@@ -112,18 +106,18 @@ impl InitializeConfigBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn config(&mut self, config: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn config(&mut self, config: solana_pubkey::Pubkey) -> &mut Self {
         self.config = Some(config);
         self
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
@@ -155,10 +149,7 @@ impl InitializeConfigBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -166,19 +157,19 @@ impl InitializeConfigBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializeConfig {
             config: self.config.expect("config is not set"),
             funder: self.funder.expect("funder is not set"),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
         };
         let args = InitializeConfigInstructionArgs {
             fee_authority: self
@@ -205,30 +196,30 @@ impl InitializeConfigBuilder {
 
 /// `initialize_config` CPI accounts.
 pub struct InitializeConfigCpiAccounts<'a, 'b> {
-    pub config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize_config` CPI instruction.
 pub struct InitializeConfigCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: InitializeConfigInstructionArgs,
 }
 
 impl<'a, 'b> InitializeConfigCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializeConfigCpiAccounts<'a, 'b>,
         args: InitializeConfigInstructionArgs,
     ) -> Self {
@@ -241,25 +232,21 @@ impl<'a, 'b> InitializeConfigCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -268,27 +255,17 @@ impl<'a, 'b> InitializeConfigCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.config.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.config.key, true));
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -298,7 +275,7 @@ impl<'a, 'b> InitializeConfigCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -313,9 +290,9 @@ impl<'a, 'b> InitializeConfigCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -333,7 +310,7 @@ pub struct InitializeConfigCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializeConfigCpiBuilderInstruction {
             __program: program,
             config: None,
@@ -348,25 +325,19 @@ impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn config(
-        &mut self,
-        config: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn config(&mut self, config: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.config = Some(config);
         self
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -401,7 +372,7 @@ impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -417,11 +388,7 @@ impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -429,7 +396,7 @@ impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -437,7 +404,7 @@ impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = InitializeConfigInstructionArgs {
             fee_authority: self
                 .instruction
@@ -482,18 +449,14 @@ impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializeConfigCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     fee_authority: Option<Pubkey>,
     collect_protocol_fees_authority: Option<Pubkey>,
     reward_emissions_super_authority: Option<Pubkey>,
     default_protocol_fee_rate: Option<u16>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_config_extension.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_config_extension.rs
@@ -11,52 +11,49 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializeConfigExtension {
-    pub config: solana_program::pubkey::Pubkey,
+    pub config: solana_pubkey::Pubkey,
 
-    pub config_extension: solana_program::pubkey::Pubkey,
+    pub config_extension: solana_pubkey::Pubkey,
 
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub fee_authority: solana_program::pubkey::Pubkey,
+    pub fee_authority: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 }
 
 impl InitializeConfigExtension {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.config_extension,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.fee_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&InitializeConfigExtensionInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -95,12 +92,12 @@ impl Default for InitializeConfigExtensionInstructionData {
 ///   4. `[optional]` system_program (default to `11111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializeConfigExtensionBuilder {
-    config: Option<solana_program::pubkey::Pubkey>,
-    config_extension: Option<solana_program::pubkey::Pubkey>,
-    funder: Option<solana_program::pubkey::Pubkey>,
-    fee_authority: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    config: Option<solana_pubkey::Pubkey>,
+    config_extension: Option<solana_pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    fee_authority: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializeConfigExtensionBuilder {
@@ -108,40 +105,34 @@ impl InitializeConfigExtensionBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn config(&mut self, config: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn config(&mut self, config: solana_pubkey::Pubkey) -> &mut Self {
         self.config = Some(config);
         self
     }
     #[inline(always)]
-    pub fn config_extension(
-        &mut self,
-        config_extension: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn config_extension(&mut self, config_extension: solana_pubkey::Pubkey) -> &mut Self {
         self.config_extension = Some(config_extension);
         self
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn fee_authority(&mut self, fee_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn fee_authority(&mut self, fee_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.fee_authority = Some(fee_authority);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -149,13 +140,13 @@ impl InitializeConfigExtensionBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializeConfigExtension {
             config: self.config.expect("config is not set"),
             config_extension: self.config_extension.expect("config_extension is not set"),
@@ -163,7 +154,7 @@ impl InitializeConfigExtensionBuilder {
             fee_authority: self.fee_authority.expect("fee_authority is not set"),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
         };
 
         accounts.instruction_with_remaining_accounts(&self.__remaining_accounts)
@@ -172,36 +163,36 @@ impl InitializeConfigExtensionBuilder {
 
 /// `initialize_config_extension` CPI accounts.
 pub struct InitializeConfigExtensionCpiAccounts<'a, 'b> {
-    pub config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+    pub config_extension: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize_config_extension` CPI instruction.
 pub struct InitializeConfigExtensionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+    pub config_extension: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> InitializeConfigExtensionCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializeConfigExtensionCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -214,25 +205,21 @@ impl<'a, 'b> InitializeConfigExtensionCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -241,35 +228,28 @@ impl<'a, 'b> InitializeConfigExtensionCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.config_extension.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.fee_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -277,7 +257,7 @@ impl<'a, 'b> InitializeConfigExtensionCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&InitializeConfigExtensionInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -294,9 +274,9 @@ impl<'a, 'b> InitializeConfigExtensionCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -316,7 +296,7 @@ pub struct InitializeConfigExtensionCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializeConfigExtensionCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializeConfigExtensionCpiBuilderInstruction {
             __program: program,
             config: None,
@@ -329,33 +309,27 @@ impl<'a, 'b> InitializeConfigExtensionCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn config(
-        &mut self,
-        config: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn config(&mut self, config: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.config = Some(config);
         self
     }
     #[inline(always)]
     pub fn config_extension(
         &mut self,
-        config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+        config_extension: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.config_extension = Some(config_extension);
         self
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
     pub fn fee_authority(
         &mut self,
-        fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        fee_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.fee_authority = Some(fee_authority);
         self
@@ -363,7 +337,7 @@ impl<'a, 'b> InitializeConfigExtensionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -372,7 +346,7 @@ impl<'a, 'b> InitializeConfigExtensionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -388,11 +362,7 @@ impl<'a, 'b> InitializeConfigExtensionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -400,7 +370,7 @@ impl<'a, 'b> InitializeConfigExtensionCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -408,7 +378,7 @@ impl<'a, 'b> InitializeConfigExtensionCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = InitializeConfigExtensionCpi {
             __program: self.instruction.__program,
 
@@ -440,16 +410,12 @@ impl<'a, 'b> InitializeConfigExtensionCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializeConfigExtensionCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    config_extension: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    fee_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    config_extension: Option<&'b solana_account_info::AccountInfo<'a>>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    fee_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_fee_tier.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_fee_tier.rs
@@ -11,22 +11,22 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializeFeeTier {
-    pub config: solana_program::pubkey::Pubkey,
+    pub config: solana_pubkey::Pubkey,
 
-    pub fee_tier: solana_program::pubkey::Pubkey,
+    pub fee_tier: solana_pubkey::Pubkey,
 
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub fee_authority: solana_program::pubkey::Pubkey,
+    pub fee_authority: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 }
 
 impl InitializeFeeTier {
     pub fn instruction(
         &self,
         args: InitializeFeeTierInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -34,26 +34,20 @@ impl InitializeFeeTier {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: InitializeFeeTierInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.fee_tier,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.fee_tier, false));
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.fee_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
@@ -62,7 +56,7 @@ impl InitializeFeeTier {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -108,14 +102,14 @@ pub struct InitializeFeeTierInstructionArgs {
 ///   4. `[optional]` system_program (default to `11111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializeFeeTierBuilder {
-    config: Option<solana_program::pubkey::Pubkey>,
-    fee_tier: Option<solana_program::pubkey::Pubkey>,
-    funder: Option<solana_program::pubkey::Pubkey>,
-    fee_authority: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
+    config: Option<solana_pubkey::Pubkey>,
+    fee_tier: Option<solana_pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    fee_authority: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
     tick_spacing: Option<u16>,
     default_fee_rate: Option<u16>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializeFeeTierBuilder {
@@ -123,28 +117,28 @@ impl InitializeFeeTierBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn config(&mut self, config: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn config(&mut self, config: solana_pubkey::Pubkey) -> &mut Self {
         self.config = Some(config);
         self
     }
     #[inline(always)]
-    pub fn fee_tier(&mut self, fee_tier: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn fee_tier(&mut self, fee_tier: solana_pubkey::Pubkey) -> &mut Self {
         self.fee_tier = Some(fee_tier);
         self
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn fee_authority(&mut self, fee_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn fee_authority(&mut self, fee_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.fee_authority = Some(fee_authority);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
@@ -160,10 +154,7 @@ impl InitializeFeeTierBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -171,13 +162,13 @@ impl InitializeFeeTierBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializeFeeTier {
             config: self.config.expect("config is not set"),
             fee_tier: self.fee_tier.expect("fee_tier is not set"),
@@ -185,7 +176,7 @@ impl InitializeFeeTierBuilder {
             fee_authority: self.fee_authority.expect("fee_authority is not set"),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
         };
         let args = InitializeFeeTierInstructionArgs {
             tick_spacing: self.tick_spacing.clone().expect("tick_spacing is not set"),
@@ -201,38 +192,38 @@ impl InitializeFeeTierBuilder {
 
 /// `initialize_fee_tier` CPI accounts.
 pub struct InitializeFeeTierCpiAccounts<'a, 'b> {
-    pub config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_tier: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_tier: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize_fee_tier` CPI instruction.
 pub struct InitializeFeeTierCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_tier: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_tier: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: InitializeFeeTierInstructionArgs,
 }
 
 impl<'a, 'b> InitializeFeeTierCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializeFeeTierCpiAccounts<'a, 'b>,
         args: InitializeFeeTierInstructionArgs,
     ) -> Self {
@@ -247,25 +238,21 @@ impl<'a, 'b> InitializeFeeTierCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -274,35 +261,28 @@ impl<'a, 'b> InitializeFeeTierCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.fee_tier.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.fee_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -312,7 +292,7 @@ impl<'a, 'b> InitializeFeeTierCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -329,9 +309,9 @@ impl<'a, 'b> InitializeFeeTierCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -351,7 +331,7 @@ pub struct InitializeFeeTierCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializeFeeTierCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializeFeeTierCpiBuilderInstruction {
             __program: program,
             config: None,
@@ -366,33 +346,24 @@ impl<'a, 'b> InitializeFeeTierCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn config(
-        &mut self,
-        config: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn config(&mut self, config: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.config = Some(config);
         self
     }
     #[inline(always)]
-    pub fn fee_tier(
-        &mut self,
-        fee_tier: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn fee_tier(&mut self, fee_tier: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.fee_tier = Some(fee_tier);
         self
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
     pub fn fee_authority(
         &mut self,
-        fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        fee_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.fee_authority = Some(fee_authority);
         self
@@ -400,7 +371,7 @@ impl<'a, 'b> InitializeFeeTierCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -419,7 +390,7 @@ impl<'a, 'b> InitializeFeeTierCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -435,11 +406,7 @@ impl<'a, 'b> InitializeFeeTierCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -447,7 +414,7 @@ impl<'a, 'b> InitializeFeeTierCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -455,7 +422,7 @@ impl<'a, 'b> InitializeFeeTierCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = InitializeFeeTierInstructionArgs {
             tick_spacing: self
                 .instruction
@@ -497,18 +464,14 @@ impl<'a, 'b> InitializeFeeTierCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializeFeeTierCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    fee_tier: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    fee_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    fee_tier: Option<&'b solana_account_info::AccountInfo<'a>>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    fee_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     tick_spacing: Option<u16>,
     default_fee_rate: Option<u16>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_pool.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_pool.rs
@@ -11,34 +11,34 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializePool {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub token_mint_a: solana_program::pubkey::Pubkey,
+    pub token_mint_a: solana_pubkey::Pubkey,
 
-    pub token_mint_b: solana_program::pubkey::Pubkey,
+    pub token_mint_b: solana_pubkey::Pubkey,
 
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub token_vault_a: solana_program::pubkey::Pubkey,
+    pub token_vault_a: solana_pubkey::Pubkey,
 
-    pub token_vault_b: solana_program::pubkey::Pubkey,
+    pub token_vault_b: solana_pubkey::Pubkey,
 
-    pub fee_tier: solana_program::pubkey::Pubkey,
+    pub fee_tier: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 }
 
 impl InitializePool {
     pub fn instruction(
         &self,
         args: InitializePoolInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -46,50 +46,44 @@ impl InitializePool {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: InitializePoolInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_a,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_b,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.fee_tier,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
         accounts.extend_from_slice(remaining_accounts);
@@ -97,7 +91,7 @@ impl InitializePool {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -150,21 +144,21 @@ pub struct InitializePoolInstructionArgs {
 ///   10. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializePoolBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    token_mint_a: Option<solana_program::pubkey::Pubkey>,
-    token_mint_b: Option<solana_program::pubkey::Pubkey>,
-    funder: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    token_vault_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_b: Option<solana_program::pubkey::Pubkey>,
-    fee_tier: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    token_mint_a: Option<solana_pubkey::Pubkey>,
+    token_mint_b: Option<solana_pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    token_vault_a: Option<solana_pubkey::Pubkey>,
+    token_vault_b: Option<solana_pubkey::Pubkey>,
+    fee_tier: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
     whirlpool_bump: Option<u8>,
     tick_spacing: Option<u16>,
     initial_sqrt_price: Option<u128>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializePoolBuilder {
@@ -172,63 +166,60 @@ impl InitializePoolBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn token_mint_a(&mut self, token_mint_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_a(&mut self, token_mint_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_a = Some(token_mint_a);
         self
     }
     #[inline(always)]
-    pub fn token_mint_b(&mut self, token_mint_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_b(&mut self, token_mint_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_b = Some(token_mint_b);
         self
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn token_vault_a(&mut self, token_vault_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_a(&mut self, token_vault_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_a = Some(token_vault_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_b(&mut self, token_vault_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_b(&mut self, token_vault_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn fee_tier(&mut self, fee_tier: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn fee_tier(&mut self, fee_tier: solana_pubkey::Pubkey) -> &mut Self {
         self.fee_tier = Some(fee_tier);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
@@ -249,10 +240,7 @@ impl InitializePoolBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -260,13 +248,13 @@ impl InitializePoolBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializePool {
             whirlpools_config: self
                 .whirlpools_config
@@ -278,13 +266,13 @@ impl InitializePoolBuilder {
             token_vault_a: self.token_vault_a.expect("token_vault_a is not set"),
             token_vault_b: self.token_vault_b.expect("token_vault_b is not set"),
             fee_tier: self.fee_tier.expect("fee_tier is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
         };
@@ -306,62 +294,62 @@ impl InitializePoolBuilder {
 
 /// `initialize_pool` CPI accounts.
 pub struct InitializePoolCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_tier: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_tier: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize_pool` CPI instruction.
 pub struct InitializePoolCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_tier: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_tier: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: InitializePoolInstructionArgs,
 }
 
 impl<'a, 'b> InitializePoolCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializePoolCpiAccounts<'a, 'b>,
         args: InitializePoolInstructionArgs,
     ) -> Self {
@@ -382,25 +370,21 @@ impl<'a, 'b> InitializePoolCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -409,59 +393,52 @@ impl<'a, 'b> InitializePoolCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_a.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_b.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.fee_tier.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -471,7 +448,7 @@ impl<'a, 'b> InitializePoolCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -494,9 +471,9 @@ impl<'a, 'b> InitializePoolCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -522,7 +499,7 @@ pub struct InitializePoolCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializePoolCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializePoolCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -546,7 +523,7 @@ impl<'a, 'b> InitializePoolCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
@@ -554,7 +531,7 @@ impl<'a, 'b> InitializePoolCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_a(
         &mut self,
-        token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_a = Some(token_mint_a);
         self
@@ -562,31 +539,25 @@ impl<'a, 'b> InitializePoolCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_b(
         &mut self,
-        token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_b = Some(token_mint_b);
         self
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token_vault_a(
         &mut self,
-        token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_a = Some(token_vault_a);
         self
@@ -594,23 +565,20 @@ impl<'a, 'b> InitializePoolCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_b(
         &mut self,
-        token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn fee_tier(
-        &mut self,
-        fee_tier: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn fee_tier(&mut self, fee_tier: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.fee_tier = Some(fee_tier);
         self
     }
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -618,13 +586,13 @@ impl<'a, 'b> InitializePoolCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -647,7 +615,7 @@ impl<'a, 'b> InitializePoolCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -663,11 +631,7 @@ impl<'a, 'b> InitializePoolCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -675,7 +639,7 @@ impl<'a, 'b> InitializePoolCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -683,7 +647,7 @@ impl<'a, 'b> InitializePoolCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = InitializePoolInstructionArgs {
             whirlpool_bump: self
                 .instruction
@@ -757,25 +721,21 @@ impl<'a, 'b> InitializePoolCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializePoolCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    fee_tier: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    fee_tier: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
     whirlpool_bump: Option<u8>,
     tick_spacing: Option<u16>,
     initial_sqrt_price: Option<u128>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_pool_v2.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_pool_v2.rs
@@ -11,40 +11,40 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializePoolV2 {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub token_mint_a: solana_program::pubkey::Pubkey,
+    pub token_mint_a: solana_pubkey::Pubkey,
 
-    pub token_mint_b: solana_program::pubkey::Pubkey,
+    pub token_mint_b: solana_pubkey::Pubkey,
 
-    pub token_badge_a: solana_program::pubkey::Pubkey,
+    pub token_badge_a: solana_pubkey::Pubkey,
 
-    pub token_badge_b: solana_program::pubkey::Pubkey,
+    pub token_badge_b: solana_pubkey::Pubkey,
 
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub token_vault_a: solana_program::pubkey::Pubkey,
+    pub token_vault_a: solana_pubkey::Pubkey,
 
-    pub token_vault_b: solana_program::pubkey::Pubkey,
+    pub token_vault_b: solana_pubkey::Pubkey,
 
-    pub fee_tier: solana_program::pubkey::Pubkey,
+    pub fee_tier: solana_pubkey::Pubkey,
 
-    pub token_program_a: solana_program::pubkey::Pubkey,
+    pub token_program_a: solana_pubkey::Pubkey,
 
-    pub token_program_b: solana_program::pubkey::Pubkey,
+    pub token_program_b: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 }
 
 impl InitializePoolV2 {
     pub fn instruction(
         &self,
         args: InitializePoolV2InstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -52,62 +52,56 @@ impl InitializePoolV2 {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: InitializePoolV2InstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_badge_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_badge_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_a,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_b,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.fee_tier,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
         accounts.extend_from_slice(remaining_accounts);
@@ -115,7 +109,7 @@ impl InitializePoolV2 {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -170,23 +164,23 @@ pub struct InitializePoolV2InstructionArgs {
 ///   13. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializePoolV2Builder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    token_mint_a: Option<solana_program::pubkey::Pubkey>,
-    token_mint_b: Option<solana_program::pubkey::Pubkey>,
-    token_badge_a: Option<solana_program::pubkey::Pubkey>,
-    token_badge_b: Option<solana_program::pubkey::Pubkey>,
-    funder: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    token_vault_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_b: Option<solana_program::pubkey::Pubkey>,
-    fee_tier: Option<solana_program::pubkey::Pubkey>,
-    token_program_a: Option<solana_program::pubkey::Pubkey>,
-    token_program_b: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    token_mint_a: Option<solana_pubkey::Pubkey>,
+    token_mint_b: Option<solana_pubkey::Pubkey>,
+    token_badge_a: Option<solana_pubkey::Pubkey>,
+    token_badge_b: Option<solana_pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    token_vault_a: Option<solana_pubkey::Pubkey>,
+    token_vault_b: Option<solana_pubkey::Pubkey>,
+    fee_tier: Option<solana_pubkey::Pubkey>,
+    token_program_a: Option<solana_pubkey::Pubkey>,
+    token_program_b: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
     tick_spacing: Option<u16>,
     initial_sqrt_price: Option<u128>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializePoolV2Builder {
@@ -194,83 +188,74 @@ impl InitializePoolV2Builder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn token_mint_a(&mut self, token_mint_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_a(&mut self, token_mint_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_a = Some(token_mint_a);
         self
     }
     #[inline(always)]
-    pub fn token_mint_b(&mut self, token_mint_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_b(&mut self, token_mint_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_b = Some(token_mint_b);
         self
     }
     #[inline(always)]
-    pub fn token_badge_a(&mut self, token_badge_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_badge_a(&mut self, token_badge_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_badge_a = Some(token_badge_a);
         self
     }
     #[inline(always)]
-    pub fn token_badge_b(&mut self, token_badge_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_badge_b(&mut self, token_badge_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_badge_b = Some(token_badge_b);
         self
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn token_vault_a(&mut self, token_vault_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_a(&mut self, token_vault_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_a = Some(token_vault_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_b(&mut self, token_vault_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_b(&mut self, token_vault_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn fee_tier(&mut self, fee_tier: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn fee_tier(&mut self, fee_tier: solana_pubkey::Pubkey) -> &mut Self {
         self.fee_tier = Some(fee_tier);
         self
     }
     #[inline(always)]
-    pub fn token_program_a(
-        &mut self,
-        token_program_a: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_a(&mut self, token_program_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_a = Some(token_program_a);
         self
     }
     #[inline(always)]
-    pub fn token_program_b(
-        &mut self,
-        token_program_b: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_b(&mut self, token_program_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_b = Some(token_program_b);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
@@ -286,10 +271,7 @@ impl InitializePoolV2Builder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -297,13 +279,13 @@ impl InitializePoolV2Builder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializePoolV2 {
             whirlpools_config: self
                 .whirlpools_config
@@ -321,8 +303,8 @@ impl InitializePoolV2Builder {
             token_program_b: self.token_program_b.expect("token_program_b is not set"),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
         };
@@ -340,74 +322,74 @@ impl InitializePoolV2Builder {
 
 /// `initialize_pool_v2` CPI accounts.
 pub struct InitializePoolV2CpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_badge_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_badge_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_badge_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_badge_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_tier: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_tier: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize_pool_v2` CPI instruction.
 pub struct InitializePoolV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_badge_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_badge_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_badge_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_badge_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_tier: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_tier: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: InitializePoolV2InstructionArgs,
 }
 
 impl<'a, 'b> InitializePoolV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializePoolV2CpiAccounts<'a, 'b>,
         args: InitializePoolV2InstructionArgs,
     ) -> Self {
@@ -431,25 +413,21 @@ impl<'a, 'b> InitializePoolV2Cpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -458,71 +436,64 @@ impl<'a, 'b> InitializePoolV2Cpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_badge_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_badge_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_a.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_b.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.fee_tier.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -532,7 +503,7 @@ impl<'a, 'b> InitializePoolV2Cpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -558,9 +529,9 @@ impl<'a, 'b> InitializePoolV2Cpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -589,7 +560,7 @@ pub struct InitializePoolV2CpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializePoolV2CpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -615,7 +586,7 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
@@ -623,7 +594,7 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_a(
         &mut self,
-        token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_a = Some(token_mint_a);
         self
@@ -631,7 +602,7 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_b(
         &mut self,
-        token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_b = Some(token_mint_b);
         self
@@ -639,7 +610,7 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_badge_a(
         &mut self,
-        token_badge_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_badge_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_badge_a = Some(token_badge_a);
         self
@@ -647,31 +618,25 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_badge_b(
         &mut self,
-        token_badge_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_badge_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_badge_b = Some(token_badge_b);
         self
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token_vault_a(
         &mut self,
-        token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_a = Some(token_vault_a);
         self
@@ -679,23 +644,20 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_b(
         &mut self,
-        token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn fee_tier(
-        &mut self,
-        fee_tier: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn fee_tier(&mut self, fee_tier: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.fee_tier = Some(fee_tier);
         self
     }
     #[inline(always)]
     pub fn token_program_a(
         &mut self,
-        token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_a = Some(token_program_a);
         self
@@ -703,7 +665,7 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program_b(
         &mut self,
-        token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_b = Some(token_program_b);
         self
@@ -711,13 +673,13 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -735,7 +697,7 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -751,11 +713,7 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -763,7 +721,7 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -771,7 +729,7 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = InitializePoolV2InstructionArgs {
             tick_spacing: self
                 .instruction
@@ -855,27 +813,23 @@ impl<'a, 'b> InitializePoolV2CpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializePoolV2CpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_badge_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_badge_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    fee_tier: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_badge_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_badge_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    fee_tier: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
     tick_spacing: Option<u16>,
     initial_sqrt_price: Option<u128>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_position_bundle.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_position_bundle.rs
@@ -11,75 +11,72 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializePositionBundle {
-    pub position_bundle: solana_program::pubkey::Pubkey,
+    pub position_bundle: solana_pubkey::Pubkey,
 
-    pub position_bundle_mint: solana_program::pubkey::Pubkey,
+    pub position_bundle_mint: solana_pubkey::Pubkey,
 
-    pub position_bundle_token_account: solana_program::pubkey::Pubkey,
+    pub position_bundle_token_account: solana_pubkey::Pubkey,
 
-    pub position_bundle_owner: solana_program::pubkey::Pubkey,
+    pub position_bundle_owner: solana_pubkey::Pubkey,
 
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 
-    pub associated_token_program: solana_program::pubkey::Pubkey,
+    pub associated_token_program: solana_pubkey::Pubkey,
 }
 
 impl InitializePositionBundle {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_bundle,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_bundle_mint,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_bundle_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_bundle_owner,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.associated_token_program,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&InitializePositionBundleInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -122,16 +119,16 @@ impl Default for InitializePositionBundleInstructionData {
 ///   8. `[]` associated_token_program
 #[derive(Clone, Debug, Default)]
 pub struct InitializePositionBundleBuilder {
-    position_bundle: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_mint: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_token_account: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_owner: Option<solana_program::pubkey::Pubkey>,
-    funder: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
-    associated_token_program: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    position_bundle: Option<solana_pubkey::Pubkey>,
+    position_bundle_mint: Option<solana_pubkey::Pubkey>,
+    position_bundle_token_account: Option<solana_pubkey::Pubkey>,
+    position_bundle_owner: Option<solana_pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
+    associated_token_program: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializePositionBundleBuilder {
@@ -139,17 +136,14 @@ impl InitializePositionBundleBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn position_bundle(
-        &mut self,
-        position_bundle: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_bundle(&mut self, position_bundle: solana_pubkey::Pubkey) -> &mut Self {
         self.position_bundle = Some(position_bundle);
         self
     }
     #[inline(always)]
     pub fn position_bundle_mint(
         &mut self,
-        position_bundle_mint: solana_program::pubkey::Pubkey,
+        position_bundle_mint: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_mint = Some(position_bundle_mint);
         self
@@ -157,7 +151,7 @@ impl InitializePositionBundleBuilder {
     #[inline(always)]
     pub fn position_bundle_token_account(
         &mut self,
-        position_bundle_token_account: solana_program::pubkey::Pubkey,
+        position_bundle_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_token_account = Some(position_bundle_token_account);
         self
@@ -165,48 +159,45 @@ impl InitializePositionBundleBuilder {
     #[inline(always)]
     pub fn position_bundle_owner(
         &mut self,
-        position_bundle_owner: solana_program::pubkey::Pubkey,
+        position_bundle_owner: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_owner = Some(position_bundle_owner);
         self
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
     #[inline(always)]
     pub fn associated_token_program(
         &mut self,
-        associated_token_program: solana_program::pubkey::Pubkey,
+        associated_token_program: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.associated_token_program = Some(associated_token_program);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -214,13 +205,13 @@ impl InitializePositionBundleBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializePositionBundle {
             position_bundle: self.position_bundle.expect("position_bundle is not set"),
             position_bundle_mint: self
@@ -233,13 +224,13 @@ impl InitializePositionBundleBuilder {
                 .position_bundle_owner
                 .expect("position_bundle_owner is not set"),
             funder: self.funder.expect("funder is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
             associated_token_program: self
@@ -253,52 +244,52 @@ impl InitializePositionBundleBuilder {
 
 /// `initialize_position_bundle` CPI accounts.
 pub struct InitializePositionBundleCpiAccounts<'a, 'b> {
-    pub position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub associated_token_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize_position_bundle` CPI instruction.
 pub struct InitializePositionBundleCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub associated_token_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> InitializePositionBundleCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializePositionBundleCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -315,25 +306,21 @@ impl<'a, 'b> InitializePositionBundleCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -342,51 +329,44 @@ impl<'a, 'b> InitializePositionBundleCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_bundle.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_bundle_mint.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_bundle_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_bundle_owner.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.associated_token_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -394,7 +374,7 @@ impl<'a, 'b> InitializePositionBundleCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&InitializePositionBundleInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -415,9 +395,9 @@ impl<'a, 'b> InitializePositionBundleCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -441,7 +421,7 @@ pub struct InitializePositionBundleCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializePositionBundleCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializePositionBundleCpiBuilderInstruction {
             __program: program,
             position_bundle: None,
@@ -460,7 +440,7 @@ impl<'a, 'b> InitializePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle(
         &mut self,
-        position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle = Some(position_bundle);
         self
@@ -468,7 +448,7 @@ impl<'a, 'b> InitializePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_mint(
         &mut self,
-        position_bundle_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_mint = Some(position_bundle_mint);
         self
@@ -476,7 +456,7 @@ impl<'a, 'b> InitializePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_token_account(
         &mut self,
-        position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_token_account = Some(position_bundle_token_account);
         self
@@ -484,23 +464,20 @@ impl<'a, 'b> InitializePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_owner(
         &mut self,
-        position_bundle_owner: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_owner: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_owner = Some(position_bundle_owner);
         self
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -508,20 +485,20 @@ impl<'a, 'b> InitializePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
     #[inline(always)]
     pub fn associated_token_program(
         &mut self,
-        associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        associated_token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.associated_token_program = Some(associated_token_program);
         self
@@ -530,7 +507,7 @@ impl<'a, 'b> InitializePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -546,11 +523,7 @@ impl<'a, 'b> InitializePositionBundleCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -558,7 +531,7 @@ impl<'a, 'b> InitializePositionBundleCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -566,7 +539,7 @@ impl<'a, 'b> InitializePositionBundleCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = InitializePositionBundleCpi {
             __program: self.instruction.__program,
 
@@ -618,20 +591,16 @@ impl<'a, 'b> InitializePositionBundleCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializePositionBundleCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    position_bundle: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    associated_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    position_bundle: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_owner: Option<&'b solana_account_info::AccountInfo<'a>>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
+    associated_token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_position_bundle_with_metadata.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_position_bundle_with_metadata.rs
@@ -11,86 +11,83 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializePositionBundleWithMetadata {
-    pub position_bundle: solana_program::pubkey::Pubkey,
+    pub position_bundle: solana_pubkey::Pubkey,
 
-    pub position_bundle_mint: solana_program::pubkey::Pubkey,
+    pub position_bundle_mint: solana_pubkey::Pubkey,
 
-    pub position_bundle_metadata: solana_program::pubkey::Pubkey,
+    pub position_bundle_metadata: solana_pubkey::Pubkey,
 
-    pub position_bundle_token_account: solana_program::pubkey::Pubkey,
+    pub position_bundle_token_account: solana_pubkey::Pubkey,
 
-    pub position_bundle_owner: solana_program::pubkey::Pubkey,
+    pub position_bundle_owner: solana_pubkey::Pubkey,
 
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub metadata_update_auth: solana_program::pubkey::Pubkey,
+    pub metadata_update_auth: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 
-    pub associated_token_program: solana_program::pubkey::Pubkey,
+    pub associated_token_program: solana_pubkey::Pubkey,
 
-    pub metadata_program: solana_program::pubkey::Pubkey,
+    pub metadata_program: solana_pubkey::Pubkey,
 }
 
 impl InitializePositionBundleWithMetadata {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(12 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_bundle,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_bundle_mint,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_bundle_metadata,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_bundle_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_bundle_owner,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.metadata_update_auth,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.associated_token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.metadata_program,
             false,
         ));
@@ -98,7 +95,7 @@ impl InitializePositionBundleWithMetadata {
         let data =
             borsh::to_vec(&InitializePositionBundleWithMetadataInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -144,19 +141,19 @@ impl Default for InitializePositionBundleWithMetadataInstructionData {
 ///   11. `[]` metadata_program
 #[derive(Clone, Debug, Default)]
 pub struct InitializePositionBundleWithMetadataBuilder {
-    position_bundle: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_mint: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_metadata: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_token_account: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_owner: Option<solana_program::pubkey::Pubkey>,
-    funder: Option<solana_program::pubkey::Pubkey>,
-    metadata_update_auth: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
-    associated_token_program: Option<solana_program::pubkey::Pubkey>,
-    metadata_program: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    position_bundle: Option<solana_pubkey::Pubkey>,
+    position_bundle_mint: Option<solana_pubkey::Pubkey>,
+    position_bundle_metadata: Option<solana_pubkey::Pubkey>,
+    position_bundle_token_account: Option<solana_pubkey::Pubkey>,
+    position_bundle_owner: Option<solana_pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    metadata_update_auth: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
+    associated_token_program: Option<solana_pubkey::Pubkey>,
+    metadata_program: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializePositionBundleWithMetadataBuilder {
@@ -164,17 +161,14 @@ impl InitializePositionBundleWithMetadataBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn position_bundle(
-        &mut self,
-        position_bundle: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_bundle(&mut self, position_bundle: solana_pubkey::Pubkey) -> &mut Self {
         self.position_bundle = Some(position_bundle);
         self
     }
     #[inline(always)]
     pub fn position_bundle_mint(
         &mut self,
-        position_bundle_mint: solana_program::pubkey::Pubkey,
+        position_bundle_mint: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_mint = Some(position_bundle_mint);
         self
@@ -182,7 +176,7 @@ impl InitializePositionBundleWithMetadataBuilder {
     #[inline(always)]
     pub fn position_bundle_metadata(
         &mut self,
-        position_bundle_metadata: solana_program::pubkey::Pubkey,
+        position_bundle_metadata: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_metadata = Some(position_bundle_metadata);
         self
@@ -190,7 +184,7 @@ impl InitializePositionBundleWithMetadataBuilder {
     #[inline(always)]
     pub fn position_bundle_token_account(
         &mut self,
-        position_bundle_token_account: solana_program::pubkey::Pubkey,
+        position_bundle_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_token_account = Some(position_bundle_token_account);
         self
@@ -198,64 +192,58 @@ impl InitializePositionBundleWithMetadataBuilder {
     #[inline(always)]
     pub fn position_bundle_owner(
         &mut self,
-        position_bundle_owner: solana_program::pubkey::Pubkey,
+        position_bundle_owner: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_owner = Some(position_bundle_owner);
         self
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     #[inline(always)]
     pub fn metadata_update_auth(
         &mut self,
-        metadata_update_auth: solana_program::pubkey::Pubkey,
+        metadata_update_auth: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.metadata_update_auth = Some(metadata_update_auth);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
     #[inline(always)]
     pub fn associated_token_program(
         &mut self,
-        associated_token_program: solana_program::pubkey::Pubkey,
+        associated_token_program: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.associated_token_program = Some(associated_token_program);
         self
     }
     #[inline(always)]
-    pub fn metadata_program(
-        &mut self,
-        metadata_program: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn metadata_program(&mut self, metadata_program: solana_pubkey::Pubkey) -> &mut Self {
         self.metadata_program = Some(metadata_program);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -263,13 +251,13 @@ impl InitializePositionBundleWithMetadataBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializePositionBundleWithMetadata {
             position_bundle: self.position_bundle.expect("position_bundle is not set"),
             position_bundle_mint: self
@@ -288,13 +276,13 @@ impl InitializePositionBundleWithMetadataBuilder {
             metadata_update_auth: self
                 .metadata_update_auth
                 .expect("metadata_update_auth is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
             associated_token_program: self
@@ -309,64 +297,64 @@ impl InitializePositionBundleWithMetadataBuilder {
 
 /// `initialize_position_bundle_with_metadata` CPI accounts.
 pub struct InitializePositionBundleWithMetadataCpiAccounts<'a, 'b> {
-    pub position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_metadata: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_metadata: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub metadata_update_auth: &'b solana_program::account_info::AccountInfo<'a>,
+    pub metadata_update_auth: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub associated_token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub metadata_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize_position_bundle_with_metadata` CPI instruction.
 pub struct InitializePositionBundleWithMetadataCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_metadata: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_metadata: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub metadata_update_auth: &'b solana_program::account_info::AccountInfo<'a>,
+    pub metadata_update_auth: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub associated_token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub metadata_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> InitializePositionBundleWithMetadataCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializePositionBundleWithMetadataCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -386,25 +374,21 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -413,63 +397,56 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(12 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_bundle.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_bundle_mint.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_bundle_metadata.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_bundle_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_bundle_owner.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.metadata_update_auth.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.associated_token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.metadata_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -478,7 +455,7 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpi<'a, 'b> {
         let data =
             borsh::to_vec(&InitializePositionBundleWithMetadataInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -502,9 +479,9 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -531,7 +508,7 @@ pub struct InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializePositionBundleWithMetadataCpiBuilderInstruction {
             __program: program,
             position_bundle: None,
@@ -553,7 +530,7 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle(
         &mut self,
-        position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle = Some(position_bundle);
         self
@@ -561,7 +538,7 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_mint(
         &mut self,
-        position_bundle_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_mint = Some(position_bundle_mint);
         self
@@ -569,7 +546,7 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_metadata(
         &mut self,
-        position_bundle_metadata: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_metadata: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_metadata = Some(position_bundle_metadata);
         self
@@ -577,7 +554,7 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_token_account(
         &mut self,
-        position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_token_account = Some(position_bundle_token_account);
         self
@@ -585,23 +562,20 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_owner(
         &mut self,
-        position_bundle_owner: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_owner: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_owner = Some(position_bundle_owner);
         self
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
     pub fn metadata_update_auth(
         &mut self,
-        metadata_update_auth: &'b solana_program::account_info::AccountInfo<'a>,
+        metadata_update_auth: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata_update_auth = Some(metadata_update_auth);
         self
@@ -609,7 +583,7 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -617,20 +591,20 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
     #[inline(always)]
     pub fn associated_token_program(
         &mut self,
-        associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        associated_token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.associated_token_program = Some(associated_token_program);
         self
@@ -638,7 +612,7 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn metadata_program(
         &mut self,
-        metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
+        metadata_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata_program = Some(metadata_program);
         self
@@ -647,7 +621,7 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -663,11 +637,7 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -675,7 +645,7 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -683,7 +653,7 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = InitializePositionBundleWithMetadataCpi {
             __program: self.instruction.__program,
 
@@ -750,23 +720,19 @@ impl<'a, 'b> InitializePositionBundleWithMetadataCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializePositionBundleWithMetadataCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    position_bundle: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    metadata_update_auth: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    associated_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    metadata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    position_bundle: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_metadata: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_owner: Option<&'b solana_account_info::AccountInfo<'a>>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    metadata_update_auth: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
+    associated_token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    metadata_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_reward.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_reward.rs
@@ -11,28 +11,28 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializeReward {
-    pub reward_authority: solana_program::pubkey::Pubkey,
+    pub reward_authority: solana_pubkey::Pubkey,
 
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub reward_mint: solana_program::pubkey::Pubkey,
+    pub reward_mint: solana_pubkey::Pubkey,
 
-    pub reward_vault: solana_program::pubkey::Pubkey,
+    pub reward_vault: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 }
 
 impl InitializeReward {
     pub fn instruction(
         &self,
         args: InitializeRewardInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -40,38 +40,32 @@ impl InitializeReward {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: InitializeRewardInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_mint,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.reward_vault,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
         accounts.extend_from_slice(remaining_accounts);
@@ -79,7 +73,7 @@ impl InitializeReward {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -127,16 +121,16 @@ pub struct InitializeRewardInstructionArgs {
 ///   7. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializeRewardBuilder {
-    reward_authority: Option<solana_program::pubkey::Pubkey>,
-    funder: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    reward_mint: Option<solana_program::pubkey::Pubkey>,
-    reward_vault: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
+    reward_authority: Option<solana_pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    reward_mint: Option<solana_pubkey::Pubkey>,
+    reward_vault: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
     reward_index: Option<u8>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializeRewardBuilder {
@@ -144,48 +138,45 @@ impl InitializeRewardBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn reward_authority(
-        &mut self,
-        reward_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn reward_authority(&mut self, reward_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_authority = Some(reward_authority);
         self
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn reward_mint(&mut self, reward_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn reward_mint(&mut self, reward_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_mint = Some(reward_mint);
         self
     }
     #[inline(always)]
-    pub fn reward_vault(&mut self, reward_vault: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn reward_vault(&mut self, reward_vault: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_vault = Some(reward_vault);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
@@ -196,10 +187,7 @@ impl InitializeRewardBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -207,26 +195,26 @@ impl InitializeRewardBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializeReward {
             reward_authority: self.reward_authority.expect("reward_authority is not set"),
             funder: self.funder.expect("funder is not set"),
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
             reward_mint: self.reward_mint.expect("reward_mint is not set"),
             reward_vault: self.reward_vault.expect("reward_vault is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
         };
@@ -240,50 +228,50 @@ impl InitializeRewardBuilder {
 
 /// `initialize_reward` CPI accounts.
 pub struct InitializeRewardCpiAccounts<'a, 'b> {
-    pub reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize_reward` CPI instruction.
 pub struct InitializeRewardCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: InitializeRewardInstructionArgs,
 }
 
 impl<'a, 'b> InitializeRewardCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializeRewardCpiAccounts<'a, 'b>,
         args: InitializeRewardInstructionArgs,
     ) -> Self {
@@ -301,25 +289,21 @@ impl<'a, 'b> InitializeRewardCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -328,47 +312,40 @@ impl<'a, 'b> InitializeRewardCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.reward_vault.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -378,7 +355,7 @@ impl<'a, 'b> InitializeRewardCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -398,9 +375,9 @@ impl<'a, 'b> InitializeRewardCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -423,7 +400,7 @@ pub struct InitializeRewardCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializeRewardCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializeRewardCpiBuilderInstruction {
             __program: program,
             reward_authority: None,
@@ -442,31 +419,25 @@ impl<'a, 'b> InitializeRewardCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_authority(
         &mut self,
-        reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_authority = Some(reward_authority);
         self
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn reward_mint(
         &mut self,
-        reward_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_mint = Some(reward_mint);
         self
@@ -474,7 +445,7 @@ impl<'a, 'b> InitializeRewardCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_vault(
         &mut self,
-        reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_vault: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_vault = Some(reward_vault);
         self
@@ -482,7 +453,7 @@ impl<'a, 'b> InitializeRewardCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -490,13 +461,13 @@ impl<'a, 'b> InitializeRewardCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -509,7 +480,7 @@ impl<'a, 'b> InitializeRewardCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -525,11 +496,7 @@ impl<'a, 'b> InitializeRewardCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -537,7 +504,7 @@ impl<'a, 'b> InitializeRewardCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -545,7 +512,7 @@ impl<'a, 'b> InitializeRewardCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = InitializeRewardInstructionArgs {
             reward_index: self
                 .instruction
@@ -597,20 +564,16 @@ impl<'a, 'b> InitializeRewardCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializeRewardCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    reward_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    reward_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_vault: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
     reward_index: Option<u8>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_reward_v2.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_reward_v2.rs
@@ -11,30 +11,30 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializeRewardV2 {
-    pub reward_authority: solana_program::pubkey::Pubkey,
+    pub reward_authority: solana_pubkey::Pubkey,
 
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub reward_mint: solana_program::pubkey::Pubkey,
+    pub reward_mint: solana_pubkey::Pubkey,
 
-    pub reward_token_badge: solana_program::pubkey::Pubkey,
+    pub reward_token_badge: solana_pubkey::Pubkey,
 
-    pub reward_vault: solana_program::pubkey::Pubkey,
+    pub reward_vault: solana_pubkey::Pubkey,
 
-    pub reward_token_program: solana_program::pubkey::Pubkey,
+    pub reward_token_program: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 }
 
 impl InitializeRewardV2 {
     pub fn instruction(
         &self,
         args: InitializeRewardV2InstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -42,42 +42,36 @@ impl InitializeRewardV2 {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: InitializeRewardV2InstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_mint,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_token_badge,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.reward_vault,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
         accounts.extend_from_slice(remaining_accounts);
@@ -85,7 +79,7 @@ impl InitializeRewardV2 {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -134,17 +128,17 @@ pub struct InitializeRewardV2InstructionArgs {
 ///   8. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializeRewardV2Builder {
-    reward_authority: Option<solana_program::pubkey::Pubkey>,
-    funder: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    reward_mint: Option<solana_program::pubkey::Pubkey>,
-    reward_token_badge: Option<solana_program::pubkey::Pubkey>,
-    reward_vault: Option<solana_program::pubkey::Pubkey>,
-    reward_token_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
+    reward_authority: Option<solana_pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    reward_mint: Option<solana_pubkey::Pubkey>,
+    reward_token_badge: Option<solana_pubkey::Pubkey>,
+    reward_vault: Option<solana_pubkey::Pubkey>,
+    reward_token_program: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
     reward_index: Option<u8>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializeRewardV2Builder {
@@ -152,58 +146,52 @@ impl InitializeRewardV2Builder {
         Self::default()
     }
     #[inline(always)]
-    pub fn reward_authority(
-        &mut self,
-        reward_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn reward_authority(&mut self, reward_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_authority = Some(reward_authority);
         self
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn reward_mint(&mut self, reward_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn reward_mint(&mut self, reward_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_mint = Some(reward_mint);
         self
     }
     #[inline(always)]
-    pub fn reward_token_badge(
-        &mut self,
-        reward_token_badge: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn reward_token_badge(&mut self, reward_token_badge: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_token_badge = Some(reward_token_badge);
         self
     }
     #[inline(always)]
-    pub fn reward_vault(&mut self, reward_vault: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn reward_vault(&mut self, reward_vault: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_vault = Some(reward_vault);
         self
     }
     #[inline(always)]
     pub fn reward_token_program(
         &mut self,
-        reward_token_program: solana_program::pubkey::Pubkey,
+        reward_token_program: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.reward_token_program = Some(reward_token_program);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
@@ -214,10 +202,7 @@ impl InitializeRewardV2Builder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -225,13 +210,13 @@ impl InitializeRewardV2Builder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializeRewardV2 {
             reward_authority: self.reward_authority.expect("reward_authority is not set"),
             funder: self.funder.expect("funder is not set"),
@@ -246,8 +231,8 @@ impl InitializeRewardV2Builder {
                 .expect("reward_token_program is not set"),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
         };
@@ -261,54 +246,54 @@ impl InitializeRewardV2Builder {
 
 /// `initialize_reward_v2` CPI accounts.
 pub struct InitializeRewardV2CpiAccounts<'a, 'b> {
-    pub reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_token_badge: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_token_badge: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize_reward_v2` CPI instruction.
 pub struct InitializeRewardV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_token_badge: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_token_badge: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: InitializeRewardV2InstructionArgs,
 }
 
 impl<'a, 'b> InitializeRewardV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializeRewardV2CpiAccounts<'a, 'b>,
         args: InitializeRewardV2InstructionArgs,
     ) -> Self {
@@ -327,25 +312,21 @@ impl<'a, 'b> InitializeRewardV2Cpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -354,51 +335,44 @@ impl<'a, 'b> InitializeRewardV2Cpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_token_badge.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.reward_vault.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -408,7 +382,7 @@ impl<'a, 'b> InitializeRewardV2Cpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -429,9 +403,9 @@ impl<'a, 'b> InitializeRewardV2Cpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -455,7 +429,7 @@ pub struct InitializeRewardV2CpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializeRewardV2CpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializeRewardV2CpiBuilderInstruction {
             __program: program,
             reward_authority: None,
@@ -475,31 +449,25 @@ impl<'a, 'b> InitializeRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_authority(
         &mut self,
-        reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_authority = Some(reward_authority);
         self
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn reward_mint(
         &mut self,
-        reward_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_mint = Some(reward_mint);
         self
@@ -507,7 +475,7 @@ impl<'a, 'b> InitializeRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_token_badge(
         &mut self,
-        reward_token_badge: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_token_badge: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_token_badge = Some(reward_token_badge);
         self
@@ -515,7 +483,7 @@ impl<'a, 'b> InitializeRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_vault(
         &mut self,
-        reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_vault: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_vault = Some(reward_vault);
         self
@@ -523,7 +491,7 @@ impl<'a, 'b> InitializeRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_token_program(
         &mut self,
-        reward_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_token_program = Some(reward_token_program);
         self
@@ -531,13 +499,13 @@ impl<'a, 'b> InitializeRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -550,7 +518,7 @@ impl<'a, 'b> InitializeRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -566,11 +534,7 @@ impl<'a, 'b> InitializeRewardV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -578,7 +542,7 @@ impl<'a, 'b> InitializeRewardV2CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -586,7 +550,7 @@ impl<'a, 'b> InitializeRewardV2CpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = InitializeRewardV2InstructionArgs {
             reward_index: self
                 .instruction
@@ -643,21 +607,17 @@ impl<'a, 'b> InitializeRewardV2CpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializeRewardV2CpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    reward_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_token_badge: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    reward_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_token_badge: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_vault: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
     reward_index: Option<u8>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_tick_array.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_tick_array.rs
@@ -11,20 +11,20 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializeTickArray {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub tick_array: solana_program::pubkey::Pubkey,
+    pub tick_array: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 }
 
 impl InitializeTickArray {
     pub fn instruction(
         &self,
         args: InitializeTickArrayInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -32,22 +32,16 @@ impl InitializeTickArray {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: InitializeTickArrayInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpool,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.tick_array,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new(self.tick_array, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
@@ -56,7 +50,7 @@ impl InitializeTickArray {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -100,12 +94,12 @@ pub struct InitializeTickArrayInstructionArgs {
 ///   3. `[optional]` system_program (default to `11111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializeTickArrayBuilder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    funder: Option<solana_program::pubkey::Pubkey>,
-    tick_array: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    tick_array: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
     start_tick_index: Option<i32>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializeTickArrayBuilder {
@@ -113,23 +107,23 @@ impl InitializeTickArrayBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn tick_array(&mut self, tick_array: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn tick_array(&mut self, tick_array: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array = Some(tick_array);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
@@ -140,10 +134,7 @@ impl InitializeTickArrayBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -151,20 +142,20 @@ impl InitializeTickArrayBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializeTickArray {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
             funder: self.funder.expect("funder is not set"),
             tick_array: self.tick_array.expect("tick_array is not set"),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
         };
         let args = InitializeTickArrayInstructionArgs {
             start_tick_index: self
@@ -179,34 +170,34 @@ impl InitializeTickArrayBuilder {
 
 /// `initialize_tick_array` CPI accounts.
 pub struct InitializeTickArrayCpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize_tick_array` CPI instruction.
 pub struct InitializeTickArrayCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: InitializeTickArrayInstructionArgs,
 }
 
 impl<'a, 'b> InitializeTickArrayCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializeTickArrayCpiAccounts<'a, 'b>,
         args: InitializeTickArrayInstructionArgs,
     ) -> Self {
@@ -220,25 +211,21 @@ impl<'a, 'b> InitializeTickArrayCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -247,31 +234,24 @@ impl<'a, 'b> InitializeTickArrayCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -281,7 +261,7 @@ impl<'a, 'b> InitializeTickArrayCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -297,9 +277,9 @@ impl<'a, 'b> InitializeTickArrayCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -318,7 +298,7 @@ pub struct InitializeTickArrayCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializeTickArrayCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializeTickArrayCpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -331,25 +311,19 @@ impl<'a, 'b> InitializeTickArrayCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
     pub fn tick_array(
         &mut self,
-        tick_array: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array = Some(tick_array);
         self
@@ -357,7 +331,7 @@ impl<'a, 'b> InitializeTickArrayCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -371,7 +345,7 @@ impl<'a, 'b> InitializeTickArrayCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -387,11 +361,7 @@ impl<'a, 'b> InitializeTickArrayCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -399,7 +369,7 @@ impl<'a, 'b> InitializeTickArrayCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -407,7 +377,7 @@ impl<'a, 'b> InitializeTickArrayCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = InitializeTickArrayInstructionArgs {
             start_tick_index: self
                 .instruction
@@ -439,16 +409,12 @@ impl<'a, 'b> InitializeTickArrayCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializeTickArrayCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     start_tick_index: Option<i32>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_token_badge.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/initialize_token_badge.rs
@@ -11,64 +11,61 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializeTokenBadge {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub whirlpools_config_extension: solana_program::pubkey::Pubkey,
+    pub whirlpools_config_extension: solana_pubkey::Pubkey,
 
-    pub token_badge_authority: solana_program::pubkey::Pubkey,
+    pub token_badge_authority: solana_pubkey::Pubkey,
 
-    pub token_mint: solana_program::pubkey::Pubkey,
+    pub token_mint: solana_pubkey::Pubkey,
 
-    pub token_badge: solana_program::pubkey::Pubkey,
+    pub token_badge: solana_pubkey::Pubkey,
 
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 }
 
 impl InitializeTokenBadge {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config_extension,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_badge_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_badge,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&InitializeTokenBadgeInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -109,14 +106,14 @@ impl Default for InitializeTokenBadgeInstructionData {
 ///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializeTokenBadgeBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    whirlpools_config_extension: Option<solana_program::pubkey::Pubkey>,
-    token_badge_authority: Option<solana_program::pubkey::Pubkey>,
-    token_mint: Option<solana_program::pubkey::Pubkey>,
-    token_badge: Option<solana_program::pubkey::Pubkey>,
-    funder: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    whirlpools_config_extension: Option<solana_pubkey::Pubkey>,
+    token_badge_authority: Option<solana_pubkey::Pubkey>,
+    token_mint: Option<solana_pubkey::Pubkey>,
+    token_badge: Option<solana_pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializeTokenBadgeBuilder {
@@ -124,17 +121,14 @@ impl InitializeTokenBadgeBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
     pub fn whirlpools_config_extension(
         &mut self,
-        whirlpools_config_extension: solana_program::pubkey::Pubkey,
+        whirlpools_config_extension: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.whirlpools_config_extension = Some(whirlpools_config_extension);
         self
@@ -142,38 +136,35 @@ impl InitializeTokenBadgeBuilder {
     #[inline(always)]
     pub fn token_badge_authority(
         &mut self,
-        token_badge_authority: solana_program::pubkey::Pubkey,
+        token_badge_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_badge_authority = Some(token_badge_authority);
         self
     }
     #[inline(always)]
-    pub fn token_mint(&mut self, token_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint(&mut self, token_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint = Some(token_mint);
         self
     }
     #[inline(always)]
-    pub fn token_badge(&mut self, token_badge: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_badge(&mut self, token_badge: solana_pubkey::Pubkey) -> &mut Self {
         self.token_badge = Some(token_badge);
         self
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -181,13 +172,13 @@ impl InitializeTokenBadgeBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializeTokenBadge {
             whirlpools_config: self
                 .whirlpools_config
@@ -203,7 +194,7 @@ impl InitializeTokenBadgeBuilder {
             funder: self.funder.expect("funder is not set"),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
         };
 
         accounts.instruction_with_remaining_accounts(&self.__remaining_accounts)
@@ -212,44 +203,44 @@ impl InitializeTokenBadgeBuilder {
 
 /// `initialize_token_badge` CPI accounts.
 pub struct InitializeTokenBadgeCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config_extension: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_badge_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_badge_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_badge: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_badge: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize_token_badge` CPI instruction.
 pub struct InitializeTokenBadgeCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config_extension: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_badge_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_badge_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_badge: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_badge: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> InitializeTokenBadgeCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializeTokenBadgeCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -264,25 +255,21 @@ impl<'a, 'b> InitializeTokenBadgeCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -291,43 +278,36 @@ impl<'a, 'b> InitializeTokenBadgeCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config_extension.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_badge_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_badge.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -335,7 +315,7 @@ impl<'a, 'b> InitializeTokenBadgeCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&InitializeTokenBadgeInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -354,9 +334,9 @@ impl<'a, 'b> InitializeTokenBadgeCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -378,7 +358,7 @@ pub struct InitializeTokenBadgeCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializeTokenBadgeCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializeTokenBadgeCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -395,7 +375,7 @@ impl<'a, 'b> InitializeTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
@@ -403,7 +383,7 @@ impl<'a, 'b> InitializeTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config_extension(
         &mut self,
-        whirlpools_config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config_extension: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config_extension = Some(whirlpools_config_extension);
         self
@@ -411,7 +391,7 @@ impl<'a, 'b> InitializeTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_badge_authority(
         &mut self,
-        token_badge_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        token_badge_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_badge_authority = Some(token_badge_authority);
         self
@@ -419,7 +399,7 @@ impl<'a, 'b> InitializeTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint(
         &mut self,
-        token_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint = Some(token_mint);
         self
@@ -427,23 +407,20 @@ impl<'a, 'b> InitializeTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_badge(
         &mut self,
-        token_badge: &'b solana_program::account_info::AccountInfo<'a>,
+        token_badge: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_badge = Some(token_badge);
         self
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -452,7 +429,7 @@ impl<'a, 'b> InitializeTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -468,11 +445,7 @@ impl<'a, 'b> InitializeTokenBadgeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -480,7 +453,7 @@ impl<'a, 'b> InitializeTokenBadgeCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -488,7 +461,7 @@ impl<'a, 'b> InitializeTokenBadgeCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = InitializeTokenBadgeCpi {
             __program: self.instruction.__program,
 
@@ -530,18 +503,14 @@ impl<'a, 'b> InitializeTokenBadgeCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializeTokenBadgeCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpools_config_extension: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_badge_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_badge: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpools_config_extension: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_badge_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_badge: Option<&'b solana_account_info::AccountInfo<'a>>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/lock_position.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/lock_position.rs
@@ -12,30 +12,30 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct LockPosition {
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub position_authority: solana_program::pubkey::Pubkey,
+    pub position_authority: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_mint: solana_program::pubkey::Pubkey,
+    pub position_mint: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub lock_config: solana_program::pubkey::Pubkey,
+    pub lock_config: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub token2022_program: solana_program::pubkey::Pubkey,
+    pub token2022_program: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 }
 
 impl LockPosition {
     pub fn instruction(
         &self,
         args: LockPositionInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -43,42 +43,39 @@ impl LockPosition {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: LockPositionInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_mint,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.lock_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpool,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token2022_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
@@ -87,7 +84,7 @@ impl LockPosition {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -136,17 +133,17 @@ pub struct LockPositionInstructionArgs {
 ///   8. `[optional]` system_program (default to `11111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct LockPositionBuilder {
-    funder: Option<solana_program::pubkey::Pubkey>,
-    position_authority: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_mint: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    lock_config: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    token2022_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    position_authority: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_mint: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    lock_config: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    token2022_program: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
     lock_type: Option<LockType>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl LockPositionBuilder {
@@ -154,57 +151,51 @@ impl LockPositionBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn position_authority(
-        &mut self,
-        position_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_authority(&mut self, position_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
-    pub fn position_mint(&mut self, position_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position_mint(&mut self, position_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.position_mint = Some(position_mint);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
     }
     #[inline(always)]
-    pub fn lock_config(&mut self, lock_config: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn lock_config(&mut self, lock_config: solana_pubkey::Pubkey) -> &mut Self {
         self.lock_config = Some(lock_config);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn token2022_program(
-        &mut self,
-        token2022_program: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token2022_program(&mut self, token2022_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token2022_program = Some(token2022_program);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
@@ -215,10 +206,7 @@ impl LockPositionBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -226,13 +214,13 @@ impl LockPositionBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = LockPosition {
             funder: self.funder.expect("funder is not set"),
             position_authority: self
@@ -250,7 +238,7 @@ impl LockPositionBuilder {
                 .expect("token2022_program is not set"),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
         };
         let args = LockPositionInstructionArgs {
             lock_type: self.lock_type.clone().expect("lock_type is not set"),
@@ -262,54 +250,54 @@ impl LockPositionBuilder {
 
 /// `lock_position` CPI accounts.
 pub struct LockPositionCpiAccounts<'a, 'b> {
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lock_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lock_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token2022_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token2022_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `lock_position` CPI instruction.
 pub struct LockPositionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lock_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lock_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token2022_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token2022_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: LockPositionInstructionArgs,
 }
 
 impl<'a, 'b> LockPositionCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: LockPositionCpiAccounts<'a, 'b>,
         args: LockPositionInstructionArgs,
     ) -> Self {
@@ -328,25 +316,21 @@ impl<'a, 'b> LockPositionCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -355,51 +339,44 @@ impl<'a, 'b> LockPositionCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.lock_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token2022_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -409,7 +386,7 @@ impl<'a, 'b> LockPositionCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -430,9 +407,9 @@ impl<'a, 'b> LockPositionCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -456,7 +433,7 @@ pub struct LockPositionCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> LockPositionCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(LockPositionCpiBuilderInstruction {
             __program: program,
             funder: None,
@@ -474,33 +451,27 @@ impl<'a, 'b> LockPositionCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
     pub fn position_authority(
         &mut self,
-        position_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_authority = Some(position_authority);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_mint(
         &mut self,
-        position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        position_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_mint = Some(position_mint);
         self
@@ -508,7 +479,7 @@ impl<'a, 'b> LockPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
@@ -516,23 +487,20 @@ impl<'a, 'b> LockPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn lock_config(
         &mut self,
-        lock_config: &'b solana_program::account_info::AccountInfo<'a>,
+        lock_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.lock_config = Some(lock_config);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token2022_program(
         &mut self,
-        token2022_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token2022_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token2022_program = Some(token2022_program);
         self
@@ -540,7 +508,7 @@ impl<'a, 'b> LockPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -554,7 +522,7 @@ impl<'a, 'b> LockPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -570,11 +538,7 @@ impl<'a, 'b> LockPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -582,7 +546,7 @@ impl<'a, 'b> LockPositionCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -590,7 +554,7 @@ impl<'a, 'b> LockPositionCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = LockPositionInstructionArgs {
             lock_type: self
                 .instruction
@@ -647,21 +611,17 @@ impl<'a, 'b> LockPositionCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct LockPositionCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    lock_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token2022_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    lock_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token2022_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     lock_type: Option<LockType>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/open_bundled_position.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/open_bundled_position.rs
@@ -11,28 +11,28 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct OpenBundledPosition {
-    pub bundled_position: solana_program::pubkey::Pubkey,
+    pub bundled_position: solana_pubkey::Pubkey,
 
-    pub position_bundle: solana_program::pubkey::Pubkey,
+    pub position_bundle: solana_pubkey::Pubkey,
 
-    pub position_bundle_token_account: solana_program::pubkey::Pubkey,
+    pub position_bundle_token_account: solana_pubkey::Pubkey,
 
-    pub position_bundle_authority: solana_program::pubkey::Pubkey,
+    pub position_bundle_authority: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 }
 
 impl OpenBundledPosition {
     pub fn instruction(
         &self,
         args: OpenBundledPositionInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -40,38 +40,35 @@ impl OpenBundledPosition {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: OpenBundledPositionInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.bundled_position,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_bundle,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_bundle_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.position_bundle_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpool,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
         accounts.extend_from_slice(remaining_accounts);
@@ -79,7 +76,7 @@ impl OpenBundledPosition {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -129,18 +126,18 @@ pub struct OpenBundledPositionInstructionArgs {
 ///   7. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct OpenBundledPositionBuilder {
-    bundled_position: Option<solana_program::pubkey::Pubkey>,
-    position_bundle: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_token_account: Option<solana_program::pubkey::Pubkey>,
-    position_bundle_authority: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    funder: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
+    bundled_position: Option<solana_pubkey::Pubkey>,
+    position_bundle: Option<solana_pubkey::Pubkey>,
+    position_bundle_token_account: Option<solana_pubkey::Pubkey>,
+    position_bundle_authority: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
     bundle_index: Option<u16>,
     tick_lower_index: Option<i32>,
     tick_upper_index: Option<i32>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl OpenBundledPositionBuilder {
@@ -148,25 +145,19 @@ impl OpenBundledPositionBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn bundled_position(
-        &mut self,
-        bundled_position: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn bundled_position(&mut self, bundled_position: solana_pubkey::Pubkey) -> &mut Self {
         self.bundled_position = Some(bundled_position);
         self
     }
     #[inline(always)]
-    pub fn position_bundle(
-        &mut self,
-        position_bundle: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn position_bundle(&mut self, position_bundle: solana_pubkey::Pubkey) -> &mut Self {
         self.position_bundle = Some(position_bundle);
         self
     }
     #[inline(always)]
     pub fn position_bundle_token_account(
         &mut self,
-        position_bundle_token_account: solana_program::pubkey::Pubkey,
+        position_bundle_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_token_account = Some(position_bundle_token_account);
         self
@@ -174,30 +165,30 @@ impl OpenBundledPositionBuilder {
     #[inline(always)]
     pub fn position_bundle_authority(
         &mut self,
-        position_bundle_authority: solana_program::pubkey::Pubkey,
+        position_bundle_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_bundle_authority = Some(position_bundle_authority);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
@@ -218,10 +209,7 @@ impl OpenBundledPositionBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -229,13 +217,13 @@ impl OpenBundledPositionBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = OpenBundledPosition {
             bundled_position: self.bundled_position.expect("bundled_position is not set"),
             position_bundle: self.position_bundle.expect("position_bundle is not set"),
@@ -249,8 +237,8 @@ impl OpenBundledPositionBuilder {
             funder: self.funder.expect("funder is not set"),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
         };
@@ -272,50 +260,50 @@ impl OpenBundledPositionBuilder {
 
 /// `open_bundled_position` CPI accounts.
 pub struct OpenBundledPositionCpiAccounts<'a, 'b> {
-    pub bundled_position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub bundled_position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `open_bundled_position` CPI instruction.
 pub struct OpenBundledPositionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub bundled_position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub bundled_position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_bundle_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_bundle_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: OpenBundledPositionInstructionArgs,
 }
 
 impl<'a, 'b> OpenBundledPositionCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: OpenBundledPositionCpiAccounts<'a, 'b>,
         args: OpenBundledPositionInstructionArgs,
     ) -> Self {
@@ -333,25 +321,21 @@ impl<'a, 'b> OpenBundledPositionCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -360,47 +344,40 @@ impl<'a, 'b> OpenBundledPositionCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.bundled_position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_bundle.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_bundle_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.position_bundle_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -410,7 +387,7 @@ impl<'a, 'b> OpenBundledPositionCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -430,9 +407,9 @@ impl<'a, 'b> OpenBundledPositionCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -455,7 +432,7 @@ pub struct OpenBundledPositionCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> OpenBundledPositionCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(OpenBundledPositionCpiBuilderInstruction {
             __program: program,
             bundled_position: None,
@@ -476,7 +453,7 @@ impl<'a, 'b> OpenBundledPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn bundled_position(
         &mut self,
-        bundled_position: &'b solana_program::account_info::AccountInfo<'a>,
+        bundled_position: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.bundled_position = Some(bundled_position);
         self
@@ -484,7 +461,7 @@ impl<'a, 'b> OpenBundledPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle(
         &mut self,
-        position_bundle: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle = Some(position_bundle);
         self
@@ -492,7 +469,7 @@ impl<'a, 'b> OpenBundledPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_token_account(
         &mut self,
-        position_bundle_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_token_account = Some(position_bundle_token_account);
         self
@@ -500,37 +477,31 @@ impl<'a, 'b> OpenBundledPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_bundle_authority(
         &mut self,
-        position_bundle_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        position_bundle_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_bundle_authority = Some(position_bundle_authority);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -553,7 +524,7 @@ impl<'a, 'b> OpenBundledPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -569,11 +540,7 @@ impl<'a, 'b> OpenBundledPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -581,7 +548,7 @@ impl<'a, 'b> OpenBundledPositionCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -589,7 +556,7 @@ impl<'a, 'b> OpenBundledPositionCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = OpenBundledPositionInstructionArgs {
             bundle_index: self
                 .instruction
@@ -651,22 +618,18 @@ impl<'a, 'b> OpenBundledPositionCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct OpenBundledPositionCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    bundled_position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_bundle_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    bundled_position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_bundle_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
     bundle_index: Option<u16>,
     tick_lower_index: Option<i32>,
     tick_upper_index: Option<i32>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/open_position.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/open_position.rs
@@ -11,32 +11,32 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct OpenPosition {
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub owner: solana_program::pubkey::Pubkey,
+    pub owner: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_mint: solana_program::pubkey::Pubkey,
+    pub position_mint: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 
-    pub associated_token_program: solana_program::pubkey::Pubkey,
+    pub associated_token_program: solana_pubkey::Pubkey,
 }
 
 impl OpenPosition {
     pub fn instruction(
         &self,
         args: OpenPositionInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -44,44 +44,38 @@ impl OpenPosition {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: OpenPositionInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.owner, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_mint,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpool,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.associated_token_program,
             false,
         ));
@@ -90,7 +84,7 @@ impl OpenPosition {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -142,20 +136,20 @@ pub struct OpenPositionInstructionArgs {
 ///   9. `[]` associated_token_program
 #[derive(Clone, Debug, Default)]
 pub struct OpenPositionBuilder {
-    funder: Option<solana_program::pubkey::Pubkey>,
-    owner: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_mint: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
-    associated_token_program: Option<solana_program::pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    owner: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_mint: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
+    associated_token_program: Option<solana_pubkey::Pubkey>,
     position_bump: Option<u8>,
     tick_lower_index: Option<i32>,
     tick_upper_index: Option<i32>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl OpenPositionBuilder {
@@ -163,60 +157,60 @@ impl OpenPositionBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn owner(&mut self, owner: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn owner(&mut self, owner: solana_pubkey::Pubkey) -> &mut Self {
         self.owner = Some(owner);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
-    pub fn position_mint(&mut self, position_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position_mint(&mut self, position_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.position_mint = Some(position_mint);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
     #[inline(always)]
     pub fn associated_token_program(
         &mut self,
-        associated_token_program: solana_program::pubkey::Pubkey,
+        associated_token_program: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.associated_token_program = Some(associated_token_program);
         self
@@ -238,10 +232,7 @@ impl OpenPositionBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -249,13 +240,13 @@ impl OpenPositionBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = OpenPosition {
             funder: self.funder.expect("funder is not set"),
             owner: self.owner.expect("owner is not set"),
@@ -265,13 +256,13 @@ impl OpenPositionBuilder {
                 .position_token_account
                 .expect("position_token_account is not set"),
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
             associated_token_program: self
@@ -299,58 +290,58 @@ impl OpenPositionBuilder {
 
 /// `open_position` CPI accounts.
 pub struct OpenPositionCpiAccounts<'a, 'b> {
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub associated_token_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `open_position` CPI instruction.
 pub struct OpenPositionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub associated_token_program: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: OpenPositionInstructionArgs,
 }
 
 impl<'a, 'b> OpenPositionCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: OpenPositionCpiAccounts<'a, 'b>,
         args: OpenPositionInstructionArgs,
     ) -> Self {
@@ -370,25 +361,21 @@ impl<'a, 'b> OpenPositionCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -397,55 +384,48 @@ impl<'a, 'b> OpenPositionCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.owner.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_mint.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.associated_token_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -455,7 +435,7 @@ impl<'a, 'b> OpenPositionCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -477,9 +457,9 @@ impl<'a, 'b> OpenPositionCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -504,7 +484,7 @@ pub struct OpenPositionCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> OpenPositionCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(OpenPositionCpiBuilderInstruction {
             __program: program,
             funder: None,
@@ -525,30 +505,24 @@ impl<'a, 'b> OpenPositionCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_mint(
         &mut self,
-        position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        position_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_mint = Some(position_mint);
         self
@@ -556,23 +530,20 @@ impl<'a, 'b> OpenPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -580,20 +551,20 @@ impl<'a, 'b> OpenPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
     #[inline(always)]
     pub fn associated_token_program(
         &mut self,
-        associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        associated_token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.associated_token_program = Some(associated_token_program);
         self
@@ -617,7 +588,7 @@ impl<'a, 'b> OpenPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -633,11 +604,7 @@ impl<'a, 'b> OpenPositionCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -645,7 +612,7 @@ impl<'a, 'b> OpenPositionCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -653,7 +620,7 @@ impl<'a, 'b> OpenPositionCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = OpenPositionInstructionArgs {
             position_bump: self
                 .instruction
@@ -719,24 +686,20 @@ impl<'a, 'b> OpenPositionCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct OpenPositionCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    associated_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
+    associated_token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     position_bump: Option<u8>,
     tick_lower_index: Option<i32>,
     tick_upper_index: Option<i32>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/open_position_with_metadata.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/open_position_with_metadata.rs
@@ -11,38 +11,38 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct OpenPositionWithMetadata {
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub owner: solana_program::pubkey::Pubkey,
+    pub owner: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_mint: solana_program::pubkey::Pubkey,
+    pub position_mint: solana_pubkey::Pubkey,
 
-    pub position_metadata_account: solana_program::pubkey::Pubkey,
+    pub position_metadata_account: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 
-    pub associated_token_program: solana_program::pubkey::Pubkey,
+    pub associated_token_program: solana_pubkey::Pubkey,
 
-    pub metadata_program: solana_program::pubkey::Pubkey,
+    pub metadata_program: solana_pubkey::Pubkey,
 
-    pub metadata_update_auth: solana_program::pubkey::Pubkey,
+    pub metadata_update_auth: solana_pubkey::Pubkey,
 }
 
 impl OpenPositionWithMetadata {
     pub fn instruction(
         &self,
         args: OpenPositionWithMetadataInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -50,56 +50,50 @@ impl OpenPositionWithMetadata {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: OpenPositionWithMetadataInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(13 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.owner, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_mint,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_metadata_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpool,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.associated_token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.metadata_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.metadata_update_auth,
             false,
         ));
@@ -108,7 +102,7 @@ impl OpenPositionWithMetadata {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -164,24 +158,24 @@ pub struct OpenPositionWithMetadataInstructionArgs {
 ///   12. `[]` metadata_update_auth
 #[derive(Clone, Debug, Default)]
 pub struct OpenPositionWithMetadataBuilder {
-    funder: Option<solana_program::pubkey::Pubkey>,
-    owner: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_mint: Option<solana_program::pubkey::Pubkey>,
-    position_metadata_account: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
-    associated_token_program: Option<solana_program::pubkey::Pubkey>,
-    metadata_program: Option<solana_program::pubkey::Pubkey>,
-    metadata_update_auth: Option<solana_program::pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    owner: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_mint: Option<solana_pubkey::Pubkey>,
+    position_metadata_account: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
+    associated_token_program: Option<solana_pubkey::Pubkey>,
+    metadata_program: Option<solana_pubkey::Pubkey>,
+    metadata_update_auth: Option<solana_pubkey::Pubkey>,
     position_bump: Option<u8>,
     metadata_bump: Option<u8>,
     tick_lower_index: Option<i32>,
     tick_upper_index: Option<i32>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl OpenPositionWithMetadataBuilder {
@@ -189,29 +183,29 @@ impl OpenPositionWithMetadataBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn owner(&mut self, owner: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn owner(&mut self, owner: solana_pubkey::Pubkey) -> &mut Self {
         self.owner = Some(owner);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
-    pub fn position_mint(&mut self, position_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position_mint(&mut self, position_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.position_mint = Some(position_mint);
         self
     }
     #[inline(always)]
     pub fn position_metadata_account(
         &mut self,
-        position_metadata_account: solana_program::pubkey::Pubkey,
+        position_metadata_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_metadata_account = Some(position_metadata_account);
         self
@@ -219,54 +213,51 @@ impl OpenPositionWithMetadataBuilder {
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
     #[inline(always)]
     pub fn associated_token_program(
         &mut self,
-        associated_token_program: solana_program::pubkey::Pubkey,
+        associated_token_program: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.associated_token_program = Some(associated_token_program);
         self
     }
     #[inline(always)]
-    pub fn metadata_program(
-        &mut self,
-        metadata_program: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn metadata_program(&mut self, metadata_program: solana_pubkey::Pubkey) -> &mut Self {
         self.metadata_program = Some(metadata_program);
         self
     }
     #[inline(always)]
     pub fn metadata_update_auth(
         &mut self,
-        metadata_update_auth: solana_program::pubkey::Pubkey,
+        metadata_update_auth: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.metadata_update_auth = Some(metadata_update_auth);
         self
@@ -293,10 +284,7 @@ impl OpenPositionWithMetadataBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -304,13 +292,13 @@ impl OpenPositionWithMetadataBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = OpenPositionWithMetadata {
             funder: self.funder.expect("funder is not set"),
             owner: self.owner.expect("owner is not set"),
@@ -323,13 +311,13 @@ impl OpenPositionWithMetadataBuilder {
                 .position_token_account
                 .expect("position_token_account is not set"),
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
             associated_token_program: self
@@ -365,70 +353,70 @@ impl OpenPositionWithMetadataBuilder {
 
 /// `open_position_with_metadata` CPI accounts.
 pub struct OpenPositionWithMetadataCpiAccounts<'a, 'b> {
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_metadata_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_metadata_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub associated_token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub metadata_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub metadata_update_auth: &'b solana_program::account_info::AccountInfo<'a>,
+    pub metadata_update_auth: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `open_position_with_metadata` CPI instruction.
 pub struct OpenPositionWithMetadataCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_metadata_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_metadata_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub associated_token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub metadata_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub metadata_update_auth: &'b solana_program::account_info::AccountInfo<'a>,
+    pub metadata_update_auth: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: OpenPositionWithMetadataInstructionArgs,
 }
 
 impl<'a, 'b> OpenPositionWithMetadataCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: OpenPositionWithMetadataCpiAccounts<'a, 'b>,
         args: OpenPositionWithMetadataInstructionArgs,
     ) -> Self {
@@ -451,25 +439,21 @@ impl<'a, 'b> OpenPositionWithMetadataCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -478,67 +462,60 @@ impl<'a, 'b> OpenPositionWithMetadataCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(13 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.owner.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_mint.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_metadata_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.associated_token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.metadata_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.metadata_update_auth.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -548,7 +525,7 @@ impl<'a, 'b> OpenPositionWithMetadataCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -573,9 +550,9 @@ impl<'a, 'b> OpenPositionWithMetadataCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -603,7 +580,7 @@ pub struct OpenPositionWithMetadataCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> OpenPositionWithMetadataCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(OpenPositionWithMetadataCpiBuilderInstruction {
             __program: program,
             funder: None,
@@ -628,30 +605,24 @@ impl<'a, 'b> OpenPositionWithMetadataCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_mint(
         &mut self,
-        position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        position_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_mint = Some(position_mint);
         self
@@ -659,7 +630,7 @@ impl<'a, 'b> OpenPositionWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_metadata_account(
         &mut self,
-        position_metadata_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_metadata_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_metadata_account = Some(position_metadata_account);
         self
@@ -667,23 +638,20 @@ impl<'a, 'b> OpenPositionWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -691,20 +659,20 @@ impl<'a, 'b> OpenPositionWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
     #[inline(always)]
     pub fn associated_token_program(
         &mut self,
-        associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        associated_token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.associated_token_program = Some(associated_token_program);
         self
@@ -712,7 +680,7 @@ impl<'a, 'b> OpenPositionWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn metadata_program(
         &mut self,
-        metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
+        metadata_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata_program = Some(metadata_program);
         self
@@ -720,7 +688,7 @@ impl<'a, 'b> OpenPositionWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn metadata_update_auth(
         &mut self,
-        metadata_update_auth: &'b solana_program::account_info::AccountInfo<'a>,
+        metadata_update_auth: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata_update_auth = Some(metadata_update_auth);
         self
@@ -749,7 +717,7 @@ impl<'a, 'b> OpenPositionWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -765,11 +733,7 @@ impl<'a, 'b> OpenPositionWithMetadataCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -777,7 +741,7 @@ impl<'a, 'b> OpenPositionWithMetadataCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -785,7 +749,7 @@ impl<'a, 'b> OpenPositionWithMetadataCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = OpenPositionWithMetadataInstructionArgs {
             position_bump: self
                 .instruction
@@ -871,28 +835,24 @@ impl<'a, 'b> OpenPositionWithMetadataCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct OpenPositionWithMetadataCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_metadata_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    associated_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    metadata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    metadata_update_auth: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_metadata_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
+    associated_token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    metadata_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    metadata_update_auth: Option<&'b solana_account_info::AccountInfo<'a>>,
     position_bump: Option<u8>,
     metadata_bump: Option<u8>,
     tick_lower_index: Option<i32>,
     tick_upper_index: Option<i32>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/open_position_with_token_extensions.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/open_position_with_token_extensions.rs
@@ -11,32 +11,32 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct OpenPositionWithTokenExtensions {
-    pub funder: solana_program::pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
 
-    pub owner: solana_program::pubkey::Pubkey,
+    pub owner: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub position_mint: solana_program::pubkey::Pubkey,
+    pub position_mint: solana_pubkey::Pubkey,
 
-    pub position_token_account: solana_program::pubkey::Pubkey,
+    pub position_token_account: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub token2022_program: solana_program::pubkey::Pubkey,
+    pub token2022_program: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub associated_token_program: solana_program::pubkey::Pubkey,
+    pub associated_token_program: solana_pubkey::Pubkey,
 
-    pub metadata_update_auth: solana_program::pubkey::Pubkey,
+    pub metadata_update_auth: solana_pubkey::Pubkey,
 }
 
 impl OpenPositionWithTokenExtensions {
     pub fn instruction(
         &self,
         args: OpenPositionWithTokenExtensionsInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -44,45 +44,39 @@ impl OpenPositionWithTokenExtensions {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: OpenPositionWithTokenExtensionsInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.funder,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.funder, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.owner, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_mint,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.position_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpool,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token2022_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.associated_token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.metadata_update_auth,
             false,
         ));
@@ -92,7 +86,7 @@ impl OpenPositionWithTokenExtensions {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -144,20 +138,20 @@ pub struct OpenPositionWithTokenExtensionsInstructionArgs {
 ///   9. `[]` metadata_update_auth
 #[derive(Clone, Debug, Default)]
 pub struct OpenPositionWithTokenExtensionsBuilder {
-    funder: Option<solana_program::pubkey::Pubkey>,
-    owner: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    position_mint: Option<solana_program::pubkey::Pubkey>,
-    position_token_account: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    token2022_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    associated_token_program: Option<solana_program::pubkey::Pubkey>,
-    metadata_update_auth: Option<solana_program::pubkey::Pubkey>,
+    funder: Option<solana_pubkey::Pubkey>,
+    owner: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    position_mint: Option<solana_pubkey::Pubkey>,
+    position_token_account: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    token2022_program: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    associated_token_program: Option<solana_pubkey::Pubkey>,
+    metadata_update_auth: Option<solana_pubkey::Pubkey>,
     tick_lower_index: Option<i32>,
     tick_upper_index: Option<i32>,
     with_token_metadata_extension: Option<bool>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl OpenPositionWithTokenExtensionsBuilder {
@@ -165,56 +159,53 @@ impl OpenPositionWithTokenExtensionsBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn funder(&mut self, funder: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn funder(&mut self, funder: solana_pubkey::Pubkey) -> &mut Self {
         self.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn owner(&mut self, owner: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn owner(&mut self, owner: solana_pubkey::Pubkey) -> &mut Self {
         self.owner = Some(owner);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
-    pub fn position_mint(&mut self, position_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position_mint(&mut self, position_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.position_mint = Some(position_mint);
         self
     }
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: solana_program::pubkey::Pubkey,
+        position_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.position_token_account = Some(position_token_account);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn token2022_program(
-        &mut self,
-        token2022_program: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token2022_program(&mut self, token2022_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token2022_program = Some(token2022_program);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     #[inline(always)]
     pub fn associated_token_program(
         &mut self,
-        associated_token_program: solana_program::pubkey::Pubkey,
+        associated_token_program: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.associated_token_program = Some(associated_token_program);
         self
@@ -222,7 +213,7 @@ impl OpenPositionWithTokenExtensionsBuilder {
     #[inline(always)]
     pub fn metadata_update_auth(
         &mut self,
-        metadata_update_auth: solana_program::pubkey::Pubkey,
+        metadata_update_auth: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.metadata_update_auth = Some(metadata_update_auth);
         self
@@ -247,10 +238,7 @@ impl OpenPositionWithTokenExtensionsBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -258,13 +246,13 @@ impl OpenPositionWithTokenExtensionsBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = OpenPositionWithTokenExtensions {
             funder: self.funder.expect("funder is not set"),
             owner: self.owner.expect("owner is not set"),
@@ -279,7 +267,7 @@ impl OpenPositionWithTokenExtensionsBuilder {
                 .expect("token2022_program is not set"),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
             associated_token_program: self
                 .associated_token_program
                 .expect("associated_token_program is not set"),
@@ -308,58 +296,58 @@ impl OpenPositionWithTokenExtensionsBuilder {
 
 /// `open_position_with_token_extensions` CPI accounts.
 pub struct OpenPositionWithTokenExtensionsCpiAccounts<'a, 'b> {
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token2022_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token2022_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub associated_token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub metadata_update_auth: &'b solana_program::account_info::AccountInfo<'a>,
+    pub metadata_update_auth: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `open_position_with_token_extensions` CPI instruction.
 pub struct OpenPositionWithTokenExtensionsCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub funder: &'b solana_program::account_info::AccountInfo<'a>,
+    pub funder: &'b solana_account_info::AccountInfo<'a>,
 
-    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token2022_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token2022_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub associated_token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub metadata_update_auth: &'b solana_program::account_info::AccountInfo<'a>,
+    pub metadata_update_auth: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: OpenPositionWithTokenExtensionsInstructionArgs,
 }
 
 impl<'a, 'b> OpenPositionWithTokenExtensionsCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: OpenPositionWithTokenExtensionsCpiAccounts<'a, 'b>,
         args: OpenPositionWithTokenExtensionsInstructionArgs,
     ) -> Self {
@@ -379,25 +367,21 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -406,55 +390,48 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.funder.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.funder.key, true));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.owner.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_mint.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token2022_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.associated_token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.metadata_update_auth.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -465,7 +442,7 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -487,9 +464,9 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -514,7 +491,7 @@ pub struct OpenPositionWithTokenExtensionsCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> OpenPositionWithTokenExtensionsCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(OpenPositionWithTokenExtensionsCpiBuilderInstruction {
             __program: program,
             funder: None,
@@ -535,30 +512,24 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn funder(
-        &mut self,
-        funder: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn funder(&mut self, funder: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.funder = Some(funder);
         self
     }
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn position_mint(
         &mut self,
-        position_mint: &'b solana_program::account_info::AccountInfo<'a>,
+        position_mint: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_mint = Some(position_mint);
         self
@@ -566,23 +537,20 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn position_token_account(
         &mut self,
-        position_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        position_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.position_token_account = Some(position_token_account);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token2022_program(
         &mut self,
-        token2022_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token2022_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token2022_program = Some(token2022_program);
         self
@@ -590,7 +558,7 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -598,7 +566,7 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn associated_token_program(
         &mut self,
-        associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        associated_token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.associated_token_program = Some(associated_token_program);
         self
@@ -606,7 +574,7 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn metadata_update_auth(
         &mut self,
-        metadata_update_auth: &'b solana_program::account_info::AccountInfo<'a>,
+        metadata_update_auth: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata_update_auth = Some(metadata_update_auth);
         self
@@ -633,7 +601,7 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -649,11 +617,7 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -661,7 +625,7 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -669,7 +633,7 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = OpenPositionWithTokenExtensionsInstructionArgs {
             tick_lower_index: self
                 .instruction
@@ -738,24 +702,20 @@ impl<'a, 'b> OpenPositionWithTokenExtensionsCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct OpenPositionWithTokenExtensionsCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    funder: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token2022_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    associated_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    metadata_update_auth: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    funder: Option<&'b solana_account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token2022_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    associated_token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    metadata_update_auth: Option<&'b solana_account_info::AccountInfo<'a>>,
     tick_lower_index: Option<i32>,
     tick_upper_index: Option<i32>,
     with_token_metadata_extension: Option<bool>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_collect_protocol_fees_authority.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_collect_protocol_fees_authority.rs
@@ -11,40 +11,40 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetCollectProtocolFeesAuthority {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub collect_protocol_fees_authority: solana_program::pubkey::Pubkey,
+    pub collect_protocol_fees_authority: solana_pubkey::Pubkey,
 
-    pub new_collect_protocol_fees_authority: solana_program::pubkey::Pubkey,
+    pub new_collect_protocol_fees_authority: solana_pubkey::Pubkey,
 }
 
 impl SetCollectProtocolFeesAuthority {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.collect_protocol_fees_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.new_collect_protocol_fees_authority,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&SetCollectProtocolFeesAuthorityInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -81,10 +81,10 @@ impl Default for SetCollectProtocolFeesAuthorityInstructionData {
 ///   2. `[]` new_collect_protocol_fees_authority
 #[derive(Clone, Debug, Default)]
 pub struct SetCollectProtocolFeesAuthorityBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    collect_protocol_fees_authority: Option<solana_program::pubkey::Pubkey>,
-    new_collect_protocol_fees_authority: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    collect_protocol_fees_authority: Option<solana_pubkey::Pubkey>,
+    new_collect_protocol_fees_authority: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetCollectProtocolFeesAuthorityBuilder {
@@ -92,17 +92,14 @@ impl SetCollectProtocolFeesAuthorityBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
     pub fn collect_protocol_fees_authority(
         &mut self,
-        collect_protocol_fees_authority: solana_program::pubkey::Pubkey,
+        collect_protocol_fees_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.collect_protocol_fees_authority = Some(collect_protocol_fees_authority);
         self
@@ -110,17 +107,14 @@ impl SetCollectProtocolFeesAuthorityBuilder {
     #[inline(always)]
     pub fn new_collect_protocol_fees_authority(
         &mut self,
-        new_collect_protocol_fees_authority: solana_program::pubkey::Pubkey,
+        new_collect_protocol_fees_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.new_collect_protocol_fees_authority = Some(new_collect_protocol_fees_authority);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -128,13 +122,13 @@ impl SetCollectProtocolFeesAuthorityBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetCollectProtocolFeesAuthority {
             whirlpools_config: self
                 .whirlpools_config
@@ -153,28 +147,28 @@ impl SetCollectProtocolFeesAuthorityBuilder {
 
 /// `set_collect_protocol_fees_authority` CPI accounts.
 pub struct SetCollectProtocolFeesAuthorityCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub collect_protocol_fees_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub collect_protocol_fees_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_collect_protocol_fees_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_collect_protocol_fees_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_collect_protocol_fees_authority` CPI instruction.
 pub struct SetCollectProtocolFeesAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub collect_protocol_fees_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub collect_protocol_fees_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_collect_protocol_fees_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_collect_protocol_fees_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> SetCollectProtocolFeesAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetCollectProtocolFeesAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -185,25 +179,21 @@ impl<'a, 'b> SetCollectProtocolFeesAuthorityCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -212,27 +202,23 @@ impl<'a, 'b> SetCollectProtocolFeesAuthorityCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.collect_protocol_fees_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.new_collect_protocol_fees_authority.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -240,7 +226,7 @@ impl<'a, 'b> SetCollectProtocolFeesAuthorityCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&SetCollectProtocolFeesAuthorityInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -255,9 +241,9 @@ impl<'a, 'b> SetCollectProtocolFeesAuthorityCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -275,7 +261,7 @@ pub struct SetCollectProtocolFeesAuthorityCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetCollectProtocolFeesAuthorityCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetCollectProtocolFeesAuthorityCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -288,7 +274,7 @@ impl<'a, 'b> SetCollectProtocolFeesAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
@@ -296,7 +282,7 @@ impl<'a, 'b> SetCollectProtocolFeesAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn collect_protocol_fees_authority(
         &mut self,
-        collect_protocol_fees_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        collect_protocol_fees_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collect_protocol_fees_authority = Some(collect_protocol_fees_authority);
         self
@@ -304,7 +290,7 @@ impl<'a, 'b> SetCollectProtocolFeesAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn new_collect_protocol_fees_authority(
         &mut self,
-        new_collect_protocol_fees_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        new_collect_protocol_fees_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_collect_protocol_fees_authority =
             Some(new_collect_protocol_fees_authority);
@@ -314,7 +300,7 @@ impl<'a, 'b> SetCollectProtocolFeesAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -330,11 +316,7 @@ impl<'a, 'b> SetCollectProtocolFeesAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -342,7 +324,7 @@ impl<'a, 'b> SetCollectProtocolFeesAuthorityCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -350,7 +332,7 @@ impl<'a, 'b> SetCollectProtocolFeesAuthorityCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = SetCollectProtocolFeesAuthorityCpi {
             __program: self.instruction.__program,
 
@@ -378,14 +360,10 @@ impl<'a, 'b> SetCollectProtocolFeesAuthorityCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetCollectProtocolFeesAuthorityCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    collect_protocol_fees_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    new_collect_protocol_fees_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    collect_protocol_fees_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    new_collect_protocol_fees_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_config_extension_authority.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_config_extension_authority.rs
@@ -11,46 +11,46 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetConfigExtensionAuthority {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub whirlpools_config_extension: solana_program::pubkey::Pubkey,
+    pub whirlpools_config_extension: solana_pubkey::Pubkey,
 
-    pub config_extension_authority: solana_program::pubkey::Pubkey,
+    pub config_extension_authority: solana_pubkey::Pubkey,
 
-    pub new_config_extension_authority: solana_program::pubkey::Pubkey,
+    pub new_config_extension_authority: solana_pubkey::Pubkey,
 }
 
 impl SetConfigExtensionAuthority {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.whirlpools_config_extension,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.config_extension_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.new_config_extension_authority,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&SetConfigExtensionAuthorityInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -88,11 +88,11 @@ impl Default for SetConfigExtensionAuthorityInstructionData {
 ///   3. `[]` new_config_extension_authority
 #[derive(Clone, Debug, Default)]
 pub struct SetConfigExtensionAuthorityBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    whirlpools_config_extension: Option<solana_program::pubkey::Pubkey>,
-    config_extension_authority: Option<solana_program::pubkey::Pubkey>,
-    new_config_extension_authority: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    whirlpools_config_extension: Option<solana_pubkey::Pubkey>,
+    config_extension_authority: Option<solana_pubkey::Pubkey>,
+    new_config_extension_authority: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetConfigExtensionAuthorityBuilder {
@@ -100,17 +100,14 @@ impl SetConfigExtensionAuthorityBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
     pub fn whirlpools_config_extension(
         &mut self,
-        whirlpools_config_extension: solana_program::pubkey::Pubkey,
+        whirlpools_config_extension: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.whirlpools_config_extension = Some(whirlpools_config_extension);
         self
@@ -118,7 +115,7 @@ impl SetConfigExtensionAuthorityBuilder {
     #[inline(always)]
     pub fn config_extension_authority(
         &mut self,
-        config_extension_authority: solana_program::pubkey::Pubkey,
+        config_extension_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.config_extension_authority = Some(config_extension_authority);
         self
@@ -126,17 +123,14 @@ impl SetConfigExtensionAuthorityBuilder {
     #[inline(always)]
     pub fn new_config_extension_authority(
         &mut self,
-        new_config_extension_authority: solana_program::pubkey::Pubkey,
+        new_config_extension_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.new_config_extension_authority = Some(new_config_extension_authority);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -144,13 +138,13 @@ impl SetConfigExtensionAuthorityBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetConfigExtensionAuthority {
             whirlpools_config: self
                 .whirlpools_config
@@ -172,32 +166,32 @@ impl SetConfigExtensionAuthorityBuilder {
 
 /// `set_config_extension_authority` CPI accounts.
 pub struct SetConfigExtensionAuthorityCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config_extension: &'b solana_account_info::AccountInfo<'a>,
 
-    pub config_extension_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub config_extension_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_config_extension_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_config_extension_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_config_extension_authority` CPI instruction.
 pub struct SetConfigExtensionAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config_extension: &'b solana_account_info::AccountInfo<'a>,
 
-    pub config_extension_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub config_extension_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_config_extension_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_config_extension_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> SetConfigExtensionAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetConfigExtensionAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -209,25 +203,21 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -236,31 +226,27 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpools_config_extension.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.config_extension_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.new_config_extension_authority.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -268,7 +254,7 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&SetConfigExtensionAuthorityInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -284,9 +270,9 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -305,7 +291,7 @@ pub struct SetConfigExtensionAuthorityCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetConfigExtensionAuthorityCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetConfigExtensionAuthorityCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -319,7 +305,7 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
@@ -327,7 +313,7 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config_extension(
         &mut self,
-        whirlpools_config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config_extension: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config_extension = Some(whirlpools_config_extension);
         self
@@ -335,7 +321,7 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn config_extension_authority(
         &mut self,
-        config_extension_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        config_extension_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.config_extension_authority = Some(config_extension_authority);
         self
@@ -343,7 +329,7 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn new_config_extension_authority(
         &mut self,
-        new_config_extension_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        new_config_extension_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_config_extension_authority = Some(new_config_extension_authority);
         self
@@ -352,7 +338,7 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -368,11 +354,7 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -380,7 +362,7 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -388,7 +370,7 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = SetConfigExtensionAuthorityCpi {
             __program: self.instruction.__program,
 
@@ -421,15 +403,11 @@ impl<'a, 'b> SetConfigExtensionAuthorityCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetConfigExtensionAuthorityCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpools_config_extension: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    config_extension_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    new_config_extension_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpools_config_extension: Option<&'b solana_account_info::AccountInfo<'a>>,
+    config_extension_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    new_config_extension_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_default_fee_rate.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_default_fee_rate.rs
@@ -11,18 +11,18 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetDefaultFeeRate {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub fee_tier: solana_program::pubkey::Pubkey,
+    pub fee_tier: solana_pubkey::Pubkey,
 
-    pub fee_authority: solana_program::pubkey::Pubkey,
+    pub fee_authority: solana_pubkey::Pubkey,
 }
 
 impl SetDefaultFeeRate {
     pub fn instruction(
         &self,
         args: SetDefaultFeeRateInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -30,18 +30,15 @@ impl SetDefaultFeeRate {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SetDefaultFeeRateInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.fee_tier,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.fee_tier, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.fee_authority,
             true,
         ));
@@ -50,7 +47,7 @@ impl SetDefaultFeeRate {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -93,11 +90,11 @@ pub struct SetDefaultFeeRateInstructionArgs {
 ///   2. `[signer]` fee_authority
 #[derive(Clone, Debug, Default)]
 pub struct SetDefaultFeeRateBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    fee_tier: Option<solana_program::pubkey::Pubkey>,
-    fee_authority: Option<solana_program::pubkey::Pubkey>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    fee_tier: Option<solana_pubkey::Pubkey>,
+    fee_authority: Option<solana_pubkey::Pubkey>,
     default_fee_rate: Option<u16>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetDefaultFeeRateBuilder {
@@ -105,20 +102,17 @@ impl SetDefaultFeeRateBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn fee_tier(&mut self, fee_tier: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn fee_tier(&mut self, fee_tier: solana_pubkey::Pubkey) -> &mut Self {
         self.fee_tier = Some(fee_tier);
         self
     }
     #[inline(always)]
-    pub fn fee_authority(&mut self, fee_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn fee_authority(&mut self, fee_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.fee_authority = Some(fee_authority);
         self
     }
@@ -129,10 +123,7 @@ impl SetDefaultFeeRateBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -140,13 +131,13 @@ impl SetDefaultFeeRateBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetDefaultFeeRate {
             whirlpools_config: self
                 .whirlpools_config
@@ -167,30 +158,30 @@ impl SetDefaultFeeRateBuilder {
 
 /// `set_default_fee_rate` CPI accounts.
 pub struct SetDefaultFeeRateCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_tier: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_tier: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_default_fee_rate` CPI instruction.
 pub struct SetDefaultFeeRateCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_tier: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_tier: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SetDefaultFeeRateInstructionArgs,
 }
 
 impl<'a, 'b> SetDefaultFeeRateCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetDefaultFeeRateCpiAccounts<'a, 'b>,
         args: SetDefaultFeeRateInstructionArgs,
     ) -> Self {
@@ -203,25 +194,21 @@ impl<'a, 'b> SetDefaultFeeRateCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -230,27 +217,23 @@ impl<'a, 'b> SetDefaultFeeRateCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.fee_tier.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.fee_authority.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -260,7 +243,7 @@ impl<'a, 'b> SetDefaultFeeRateCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -275,9 +258,9 @@ impl<'a, 'b> SetDefaultFeeRateCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -295,7 +278,7 @@ pub struct SetDefaultFeeRateCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetDefaultFeeRateCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetDefaultFeeRateCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -309,23 +292,20 @@ impl<'a, 'b> SetDefaultFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn fee_tier(
-        &mut self,
-        fee_tier: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn fee_tier(&mut self, fee_tier: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.fee_tier = Some(fee_tier);
         self
     }
     #[inline(always)]
     pub fn fee_authority(
         &mut self,
-        fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        fee_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.fee_authority = Some(fee_authority);
         self
@@ -339,7 +319,7 @@ impl<'a, 'b> SetDefaultFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -355,11 +335,7 @@ impl<'a, 'b> SetDefaultFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -367,7 +343,7 @@ impl<'a, 'b> SetDefaultFeeRateCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -375,7 +351,7 @@ impl<'a, 'b> SetDefaultFeeRateCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SetDefaultFeeRateInstructionArgs {
             default_fee_rate: self
                 .instruction
@@ -408,15 +384,11 @@ impl<'a, 'b> SetDefaultFeeRateCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetDefaultFeeRateCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    fee_tier: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    fee_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    fee_tier: Option<&'b solana_account_info::AccountInfo<'a>>,
+    fee_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     default_fee_rate: Option<u16>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_default_protocol_fee_rate.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_default_protocol_fee_rate.rs
@@ -11,16 +11,16 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetDefaultProtocolFeeRate {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub fee_authority: solana_program::pubkey::Pubkey,
+    pub fee_authority: solana_pubkey::Pubkey,
 }
 
 impl SetDefaultProtocolFeeRate {
     pub fn instruction(
         &self,
         args: SetDefaultProtocolFeeRateInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -28,14 +28,14 @@ impl SetDefaultProtocolFeeRate {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SetDefaultProtocolFeeRateInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.fee_authority,
             true,
         ));
@@ -44,7 +44,7 @@ impl SetDefaultProtocolFeeRate {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -86,10 +86,10 @@ pub struct SetDefaultProtocolFeeRateInstructionArgs {
 ///   1. `[signer]` fee_authority
 #[derive(Clone, Debug, Default)]
 pub struct SetDefaultProtocolFeeRateBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    fee_authority: Option<solana_program::pubkey::Pubkey>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    fee_authority: Option<solana_pubkey::Pubkey>,
     default_protocol_fee_rate: Option<u16>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetDefaultProtocolFeeRateBuilder {
@@ -97,15 +97,12 @@ impl SetDefaultProtocolFeeRateBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn fee_authority(&mut self, fee_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn fee_authority(&mut self, fee_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.fee_authority = Some(fee_authority);
         self
     }
@@ -116,10 +113,7 @@ impl SetDefaultProtocolFeeRateBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -127,13 +121,13 @@ impl SetDefaultProtocolFeeRateBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetDefaultProtocolFeeRate {
             whirlpools_config: self
                 .whirlpools_config
@@ -153,26 +147,26 @@ impl SetDefaultProtocolFeeRateBuilder {
 
 /// `set_default_protocol_fee_rate` CPI accounts.
 pub struct SetDefaultProtocolFeeRateCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_default_protocol_fee_rate` CPI instruction.
 pub struct SetDefaultProtocolFeeRateCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SetDefaultProtocolFeeRateInstructionArgs,
 }
 
 impl<'a, 'b> SetDefaultProtocolFeeRateCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetDefaultProtocolFeeRateCpiAccounts<'a, 'b>,
         args: SetDefaultProtocolFeeRateInstructionArgs,
     ) -> Self {
@@ -184,25 +178,21 @@ impl<'a, 'b> SetDefaultProtocolFeeRateCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -211,23 +201,19 @@ impl<'a, 'b> SetDefaultProtocolFeeRateCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.fee_authority.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -237,7 +223,7 @@ impl<'a, 'b> SetDefaultProtocolFeeRateCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -251,9 +237,9 @@ impl<'a, 'b> SetDefaultProtocolFeeRateCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -270,7 +256,7 @@ pub struct SetDefaultProtocolFeeRateCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetDefaultProtocolFeeRateCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetDefaultProtocolFeeRateCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -283,7 +269,7 @@ impl<'a, 'b> SetDefaultProtocolFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
@@ -291,7 +277,7 @@ impl<'a, 'b> SetDefaultProtocolFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn fee_authority(
         &mut self,
-        fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        fee_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.fee_authority = Some(fee_authority);
         self
@@ -305,7 +291,7 @@ impl<'a, 'b> SetDefaultProtocolFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -321,11 +307,7 @@ impl<'a, 'b> SetDefaultProtocolFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -333,7 +315,7 @@ impl<'a, 'b> SetDefaultProtocolFeeRateCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -341,7 +323,7 @@ impl<'a, 'b> SetDefaultProtocolFeeRateCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SetDefaultProtocolFeeRateInstructionArgs {
             default_protocol_fee_rate: self
                 .instruction
@@ -372,14 +354,10 @@ impl<'a, 'b> SetDefaultProtocolFeeRateCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetDefaultProtocolFeeRateCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    fee_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    fee_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     default_protocol_fee_rate: Option<u16>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_fee_authority.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_fee_authority.rs
@@ -11,40 +11,40 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetFeeAuthority {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub fee_authority: solana_program::pubkey::Pubkey,
+    pub fee_authority: solana_pubkey::Pubkey,
 
-    pub new_fee_authority: solana_program::pubkey::Pubkey,
+    pub new_fee_authority: solana_pubkey::Pubkey,
 }
 
 impl SetFeeAuthority {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.fee_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.new_fee_authority,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&SetFeeAuthorityInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -81,10 +81,10 @@ impl Default for SetFeeAuthorityInstructionData {
 ///   2. `[]` new_fee_authority
 #[derive(Clone, Debug, Default)]
 pub struct SetFeeAuthorityBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    fee_authority: Option<solana_program::pubkey::Pubkey>,
-    new_fee_authority: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    fee_authority: Option<solana_pubkey::Pubkey>,
+    new_fee_authority: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetFeeAuthorityBuilder {
@@ -92,32 +92,23 @@ impl SetFeeAuthorityBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn fee_authority(&mut self, fee_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn fee_authority(&mut self, fee_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.fee_authority = Some(fee_authority);
         self
     }
     #[inline(always)]
-    pub fn new_fee_authority(
-        &mut self,
-        new_fee_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn new_fee_authority(&mut self, new_fee_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.new_fee_authority = Some(new_fee_authority);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -125,13 +116,13 @@ impl SetFeeAuthorityBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetFeeAuthority {
             whirlpools_config: self
                 .whirlpools_config
@@ -148,28 +139,28 @@ impl SetFeeAuthorityBuilder {
 
 /// `set_fee_authority` CPI accounts.
 pub struct SetFeeAuthorityCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_fee_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_fee_authority` CPI instruction.
 pub struct SetFeeAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_fee_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> SetFeeAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetFeeAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -180,25 +171,21 @@ impl<'a, 'b> SetFeeAuthorityCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -207,27 +194,23 @@ impl<'a, 'b> SetFeeAuthorityCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.fee_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.new_fee_authority.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -235,7 +218,7 @@ impl<'a, 'b> SetFeeAuthorityCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&SetFeeAuthorityInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -250,9 +233,9 @@ impl<'a, 'b> SetFeeAuthorityCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -270,7 +253,7 @@ pub struct SetFeeAuthorityCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetFeeAuthorityCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetFeeAuthorityCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -283,7 +266,7 @@ impl<'a, 'b> SetFeeAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
@@ -291,7 +274,7 @@ impl<'a, 'b> SetFeeAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn fee_authority(
         &mut self,
-        fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        fee_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.fee_authority = Some(fee_authority);
         self
@@ -299,7 +282,7 @@ impl<'a, 'b> SetFeeAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn new_fee_authority(
         &mut self,
-        new_fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        new_fee_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_fee_authority = Some(new_fee_authority);
         self
@@ -308,7 +291,7 @@ impl<'a, 'b> SetFeeAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -324,11 +307,7 @@ impl<'a, 'b> SetFeeAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -336,7 +315,7 @@ impl<'a, 'b> SetFeeAuthorityCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -344,7 +323,7 @@ impl<'a, 'b> SetFeeAuthorityCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = SetFeeAuthorityCpi {
             __program: self.instruction.__program,
 
@@ -372,14 +351,10 @@ impl<'a, 'b> SetFeeAuthorityCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetFeeAuthorityCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    fee_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    new_fee_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    fee_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    new_fee_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_fee_rate.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_fee_rate.rs
@@ -11,18 +11,15 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetFeeRate {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub fee_authority: solana_program::pubkey::Pubkey,
+    pub fee_authority: solana_pubkey::Pubkey,
 }
 
 impl SetFeeRate {
-    pub fn instruction(
-        &self,
-        args: SetFeeRateInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: SetFeeRateInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -30,18 +27,15 @@ impl SetFeeRate {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SetFeeRateInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.fee_authority,
             true,
         ));
@@ -50,7 +44,7 @@ impl SetFeeRate {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -93,11 +87,11 @@ pub struct SetFeeRateInstructionArgs {
 ///   2. `[signer]` fee_authority
 #[derive(Clone, Debug, Default)]
 pub struct SetFeeRateBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    fee_authority: Option<solana_program::pubkey::Pubkey>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    fee_authority: Option<solana_pubkey::Pubkey>,
     fee_rate: Option<u16>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetFeeRateBuilder {
@@ -105,20 +99,17 @@ impl SetFeeRateBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn fee_authority(&mut self, fee_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn fee_authority(&mut self, fee_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.fee_authority = Some(fee_authority);
         self
     }
@@ -129,10 +120,7 @@ impl SetFeeRateBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -140,13 +128,13 @@ impl SetFeeRateBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetFeeRate {
             whirlpools_config: self
                 .whirlpools_config
@@ -164,30 +152,30 @@ impl SetFeeRateBuilder {
 
 /// `set_fee_rate` CPI accounts.
 pub struct SetFeeRateCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_fee_rate` CPI instruction.
 pub struct SetFeeRateCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SetFeeRateInstructionArgs,
 }
 
 impl<'a, 'b> SetFeeRateCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetFeeRateCpiAccounts<'a, 'b>,
         args: SetFeeRateInstructionArgs,
     ) -> Self {
@@ -200,25 +188,21 @@ impl<'a, 'b> SetFeeRateCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -227,27 +211,23 @@ impl<'a, 'b> SetFeeRateCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.fee_authority.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -257,7 +237,7 @@ impl<'a, 'b> SetFeeRateCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -272,9 +252,9 @@ impl<'a, 'b> SetFeeRateCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -292,7 +272,7 @@ pub struct SetFeeRateCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetFeeRateCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetFeeRateCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -306,23 +286,20 @@ impl<'a, 'b> SetFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn fee_authority(
         &mut self,
-        fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        fee_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.fee_authority = Some(fee_authority);
         self
@@ -336,7 +313,7 @@ impl<'a, 'b> SetFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -352,11 +329,7 @@ impl<'a, 'b> SetFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -364,7 +337,7 @@ impl<'a, 'b> SetFeeRateCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -372,7 +345,7 @@ impl<'a, 'b> SetFeeRateCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SetFeeRateInstructionArgs {
             fee_rate: self
                 .instruction
@@ -405,15 +378,11 @@ impl<'a, 'b> SetFeeRateCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetFeeRateCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    fee_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    fee_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     fee_rate: Option<u16>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_protocol_fee_rate.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_protocol_fee_rate.rs
@@ -11,18 +11,18 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetProtocolFeeRate {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub fee_authority: solana_program::pubkey::Pubkey,
+    pub fee_authority: solana_pubkey::Pubkey,
 }
 
 impl SetProtocolFeeRate {
     pub fn instruction(
         &self,
         args: SetProtocolFeeRateInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -30,18 +30,15 @@ impl SetProtocolFeeRate {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SetProtocolFeeRateInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.fee_authority,
             true,
         ));
@@ -50,7 +47,7 @@ impl SetProtocolFeeRate {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -93,11 +90,11 @@ pub struct SetProtocolFeeRateInstructionArgs {
 ///   2. `[signer]` fee_authority
 #[derive(Clone, Debug, Default)]
 pub struct SetProtocolFeeRateBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    fee_authority: Option<solana_program::pubkey::Pubkey>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    fee_authority: Option<solana_pubkey::Pubkey>,
     protocol_fee_rate: Option<u16>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetProtocolFeeRateBuilder {
@@ -105,20 +102,17 @@ impl SetProtocolFeeRateBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn fee_authority(&mut self, fee_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn fee_authority(&mut self, fee_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.fee_authority = Some(fee_authority);
         self
     }
@@ -129,10 +123,7 @@ impl SetProtocolFeeRateBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -140,13 +131,13 @@ impl SetProtocolFeeRateBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetProtocolFeeRate {
             whirlpools_config: self
                 .whirlpools_config
@@ -167,30 +158,30 @@ impl SetProtocolFeeRateBuilder {
 
 /// `set_protocol_fee_rate` CPI accounts.
 pub struct SetProtocolFeeRateCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_protocol_fee_rate` CPI instruction.
 pub struct SetProtocolFeeRateCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub fee_authority: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SetProtocolFeeRateInstructionArgs,
 }
 
 impl<'a, 'b> SetProtocolFeeRateCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetProtocolFeeRateCpiAccounts<'a, 'b>,
         args: SetProtocolFeeRateInstructionArgs,
     ) -> Self {
@@ -203,25 +194,21 @@ impl<'a, 'b> SetProtocolFeeRateCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -230,27 +217,23 @@ impl<'a, 'b> SetProtocolFeeRateCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.fee_authority.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -260,7 +243,7 @@ impl<'a, 'b> SetProtocolFeeRateCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -275,9 +258,9 @@ impl<'a, 'b> SetProtocolFeeRateCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -295,7 +278,7 @@ pub struct SetProtocolFeeRateCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetProtocolFeeRateCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetProtocolFeeRateCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -309,23 +292,20 @@ impl<'a, 'b> SetProtocolFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn fee_authority(
         &mut self,
-        fee_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        fee_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.fee_authority = Some(fee_authority);
         self
@@ -339,7 +319,7 @@ impl<'a, 'b> SetProtocolFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -355,11 +335,7 @@ impl<'a, 'b> SetProtocolFeeRateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -367,7 +343,7 @@ impl<'a, 'b> SetProtocolFeeRateCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -375,7 +351,7 @@ impl<'a, 'b> SetProtocolFeeRateCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SetProtocolFeeRateInstructionArgs {
             protocol_fee_rate: self
                 .instruction
@@ -408,15 +384,11 @@ impl<'a, 'b> SetProtocolFeeRateCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetProtocolFeeRateCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    fee_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    fee_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     protocol_fee_rate: Option<u16>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_reward_authority.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_reward_authority.rs
@@ -11,18 +11,18 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetRewardAuthority {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub reward_authority: solana_program::pubkey::Pubkey,
+    pub reward_authority: solana_pubkey::Pubkey,
 
-    pub new_reward_authority: solana_program::pubkey::Pubkey,
+    pub new_reward_authority: solana_pubkey::Pubkey,
 }
 
 impl SetRewardAuthority {
     pub fn instruction(
         &self,
         args: SetRewardAuthorityInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -30,18 +30,15 @@ impl SetRewardAuthority {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SetRewardAuthorityInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.new_reward_authority,
             false,
         ));
@@ -50,7 +47,7 @@ impl SetRewardAuthority {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -93,11 +90,11 @@ pub struct SetRewardAuthorityInstructionArgs {
 ///   2. `[]` new_reward_authority
 #[derive(Clone, Debug, Default)]
 pub struct SetRewardAuthorityBuilder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    reward_authority: Option<solana_program::pubkey::Pubkey>,
-    new_reward_authority: Option<solana_program::pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    reward_authority: Option<solana_pubkey::Pubkey>,
+    new_reward_authority: Option<solana_pubkey::Pubkey>,
     reward_index: Option<u8>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetRewardAuthorityBuilder {
@@ -105,22 +102,19 @@ impl SetRewardAuthorityBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn reward_authority(
-        &mut self,
-        reward_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn reward_authority(&mut self, reward_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_authority = Some(reward_authority);
         self
     }
     #[inline(always)]
     pub fn new_reward_authority(
         &mut self,
-        new_reward_authority: solana_program::pubkey::Pubkey,
+        new_reward_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.new_reward_authority = Some(new_reward_authority);
         self
@@ -132,10 +126,7 @@ impl SetRewardAuthorityBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -143,13 +134,13 @@ impl SetRewardAuthorityBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetRewardAuthority {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
             reward_authority: self.reward_authority.expect("reward_authority is not set"),
@@ -167,30 +158,30 @@ impl SetRewardAuthorityBuilder {
 
 /// `set_reward_authority` CPI accounts.
 pub struct SetRewardAuthorityCpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_reward_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_reward_authority` CPI instruction.
 pub struct SetRewardAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_reward_authority: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SetRewardAuthorityInstructionArgs,
 }
 
 impl<'a, 'b> SetRewardAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetRewardAuthorityCpiAccounts<'a, 'b>,
         args: SetRewardAuthorityInstructionArgs,
     ) -> Self {
@@ -203,25 +194,21 @@ impl<'a, 'b> SetRewardAuthorityCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -230,27 +217,23 @@ impl<'a, 'b> SetRewardAuthorityCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.new_reward_authority.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -260,7 +243,7 @@ impl<'a, 'b> SetRewardAuthorityCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -275,9 +258,9 @@ impl<'a, 'b> SetRewardAuthorityCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -295,7 +278,7 @@ pub struct SetRewardAuthorityCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetRewardAuthorityCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetRewardAuthorityCpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -307,17 +290,14 @@ impl<'a, 'b> SetRewardAuthorityCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn reward_authority(
         &mut self,
-        reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_authority = Some(reward_authority);
         self
@@ -325,7 +305,7 @@ impl<'a, 'b> SetRewardAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn new_reward_authority(
         &mut self,
-        new_reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        new_reward_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_reward_authority = Some(new_reward_authority);
         self
@@ -339,7 +319,7 @@ impl<'a, 'b> SetRewardAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -355,11 +335,7 @@ impl<'a, 'b> SetRewardAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -367,7 +343,7 @@ impl<'a, 'b> SetRewardAuthorityCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -375,7 +351,7 @@ impl<'a, 'b> SetRewardAuthorityCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SetRewardAuthorityInstructionArgs {
             reward_index: self
                 .instruction
@@ -408,15 +384,11 @@ impl<'a, 'b> SetRewardAuthorityCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetRewardAuthorityCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    new_reward_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    new_reward_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     reward_index: Option<u8>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_reward_authority_by_super_authority.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_reward_authority_by_super_authority.rs
@@ -11,20 +11,20 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetRewardAuthorityBySuperAuthority {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub reward_emissions_super_authority: solana_program::pubkey::Pubkey,
+    pub reward_emissions_super_authority: solana_pubkey::Pubkey,
 
-    pub new_reward_authority: solana_program::pubkey::Pubkey,
+    pub new_reward_authority: solana_pubkey::Pubkey,
 }
 
 impl SetRewardAuthorityBySuperAuthority {
     pub fn instruction(
         &self,
         args: SetRewardAuthorityBySuperAuthorityInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -32,22 +32,19 @@ impl SetRewardAuthorityBySuperAuthority {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SetRewardAuthorityBySuperAuthorityInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_emissions_super_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.new_reward_authority,
             false,
         ));
@@ -57,7 +54,7 @@ impl SetRewardAuthorityBySuperAuthority {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -101,12 +98,12 @@ pub struct SetRewardAuthorityBySuperAuthorityInstructionArgs {
 ///   3. `[]` new_reward_authority
 #[derive(Clone, Debug, Default)]
 pub struct SetRewardAuthorityBySuperAuthorityBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    reward_emissions_super_authority: Option<solana_program::pubkey::Pubkey>,
-    new_reward_authority: Option<solana_program::pubkey::Pubkey>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    reward_emissions_super_authority: Option<solana_pubkey::Pubkey>,
+    new_reward_authority: Option<solana_pubkey::Pubkey>,
     reward_index: Option<u8>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetRewardAuthorityBySuperAuthorityBuilder {
@@ -114,22 +111,19 @@ impl SetRewardAuthorityBySuperAuthorityBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn reward_emissions_super_authority(
         &mut self,
-        reward_emissions_super_authority: solana_program::pubkey::Pubkey,
+        reward_emissions_super_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.reward_emissions_super_authority = Some(reward_emissions_super_authority);
         self
@@ -137,7 +131,7 @@ impl SetRewardAuthorityBySuperAuthorityBuilder {
     #[inline(always)]
     pub fn new_reward_authority(
         &mut self,
-        new_reward_authority: solana_program::pubkey::Pubkey,
+        new_reward_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.new_reward_authority = Some(new_reward_authority);
         self
@@ -149,10 +143,7 @@ impl SetRewardAuthorityBySuperAuthorityBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -160,13 +151,13 @@ impl SetRewardAuthorityBySuperAuthorityBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetRewardAuthorityBySuperAuthority {
             whirlpools_config: self
                 .whirlpools_config
@@ -189,34 +180,34 @@ impl SetRewardAuthorityBySuperAuthorityBuilder {
 
 /// `set_reward_authority_by_super_authority` CPI accounts.
 pub struct SetRewardAuthorityBySuperAuthorityCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_emissions_super_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_emissions_super_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_reward_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_reward_authority_by_super_authority` CPI instruction.
 pub struct SetRewardAuthorityBySuperAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_emissions_super_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_emissions_super_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_reward_authority: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SetRewardAuthorityBySuperAuthorityInstructionArgs,
 }
 
 impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetRewardAuthorityBySuperAuthorityCpiAccounts<'a, 'b>,
         args: SetRewardAuthorityBySuperAuthorityInstructionArgs,
     ) -> Self {
@@ -230,25 +221,21 @@ impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -257,31 +244,27 @@ impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_emissions_super_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.new_reward_authority.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -292,7 +275,7 @@ impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -308,9 +291,9 @@ impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -329,7 +312,7 @@ pub struct SetRewardAuthorityBySuperAuthorityCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetRewardAuthorityBySuperAuthorityCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -344,23 +327,20 @@ impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn reward_emissions_super_authority(
         &mut self,
-        reward_emissions_super_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_emissions_super_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_emissions_super_authority = Some(reward_emissions_super_authority);
         self
@@ -368,7 +348,7 @@ impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn new_reward_authority(
         &mut self,
-        new_reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        new_reward_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_reward_authority = Some(new_reward_authority);
         self
@@ -382,7 +362,7 @@ impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -398,11 +378,7 @@ impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -410,7 +386,7 @@ impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -418,7 +394,7 @@ impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SetRewardAuthorityBySuperAuthorityInstructionArgs {
             reward_index: self
                 .instruction
@@ -456,16 +432,12 @@ impl<'a, 'b> SetRewardAuthorityBySuperAuthorityCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetRewardAuthorityBySuperAuthorityCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_emissions_super_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    new_reward_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_emissions_super_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    new_reward_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     reward_index: Option<u8>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_reward_emissions.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_reward_emissions.rs
@@ -11,18 +11,18 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetRewardEmissions {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub reward_authority: solana_program::pubkey::Pubkey,
+    pub reward_authority: solana_pubkey::Pubkey,
 
-    pub reward_vault: solana_program::pubkey::Pubkey,
+    pub reward_vault: solana_pubkey::Pubkey,
 }
 
 impl SetRewardEmissions {
     pub fn instruction(
         &self,
         args: SetRewardEmissionsInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -30,18 +30,15 @@ impl SetRewardEmissions {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SetRewardEmissionsInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_vault,
             false,
         ));
@@ -50,7 +47,7 @@ impl SetRewardEmissions {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -94,12 +91,12 @@ pub struct SetRewardEmissionsInstructionArgs {
 ///   2. `[]` reward_vault
 #[derive(Clone, Debug, Default)]
 pub struct SetRewardEmissionsBuilder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    reward_authority: Option<solana_program::pubkey::Pubkey>,
-    reward_vault: Option<solana_program::pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    reward_authority: Option<solana_pubkey::Pubkey>,
+    reward_vault: Option<solana_pubkey::Pubkey>,
     reward_index: Option<u8>,
     emissions_per_second_x64: Option<u128>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetRewardEmissionsBuilder {
@@ -107,20 +104,17 @@ impl SetRewardEmissionsBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn reward_authority(
-        &mut self,
-        reward_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn reward_authority(&mut self, reward_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_authority = Some(reward_authority);
         self
     }
     #[inline(always)]
-    pub fn reward_vault(&mut self, reward_vault: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn reward_vault(&mut self, reward_vault: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_vault = Some(reward_vault);
         self
     }
@@ -136,10 +130,7 @@ impl SetRewardEmissionsBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -147,13 +138,13 @@ impl SetRewardEmissionsBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetRewardEmissions {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
             reward_authority: self.reward_authority.expect("reward_authority is not set"),
@@ -173,30 +164,30 @@ impl SetRewardEmissionsBuilder {
 
 /// `set_reward_emissions` CPI accounts.
 pub struct SetRewardEmissionsCpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_vault: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_reward_emissions` CPI instruction.
 pub struct SetRewardEmissionsCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_vault: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SetRewardEmissionsInstructionArgs,
 }
 
 impl<'a, 'b> SetRewardEmissionsCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetRewardEmissionsCpiAccounts<'a, 'b>,
         args: SetRewardEmissionsInstructionArgs,
     ) -> Self {
@@ -209,25 +200,21 @@ impl<'a, 'b> SetRewardEmissionsCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -236,27 +223,23 @@ impl<'a, 'b> SetRewardEmissionsCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_vault.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -266,7 +249,7 @@ impl<'a, 'b> SetRewardEmissionsCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -281,9 +264,9 @@ impl<'a, 'b> SetRewardEmissionsCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -301,7 +284,7 @@ pub struct SetRewardEmissionsCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetRewardEmissionsCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetRewardEmissionsCpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -314,17 +297,14 @@ impl<'a, 'b> SetRewardEmissionsCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn reward_authority(
         &mut self,
-        reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_authority = Some(reward_authority);
         self
@@ -332,7 +312,7 @@ impl<'a, 'b> SetRewardEmissionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_vault(
         &mut self,
-        reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_vault: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_vault = Some(reward_vault);
         self
@@ -351,7 +331,7 @@ impl<'a, 'b> SetRewardEmissionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -367,11 +347,7 @@ impl<'a, 'b> SetRewardEmissionsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -379,7 +355,7 @@ impl<'a, 'b> SetRewardEmissionsCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -387,7 +363,7 @@ impl<'a, 'b> SetRewardEmissionsCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SetRewardEmissionsInstructionArgs {
             reward_index: self
                 .instruction
@@ -425,16 +401,12 @@ impl<'a, 'b> SetRewardEmissionsCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetRewardEmissionsCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_vault: Option<&'b solana_account_info::AccountInfo<'a>>,
     reward_index: Option<u8>,
     emissions_per_second_x64: Option<u128>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_reward_emissions_super_authority.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_reward_emissions_super_authority.rs
@@ -11,40 +11,40 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetRewardEmissionsSuperAuthority {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub reward_emissions_super_authority: solana_program::pubkey::Pubkey,
+    pub reward_emissions_super_authority: solana_pubkey::Pubkey,
 
-    pub new_reward_emissions_super_authority: solana_program::pubkey::Pubkey,
+    pub new_reward_emissions_super_authority: solana_pubkey::Pubkey,
 }
 
 impl SetRewardEmissionsSuperAuthority {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_emissions_super_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.new_reward_emissions_super_authority,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&SetRewardEmissionsSuperAuthorityInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -81,10 +81,10 @@ impl Default for SetRewardEmissionsSuperAuthorityInstructionData {
 ///   2. `[]` new_reward_emissions_super_authority
 #[derive(Clone, Debug, Default)]
 pub struct SetRewardEmissionsSuperAuthorityBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    reward_emissions_super_authority: Option<solana_program::pubkey::Pubkey>,
-    new_reward_emissions_super_authority: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    reward_emissions_super_authority: Option<solana_pubkey::Pubkey>,
+    new_reward_emissions_super_authority: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetRewardEmissionsSuperAuthorityBuilder {
@@ -92,17 +92,14 @@ impl SetRewardEmissionsSuperAuthorityBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
     pub fn reward_emissions_super_authority(
         &mut self,
-        reward_emissions_super_authority: solana_program::pubkey::Pubkey,
+        reward_emissions_super_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.reward_emissions_super_authority = Some(reward_emissions_super_authority);
         self
@@ -110,17 +107,14 @@ impl SetRewardEmissionsSuperAuthorityBuilder {
     #[inline(always)]
     pub fn new_reward_emissions_super_authority(
         &mut self,
-        new_reward_emissions_super_authority: solana_program::pubkey::Pubkey,
+        new_reward_emissions_super_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.new_reward_emissions_super_authority = Some(new_reward_emissions_super_authority);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -128,13 +122,13 @@ impl SetRewardEmissionsSuperAuthorityBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetRewardEmissionsSuperAuthority {
             whirlpools_config: self
                 .whirlpools_config
@@ -153,28 +147,28 @@ impl SetRewardEmissionsSuperAuthorityBuilder {
 
 /// `set_reward_emissions_super_authority` CPI accounts.
 pub struct SetRewardEmissionsSuperAuthorityCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_emissions_super_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_emissions_super_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_reward_emissions_super_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_reward_emissions_super_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_reward_emissions_super_authority` CPI instruction.
 pub struct SetRewardEmissionsSuperAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_emissions_super_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_emissions_super_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_reward_emissions_super_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_reward_emissions_super_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetRewardEmissionsSuperAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -185,25 +179,21 @@ impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -212,27 +202,23 @@ impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_emissions_super_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.new_reward_emissions_super_authority.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -240,7 +226,7 @@ impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&SetRewardEmissionsSuperAuthorityInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -255,9 +241,9 @@ impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -275,7 +261,7 @@ pub struct SetRewardEmissionsSuperAuthorityCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetRewardEmissionsSuperAuthorityCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -288,7 +274,7 @@ impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
@@ -296,7 +282,7 @@ impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_emissions_super_authority(
         &mut self,
-        reward_emissions_super_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_emissions_super_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_emissions_super_authority = Some(reward_emissions_super_authority);
         self
@@ -304,7 +290,7 @@ impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn new_reward_emissions_super_authority(
         &mut self,
-        new_reward_emissions_super_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        new_reward_emissions_super_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_reward_emissions_super_authority =
             Some(new_reward_emissions_super_authority);
@@ -314,7 +300,7 @@ impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -330,11 +316,7 @@ impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -342,7 +324,7 @@ impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -350,7 +332,7 @@ impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = SetRewardEmissionsSuperAuthorityCpi {
             __program: self.instruction.__program,
 
@@ -378,14 +360,10 @@ impl<'a, 'b> SetRewardEmissionsSuperAuthorityCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetRewardEmissionsSuperAuthorityCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_emissions_super_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    new_reward_emissions_super_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_emissions_super_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    new_reward_emissions_super_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_reward_emissions_v2.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_reward_emissions_v2.rs
@@ -11,18 +11,18 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetRewardEmissionsV2 {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub reward_authority: solana_program::pubkey::Pubkey,
+    pub reward_authority: solana_pubkey::Pubkey,
 
-    pub reward_vault: solana_program::pubkey::Pubkey,
+    pub reward_vault: solana_pubkey::Pubkey,
 }
 
 impl SetRewardEmissionsV2 {
     pub fn instruction(
         &self,
         args: SetRewardEmissionsV2InstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -30,18 +30,15 @@ impl SetRewardEmissionsV2 {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SetRewardEmissionsV2InstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.reward_vault,
             false,
         ));
@@ -50,7 +47,7 @@ impl SetRewardEmissionsV2 {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -94,12 +91,12 @@ pub struct SetRewardEmissionsV2InstructionArgs {
 ///   2. `[]` reward_vault
 #[derive(Clone, Debug, Default)]
 pub struct SetRewardEmissionsV2Builder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    reward_authority: Option<solana_program::pubkey::Pubkey>,
-    reward_vault: Option<solana_program::pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    reward_authority: Option<solana_pubkey::Pubkey>,
+    reward_vault: Option<solana_pubkey::Pubkey>,
     reward_index: Option<u8>,
     emissions_per_second_x64: Option<u128>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetRewardEmissionsV2Builder {
@@ -107,20 +104,17 @@ impl SetRewardEmissionsV2Builder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn reward_authority(
-        &mut self,
-        reward_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn reward_authority(&mut self, reward_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_authority = Some(reward_authority);
         self
     }
     #[inline(always)]
-    pub fn reward_vault(&mut self, reward_vault: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn reward_vault(&mut self, reward_vault: solana_pubkey::Pubkey) -> &mut Self {
         self.reward_vault = Some(reward_vault);
         self
     }
@@ -136,10 +130,7 @@ impl SetRewardEmissionsV2Builder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -147,13 +138,13 @@ impl SetRewardEmissionsV2Builder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetRewardEmissionsV2 {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
             reward_authority: self.reward_authority.expect("reward_authority is not set"),
@@ -173,30 +164,30 @@ impl SetRewardEmissionsV2Builder {
 
 /// `set_reward_emissions_v2` CPI accounts.
 pub struct SetRewardEmissionsV2CpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_vault: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_reward_emissions_v2` CPI instruction.
 pub struct SetRewardEmissionsV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub reward_vault: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SetRewardEmissionsV2InstructionArgs,
 }
 
 impl<'a, 'b> SetRewardEmissionsV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetRewardEmissionsV2CpiAccounts<'a, 'b>,
         args: SetRewardEmissionsV2InstructionArgs,
     ) -> Self {
@@ -209,25 +200,21 @@ impl<'a, 'b> SetRewardEmissionsV2Cpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -236,27 +223,23 @@ impl<'a, 'b> SetRewardEmissionsV2Cpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.reward_vault.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -266,7 +249,7 @@ impl<'a, 'b> SetRewardEmissionsV2Cpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -281,9 +264,9 @@ impl<'a, 'b> SetRewardEmissionsV2Cpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -301,7 +284,7 @@ pub struct SetRewardEmissionsV2CpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetRewardEmissionsV2CpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetRewardEmissionsV2CpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -314,17 +297,14 @@ impl<'a, 'b> SetRewardEmissionsV2CpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn reward_authority(
         &mut self,
-        reward_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_authority = Some(reward_authority);
         self
@@ -332,7 +312,7 @@ impl<'a, 'b> SetRewardEmissionsV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn reward_vault(
         &mut self,
-        reward_vault: &'b solana_program::account_info::AccountInfo<'a>,
+        reward_vault: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reward_vault = Some(reward_vault);
         self
@@ -351,7 +331,7 @@ impl<'a, 'b> SetRewardEmissionsV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -367,11 +347,7 @@ impl<'a, 'b> SetRewardEmissionsV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -379,7 +355,7 @@ impl<'a, 'b> SetRewardEmissionsV2CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -387,7 +363,7 @@ impl<'a, 'b> SetRewardEmissionsV2CpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SetRewardEmissionsV2InstructionArgs {
             reward_index: self
                 .instruction
@@ -425,16 +401,12 @@ impl<'a, 'b> SetRewardEmissionsV2CpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetRewardEmissionsV2CpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    reward_vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    reward_vault: Option<&'b solana_account_info::AccountInfo<'a>>,
     reward_index: Option<u8>,
     emissions_per_second_x64: Option<u128>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_token_badge_authority.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/set_token_badge_authority.rs
@@ -11,46 +11,46 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SetTokenBadgeAuthority {
-    pub whirlpools_config: solana_program::pubkey::Pubkey,
+    pub whirlpools_config: solana_pubkey::Pubkey,
 
-    pub whirlpools_config_extension: solana_program::pubkey::Pubkey,
+    pub whirlpools_config_extension: solana_pubkey::Pubkey,
 
-    pub config_extension_authority: solana_program::pubkey::Pubkey,
+    pub config_extension_authority: solana_pubkey::Pubkey,
 
-    pub new_token_badge_authority: solana_program::pubkey::Pubkey,
+    pub new_token_badge_authority: solana_pubkey::Pubkey,
 }
 
 impl SetTokenBadgeAuthority {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.whirlpools_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.whirlpools_config_extension,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.config_extension_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.new_token_badge_authority,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&SetTokenBadgeAuthorityInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -88,11 +88,11 @@ impl Default for SetTokenBadgeAuthorityInstructionData {
 ///   3. `[]` new_token_badge_authority
 #[derive(Clone, Debug, Default)]
 pub struct SetTokenBadgeAuthorityBuilder {
-    whirlpools_config: Option<solana_program::pubkey::Pubkey>,
-    whirlpools_config_extension: Option<solana_program::pubkey::Pubkey>,
-    config_extension_authority: Option<solana_program::pubkey::Pubkey>,
-    new_token_badge_authority: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    whirlpools_config: Option<solana_pubkey::Pubkey>,
+    whirlpools_config_extension: Option<solana_pubkey::Pubkey>,
+    config_extension_authority: Option<solana_pubkey::Pubkey>,
+    new_token_badge_authority: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetTokenBadgeAuthorityBuilder {
@@ -100,17 +100,14 @@ impl SetTokenBadgeAuthorityBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpools_config(
-        &mut self,
-        whirlpools_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn whirlpools_config(&mut self, whirlpools_config: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpools_config = Some(whirlpools_config);
         self
     }
     #[inline(always)]
     pub fn whirlpools_config_extension(
         &mut self,
-        whirlpools_config_extension: solana_program::pubkey::Pubkey,
+        whirlpools_config_extension: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.whirlpools_config_extension = Some(whirlpools_config_extension);
         self
@@ -118,7 +115,7 @@ impl SetTokenBadgeAuthorityBuilder {
     #[inline(always)]
     pub fn config_extension_authority(
         &mut self,
-        config_extension_authority: solana_program::pubkey::Pubkey,
+        config_extension_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.config_extension_authority = Some(config_extension_authority);
         self
@@ -126,17 +123,14 @@ impl SetTokenBadgeAuthorityBuilder {
     #[inline(always)]
     pub fn new_token_badge_authority(
         &mut self,
-        new_token_badge_authority: solana_program::pubkey::Pubkey,
+        new_token_badge_authority: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.new_token_badge_authority = Some(new_token_badge_authority);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -144,13 +138,13 @@ impl SetTokenBadgeAuthorityBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetTokenBadgeAuthority {
             whirlpools_config: self
                 .whirlpools_config
@@ -172,32 +166,32 @@ impl SetTokenBadgeAuthorityBuilder {
 
 /// `set_token_badge_authority` CPI accounts.
 pub struct SetTokenBadgeAuthorityCpiAccounts<'a, 'b> {
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config_extension: &'b solana_account_info::AccountInfo<'a>,
 
-    pub config_extension_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub config_extension_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_token_badge_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_token_badge_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_token_badge_authority` CPI instruction.
 pub struct SetTokenBadgeAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpools_config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpools_config_extension: &'b solana_account_info::AccountInfo<'a>,
 
-    pub config_extension_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub config_extension_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_token_badge_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_token_badge_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> SetTokenBadgeAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetTokenBadgeAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -209,25 +203,21 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -236,31 +226,27 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.whirlpools_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpools_config_extension.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.config_extension_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.new_token_badge_authority.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -268,7 +254,7 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&SetTokenBadgeAuthorityInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -284,9 +270,9 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -305,7 +291,7 @@ pub struct SetTokenBadgeAuthorityCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetTokenBadgeAuthorityCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetTokenBadgeAuthorityCpiBuilderInstruction {
             __program: program,
             whirlpools_config: None,
@@ -319,7 +305,7 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config(
         &mut self,
-        whirlpools_config: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config = Some(whirlpools_config);
         self
@@ -327,7 +313,7 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpools_config_extension(
         &mut self,
-        whirlpools_config_extension: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpools_config_extension: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpools_config_extension = Some(whirlpools_config_extension);
         self
@@ -335,7 +321,7 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn config_extension_authority(
         &mut self,
-        config_extension_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        config_extension_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.config_extension_authority = Some(config_extension_authority);
         self
@@ -343,7 +329,7 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn new_token_badge_authority(
         &mut self,
-        new_token_badge_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        new_token_badge_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_token_badge_authority = Some(new_token_badge_authority);
         self
@@ -352,7 +338,7 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -368,11 +354,7 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -380,7 +362,7 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -388,7 +370,7 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = SetTokenBadgeAuthorityCpi {
             __program: self.instruction.__program,
 
@@ -421,15 +403,11 @@ impl<'a, 'b> SetTokenBadgeAuthorityCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetTokenBadgeAuthorityCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpools_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpools_config_extension: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    config_extension_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    new_token_badge_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpools_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpools_config_extension: Option<&'b solana_account_info::AccountInfo<'a>>,
+    config_extension_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    new_token_badge_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/swap.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/swap.rs
@@ -11,34 +11,31 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct Swap {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub token_authority: solana_program::pubkey::Pubkey,
+    pub token_authority: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub token_owner_account_a: solana_program::pubkey::Pubkey,
+    pub token_owner_account_a: solana_pubkey::Pubkey,
 
-    pub token_vault_a: solana_program::pubkey::Pubkey,
+    pub token_vault_a: solana_pubkey::Pubkey,
 
-    pub token_owner_account_b: solana_program::pubkey::Pubkey,
+    pub token_owner_account_b: solana_pubkey::Pubkey,
 
-    pub token_vault_b: solana_program::pubkey::Pubkey,
+    pub token_vault_b: solana_pubkey::Pubkey,
 
-    pub tick_array0: solana_program::pubkey::Pubkey,
+    pub tick_array0: solana_pubkey::Pubkey,
 
-    pub tick_array1: solana_program::pubkey::Pubkey,
+    pub tick_array1: solana_pubkey::Pubkey,
 
-    pub tick_array2: solana_program::pubkey::Pubkey,
+    pub tick_array2: solana_pubkey::Pubkey,
 
-    pub oracle: solana_program::pubkey::Pubkey,
+    pub oracle: solana_pubkey::Pubkey,
 }
 
 impl Swap {
-    pub fn instruction(
-        &self,
-        args: SwapInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: SwapInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -46,50 +43,47 @@ impl Swap {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SwapInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array0,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array1,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array2,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.oracle,
             false,
         ));
@@ -98,7 +92,7 @@ impl Swap {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -153,23 +147,23 @@ pub struct SwapInstructionArgs {
 ///   10. `[]` oracle
 #[derive(Clone, Debug, Default)]
 pub struct SwapBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    token_authority: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_a: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_b: Option<solana_program::pubkey::Pubkey>,
-    token_vault_b: Option<solana_program::pubkey::Pubkey>,
-    tick_array0: Option<solana_program::pubkey::Pubkey>,
-    tick_array1: Option<solana_program::pubkey::Pubkey>,
-    tick_array2: Option<solana_program::pubkey::Pubkey>,
-    oracle: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    token_authority: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    token_owner_account_a: Option<solana_pubkey::Pubkey>,
+    token_vault_a: Option<solana_pubkey::Pubkey>,
+    token_owner_account_b: Option<solana_pubkey::Pubkey>,
+    token_vault_b: Option<solana_pubkey::Pubkey>,
+    tick_array0: Option<solana_pubkey::Pubkey>,
+    tick_array1: Option<solana_pubkey::Pubkey>,
+    tick_array2: Option<solana_pubkey::Pubkey>,
+    oracle: Option<solana_pubkey::Pubkey>,
     amount: Option<u64>,
     other_amount_threshold: Option<u64>,
     sqrt_price_limit: Option<u128>,
     amount_specified_is_input: Option<bool>,
     a_to_b: Option<bool>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SwapBuilder {
@@ -178,66 +172,63 @@ impl SwapBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn token_authority(
-        &mut self,
-        token_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_authority(&mut self, token_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.token_authority = Some(token_authority);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: solana_program::pubkey::Pubkey,
+        token_owner_account_a: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_a = Some(token_owner_account_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_a(&mut self, token_vault_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_a(&mut self, token_vault_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_a = Some(token_vault_a);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: solana_program::pubkey::Pubkey,
+        token_owner_account_b: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_b = Some(token_owner_account_b);
         self
     }
     #[inline(always)]
-    pub fn token_vault_b(&mut self, token_vault_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_b(&mut self, token_vault_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn tick_array0(&mut self, tick_array0: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn tick_array0(&mut self, tick_array0: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array0 = Some(tick_array0);
         self
     }
     #[inline(always)]
-    pub fn tick_array1(&mut self, tick_array1: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn tick_array1(&mut self, tick_array1: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array1 = Some(tick_array1);
         self
     }
     #[inline(always)]
-    pub fn tick_array2(&mut self, tick_array2: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn tick_array2(&mut self, tick_array2: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array2 = Some(tick_array2);
         self
     }
     #[inline(always)]
-    pub fn oracle(&mut self, oracle: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn oracle(&mut self, oracle: solana_pubkey::Pubkey) -> &mut Self {
         self.oracle = Some(oracle);
         self
     }
@@ -268,10 +259,7 @@ impl SwapBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -279,15 +267,15 @@ impl SwapBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = Swap {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             token_authority: self.token_authority.expect("token_authority is not set"),
@@ -328,62 +316,62 @@ impl SwapBuilder {
 
 /// `swap` CPI accounts.
 pub struct SwapCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array0: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array0: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array1: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array1: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array2: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array2: &'b solana_account_info::AccountInfo<'a>,
 
-    pub oracle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub oracle: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `swap` CPI instruction.
 pub struct SwapCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array0: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array0: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array1: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array1: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array2: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array2: &'b solana_account_info::AccountInfo<'a>,
 
-    pub oracle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub oracle: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SwapInstructionArgs,
 }
 
 impl<'a, 'b> SwapCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SwapCpiAccounts<'a, 'b>,
         args: SwapInstructionArgs,
     ) -> Self {
@@ -404,25 +392,21 @@ impl<'a, 'b> SwapCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -431,59 +415,55 @@ impl<'a, 'b> SwapCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array0.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array1.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array2.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.oracle.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -493,7 +473,7 @@ impl<'a, 'b> SwapCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -516,9 +496,9 @@ impl<'a, 'b> SwapCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -544,7 +524,7 @@ pub struct SwapCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SwapCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -570,7 +550,7 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -578,23 +558,20 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_authority(
         &mut self,
-        token_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        token_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_authority = Some(token_authority);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_a = Some(token_owner_account_a);
         self
@@ -602,7 +579,7 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_a(
         &mut self,
-        token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_a = Some(token_vault_a);
         self
@@ -610,7 +587,7 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_b = Some(token_owner_account_b);
         self
@@ -618,7 +595,7 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_b(
         &mut self,
-        token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_b = Some(token_vault_b);
         self
@@ -626,7 +603,7 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array0(
         &mut self,
-        tick_array0: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array0: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array0 = Some(tick_array0);
         self
@@ -634,7 +611,7 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array1(
         &mut self,
-        tick_array1: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array1: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array1 = Some(tick_array1);
         self
@@ -642,16 +619,13 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array2(
         &mut self,
-        tick_array2: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array2: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array2 = Some(tick_array2);
         self
     }
     #[inline(always)]
-    pub fn oracle(
-        &mut self,
-        oracle: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn oracle(&mut self, oracle: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.oracle = Some(oracle);
         self
     }
@@ -684,7 +658,7 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -700,11 +674,7 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -712,7 +682,7 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -720,7 +690,7 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SwapInstructionArgs {
             amount: self.instruction.amount.clone().expect("amount is not set"),
             other_amount_threshold: self
@@ -802,27 +772,23 @@ impl<'a, 'b> SwapCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SwapCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array0: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array1: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    oracle: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array0: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array1: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array2: Option<&'b solana_account_info::AccountInfo<'a>>,
+    oracle: Option<&'b solana_account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     other_amount_threshold: Option<u64>,
     sqrt_price_limit: Option<u128>,
     amount_specified_is_input: Option<bool>,
     a_to_b: Option<bool>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/swap_v2.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/swap_v2.rs
@@ -12,42 +12,39 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SwapV2 {
-    pub token_program_a: solana_program::pubkey::Pubkey,
+    pub token_program_a: solana_pubkey::Pubkey,
 
-    pub token_program_b: solana_program::pubkey::Pubkey,
+    pub token_program_b: solana_pubkey::Pubkey,
 
-    pub memo_program: solana_program::pubkey::Pubkey,
+    pub memo_program: solana_pubkey::Pubkey,
 
-    pub token_authority: solana_program::pubkey::Pubkey,
+    pub token_authority: solana_pubkey::Pubkey,
 
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub token_mint_a: solana_program::pubkey::Pubkey,
+    pub token_mint_a: solana_pubkey::Pubkey,
 
-    pub token_mint_b: solana_program::pubkey::Pubkey,
+    pub token_mint_b: solana_pubkey::Pubkey,
 
-    pub token_owner_account_a: solana_program::pubkey::Pubkey,
+    pub token_owner_account_a: solana_pubkey::Pubkey,
 
-    pub token_vault_a: solana_program::pubkey::Pubkey,
+    pub token_vault_a: solana_pubkey::Pubkey,
 
-    pub token_owner_account_b: solana_program::pubkey::Pubkey,
+    pub token_owner_account_b: solana_pubkey::Pubkey,
 
-    pub token_vault_b: solana_program::pubkey::Pubkey,
+    pub token_vault_b: solana_pubkey::Pubkey,
 
-    pub tick_array0: solana_program::pubkey::Pubkey,
+    pub tick_array0: solana_pubkey::Pubkey,
 
-    pub tick_array1: solana_program::pubkey::Pubkey,
+    pub tick_array1: solana_pubkey::Pubkey,
 
-    pub tick_array2: solana_program::pubkey::Pubkey,
+    pub tick_array2: solana_pubkey::Pubkey,
 
-    pub oracle: solana_program::pubkey::Pubkey,
+    pub oracle: solana_pubkey::Pubkey,
 }
 
 impl SwapV2 {
-    pub fn instruction(
-        &self,
-        args: SwapV2InstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: SwapV2InstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -55,75 +52,69 @@ impl SwapV2 {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SwapV2InstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(15 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.memo_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array0,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array1,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array2,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.oracle,
-            false,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.oracle, false));
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&SwapV2InstructionData::new()).unwrap();
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -183,28 +174,28 @@ pub struct SwapV2InstructionArgs {
 ///   14. `[writable]` oracle
 #[derive(Clone, Debug, Default)]
 pub struct SwapV2Builder {
-    token_program_a: Option<solana_program::pubkey::Pubkey>,
-    token_program_b: Option<solana_program::pubkey::Pubkey>,
-    memo_program: Option<solana_program::pubkey::Pubkey>,
-    token_authority: Option<solana_program::pubkey::Pubkey>,
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    token_mint_a: Option<solana_program::pubkey::Pubkey>,
-    token_mint_b: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_a: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_b: Option<solana_program::pubkey::Pubkey>,
-    token_vault_b: Option<solana_program::pubkey::Pubkey>,
-    tick_array0: Option<solana_program::pubkey::Pubkey>,
-    tick_array1: Option<solana_program::pubkey::Pubkey>,
-    tick_array2: Option<solana_program::pubkey::Pubkey>,
-    oracle: Option<solana_program::pubkey::Pubkey>,
+    token_program_a: Option<solana_pubkey::Pubkey>,
+    token_program_b: Option<solana_pubkey::Pubkey>,
+    memo_program: Option<solana_pubkey::Pubkey>,
+    token_authority: Option<solana_pubkey::Pubkey>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    token_mint_a: Option<solana_pubkey::Pubkey>,
+    token_mint_b: Option<solana_pubkey::Pubkey>,
+    token_owner_account_a: Option<solana_pubkey::Pubkey>,
+    token_vault_a: Option<solana_pubkey::Pubkey>,
+    token_owner_account_b: Option<solana_pubkey::Pubkey>,
+    token_vault_b: Option<solana_pubkey::Pubkey>,
+    tick_array0: Option<solana_pubkey::Pubkey>,
+    tick_array1: Option<solana_pubkey::Pubkey>,
+    tick_array2: Option<solana_pubkey::Pubkey>,
+    oracle: Option<solana_pubkey::Pubkey>,
     amount: Option<u64>,
     other_amount_threshold: Option<u64>,
     sqrt_price_limit: Option<u128>,
     amount_specified_is_input: Option<bool>,
     a_to_b: Option<bool>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SwapV2Builder {
@@ -212,92 +203,83 @@ impl SwapV2Builder {
         Self::default()
     }
     #[inline(always)]
-    pub fn token_program_a(
-        &mut self,
-        token_program_a: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_a(&mut self, token_program_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_a = Some(token_program_a);
         self
     }
     #[inline(always)]
-    pub fn token_program_b(
-        &mut self,
-        token_program_b: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_b(&mut self, token_program_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_b = Some(token_program_b);
         self
     }
     #[inline(always)]
-    pub fn memo_program(&mut self, memo_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn memo_program(&mut self, memo_program: solana_pubkey::Pubkey) -> &mut Self {
         self.memo_program = Some(memo_program);
         self
     }
     #[inline(always)]
-    pub fn token_authority(
-        &mut self,
-        token_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_authority(&mut self, token_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.token_authority = Some(token_authority);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn token_mint_a(&mut self, token_mint_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_a(&mut self, token_mint_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_a = Some(token_mint_a);
         self
     }
     #[inline(always)]
-    pub fn token_mint_b(&mut self, token_mint_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_mint_b(&mut self, token_mint_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_b = Some(token_mint_b);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: solana_program::pubkey::Pubkey,
+        token_owner_account_a: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_a = Some(token_owner_account_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_a(&mut self, token_vault_a: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_a(&mut self, token_vault_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_a = Some(token_vault_a);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: solana_program::pubkey::Pubkey,
+        token_owner_account_b: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_b = Some(token_owner_account_b);
         self
     }
     #[inline(always)]
-    pub fn token_vault_b(&mut self, token_vault_b: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_vault_b(&mut self, token_vault_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_b = Some(token_vault_b);
         self
     }
     #[inline(always)]
-    pub fn tick_array0(&mut self, tick_array0: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn tick_array0(&mut self, tick_array0: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array0 = Some(tick_array0);
         self
     }
     #[inline(always)]
-    pub fn tick_array1(&mut self, tick_array1: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn tick_array1(&mut self, tick_array1: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array1 = Some(tick_array1);
         self
     }
     #[inline(always)]
-    pub fn tick_array2(&mut self, tick_array2: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn tick_array2(&mut self, tick_array2: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array2 = Some(tick_array2);
         self
     }
     #[inline(always)]
-    pub fn oracle(&mut self, oracle: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn oracle(&mut self, oracle: solana_pubkey::Pubkey) -> &mut Self {
         self.oracle = Some(oracle);
         self
     }
@@ -337,10 +319,7 @@ impl SwapV2Builder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -348,13 +327,13 @@ impl SwapV2Builder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SwapV2 {
             token_program_a: self.token_program_a.expect("token_program_a is not set"),
             token_program_b: self.token_program_b.expect("token_program_b is not set"),
@@ -400,78 +379,78 @@ impl SwapV2Builder {
 
 /// `swap_v2` CPI accounts.
 pub struct SwapV2CpiAccounts<'a, 'b> {
-    pub token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array0: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array0: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array1: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array1: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array2: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array2: &'b solana_account_info::AccountInfo<'a>,
 
-    pub oracle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub oracle: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `swap_v2` CPI instruction.
 pub struct SwapV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array0: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array0: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array1: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array1: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array2: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array2: &'b solana_account_info::AccountInfo<'a>,
 
-    pub oracle: &'b solana_program::account_info::AccountInfo<'a>,
+    pub oracle: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SwapV2InstructionArgs,
 }
 
 impl<'a, 'b> SwapV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SwapV2CpiAccounts<'a, 'b>,
         args: SwapV2InstructionArgs,
     ) -> Self {
@@ -496,25 +475,21 @@ impl<'a, 'b> SwapV2Cpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -523,75 +498,71 @@ impl<'a, 'b> SwapV2Cpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(15 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.memo_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array0.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array1.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array2.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.oracle.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -601,7 +572,7 @@ impl<'a, 'b> SwapV2Cpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -628,9 +599,9 @@ impl<'a, 'b> SwapV2Cpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -660,7 +631,7 @@ pub struct SwapV2CpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SwapV2CpiBuilderInstruction {
             __program: program,
             token_program_a: None,
@@ -691,7 +662,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program_a(
         &mut self,
-        token_program_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_a = Some(token_program_a);
         self
@@ -699,7 +670,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program_b(
         &mut self,
-        token_program_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_b = Some(token_program_b);
         self
@@ -707,7 +678,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn memo_program(
         &mut self,
-        memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+        memo_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.memo_program = Some(memo_program);
         self
@@ -715,23 +686,20 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_authority(
         &mut self,
-        token_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        token_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_authority = Some(token_authority);
         self
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
     pub fn token_mint_a(
         &mut self,
-        token_mint_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_a = Some(token_mint_a);
         self
@@ -739,7 +707,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_b(
         &mut self,
-        token_mint_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_b = Some(token_mint_b);
         self
@@ -747,7 +715,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_a(
         &mut self,
-        token_owner_account_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_a = Some(token_owner_account_a);
         self
@@ -755,7 +723,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_a(
         &mut self,
-        token_vault_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_a = Some(token_vault_a);
         self
@@ -763,7 +731,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_b(
         &mut self,
-        token_owner_account_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_b = Some(token_owner_account_b);
         self
@@ -771,7 +739,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_b(
         &mut self,
-        token_vault_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_b = Some(token_vault_b);
         self
@@ -779,7 +747,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array0(
         &mut self,
-        tick_array0: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array0: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array0 = Some(tick_array0);
         self
@@ -787,7 +755,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array1(
         &mut self,
-        tick_array1: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array1: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array1 = Some(tick_array1);
         self
@@ -795,16 +763,13 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array2(
         &mut self,
-        tick_array2: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array2: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array2 = Some(tick_array2);
         self
     }
     #[inline(always)]
-    pub fn oracle(
-        &mut self,
-        oracle: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn oracle(&mut self, oracle: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.oracle = Some(oracle);
         self
     }
@@ -846,7 +811,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -862,11 +827,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -874,7 +835,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -882,7 +843,7 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SwapV2InstructionArgs {
             amount: self.instruction.amount.clone().expect("amount is not set"),
             other_amount_threshold: self
@@ -985,22 +946,22 @@ impl<'a, 'b> SwapV2CpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SwapV2CpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    memo_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array0: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array1: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    oracle: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    memo_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array0: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array1: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array2: Option<&'b solana_account_info::AccountInfo<'a>>,
+    oracle: Option<&'b solana_account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     other_amount_threshold: Option<u64>,
     sqrt_price_limit: Option<u128>,
@@ -1008,9 +969,5 @@ struct SwapV2CpiBuilderInstruction<'a, 'b> {
     a_to_b: Option<bool>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/two_hop_swap.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/two_hop_swap.rs
@@ -11,52 +11,49 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct TwoHopSwap {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub token_authority: solana_program::pubkey::Pubkey,
+    pub token_authority: solana_pubkey::Pubkey,
 
-    pub whirlpool_one: solana_program::pubkey::Pubkey,
+    pub whirlpool_one: solana_pubkey::Pubkey,
 
-    pub whirlpool_two: solana_program::pubkey::Pubkey,
+    pub whirlpool_two: solana_pubkey::Pubkey,
 
-    pub token_owner_account_one_a: solana_program::pubkey::Pubkey,
+    pub token_owner_account_one_a: solana_pubkey::Pubkey,
 
-    pub token_vault_one_a: solana_program::pubkey::Pubkey,
+    pub token_vault_one_a: solana_pubkey::Pubkey,
 
-    pub token_owner_account_one_b: solana_program::pubkey::Pubkey,
+    pub token_owner_account_one_b: solana_pubkey::Pubkey,
 
-    pub token_vault_one_b: solana_program::pubkey::Pubkey,
+    pub token_vault_one_b: solana_pubkey::Pubkey,
 
-    pub token_owner_account_two_a: solana_program::pubkey::Pubkey,
+    pub token_owner_account_two_a: solana_pubkey::Pubkey,
 
-    pub token_vault_two_a: solana_program::pubkey::Pubkey,
+    pub token_vault_two_a: solana_pubkey::Pubkey,
 
-    pub token_owner_account_two_b: solana_program::pubkey::Pubkey,
+    pub token_owner_account_two_b: solana_pubkey::Pubkey,
 
-    pub token_vault_two_b: solana_program::pubkey::Pubkey,
+    pub token_vault_two_b: solana_pubkey::Pubkey,
 
-    pub tick_array_one0: solana_program::pubkey::Pubkey,
+    pub tick_array_one0: solana_pubkey::Pubkey,
 
-    pub tick_array_one1: solana_program::pubkey::Pubkey,
+    pub tick_array_one1: solana_pubkey::Pubkey,
 
-    pub tick_array_one2: solana_program::pubkey::Pubkey,
+    pub tick_array_one2: solana_pubkey::Pubkey,
 
-    pub tick_array_two0: solana_program::pubkey::Pubkey,
+    pub tick_array_two0: solana_pubkey::Pubkey,
 
-    pub tick_array_two1: solana_program::pubkey::Pubkey,
+    pub tick_array_two1: solana_pubkey::Pubkey,
 
-    pub tick_array_two2: solana_program::pubkey::Pubkey,
+    pub tick_array_two2: solana_pubkey::Pubkey,
 
-    pub oracle_one: solana_program::pubkey::Pubkey,
+    pub oracle_one: solana_pubkey::Pubkey,
 
-    pub oracle_two: solana_program::pubkey::Pubkey,
+    pub oracle_two: solana_pubkey::Pubkey,
 }
 
 impl TwoHopSwap {
-    pub fn instruction(
-        &self,
-        args: TwoHopSwapInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: TwoHopSwapInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -64,86 +61,86 @@ impl TwoHopSwap {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: TwoHopSwapInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(20 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.whirlpool_one,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.whirlpool_two,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_one_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_one_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_one_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_one_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_two_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_two_a,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_two_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_two_b,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_one0,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_one1,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_one2,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_two0,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_two1,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_two2,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.oracle_one,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.oracle_two,
             false,
         ));
@@ -152,7 +149,7 @@ impl TwoHopSwap {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -218,26 +215,26 @@ pub struct TwoHopSwapInstructionArgs {
 ///   19. `[]` oracle_two
 #[derive(Clone, Debug, Default)]
 pub struct TwoHopSwapBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    token_authority: Option<solana_program::pubkey::Pubkey>,
-    whirlpool_one: Option<solana_program::pubkey::Pubkey>,
-    whirlpool_two: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_one_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_one_a: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_one_b: Option<solana_program::pubkey::Pubkey>,
-    token_vault_one_b: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_two_a: Option<solana_program::pubkey::Pubkey>,
-    token_vault_two_a: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_two_b: Option<solana_program::pubkey::Pubkey>,
-    token_vault_two_b: Option<solana_program::pubkey::Pubkey>,
-    tick_array_one0: Option<solana_program::pubkey::Pubkey>,
-    tick_array_one1: Option<solana_program::pubkey::Pubkey>,
-    tick_array_one2: Option<solana_program::pubkey::Pubkey>,
-    tick_array_two0: Option<solana_program::pubkey::Pubkey>,
-    tick_array_two1: Option<solana_program::pubkey::Pubkey>,
-    tick_array_two2: Option<solana_program::pubkey::Pubkey>,
-    oracle_one: Option<solana_program::pubkey::Pubkey>,
-    oracle_two: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    token_authority: Option<solana_pubkey::Pubkey>,
+    whirlpool_one: Option<solana_pubkey::Pubkey>,
+    whirlpool_two: Option<solana_pubkey::Pubkey>,
+    token_owner_account_one_a: Option<solana_pubkey::Pubkey>,
+    token_vault_one_a: Option<solana_pubkey::Pubkey>,
+    token_owner_account_one_b: Option<solana_pubkey::Pubkey>,
+    token_vault_one_b: Option<solana_pubkey::Pubkey>,
+    token_owner_account_two_a: Option<solana_pubkey::Pubkey>,
+    token_vault_two_a: Option<solana_pubkey::Pubkey>,
+    token_owner_account_two_b: Option<solana_pubkey::Pubkey>,
+    token_vault_two_b: Option<solana_pubkey::Pubkey>,
+    tick_array_one0: Option<solana_pubkey::Pubkey>,
+    tick_array_one1: Option<solana_pubkey::Pubkey>,
+    tick_array_one2: Option<solana_pubkey::Pubkey>,
+    tick_array_two0: Option<solana_pubkey::Pubkey>,
+    tick_array_two1: Option<solana_pubkey::Pubkey>,
+    tick_array_two2: Option<solana_pubkey::Pubkey>,
+    oracle_one: Option<solana_pubkey::Pubkey>,
+    oracle_two: Option<solana_pubkey::Pubkey>,
     amount: Option<u64>,
     other_amount_threshold: Option<u64>,
     amount_specified_is_input: Option<bool>,
@@ -245,7 +242,7 @@ pub struct TwoHopSwapBuilder {
     a_to_b_two: Option<bool>,
     sqrt_price_limit_one: Option<u128>,
     sqrt_price_limit_two: Option<u128>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl TwoHopSwapBuilder {
@@ -254,147 +251,114 @@ impl TwoHopSwapBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn token_authority(
-        &mut self,
-        token_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_authority(&mut self, token_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.token_authority = Some(token_authority);
         self
     }
     #[inline(always)]
-    pub fn whirlpool_one(&mut self, whirlpool_one: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool_one(&mut self, whirlpool_one: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool_one = Some(whirlpool_one);
         self
     }
     #[inline(always)]
-    pub fn whirlpool_two(&mut self, whirlpool_two: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool_two(&mut self, whirlpool_two: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool_two = Some(whirlpool_two);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_one_a(
         &mut self,
-        token_owner_account_one_a: solana_program::pubkey::Pubkey,
+        token_owner_account_one_a: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_one_a = Some(token_owner_account_one_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_one_a(
-        &mut self,
-        token_vault_one_a: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_vault_one_a(&mut self, token_vault_one_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_one_a = Some(token_vault_one_a);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_one_b(
         &mut self,
-        token_owner_account_one_b: solana_program::pubkey::Pubkey,
+        token_owner_account_one_b: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_one_b = Some(token_owner_account_one_b);
         self
     }
     #[inline(always)]
-    pub fn token_vault_one_b(
-        &mut self,
-        token_vault_one_b: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_vault_one_b(&mut self, token_vault_one_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_one_b = Some(token_vault_one_b);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_two_a(
         &mut self,
-        token_owner_account_two_a: solana_program::pubkey::Pubkey,
+        token_owner_account_two_a: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_two_a = Some(token_owner_account_two_a);
         self
     }
     #[inline(always)]
-    pub fn token_vault_two_a(
-        &mut self,
-        token_vault_two_a: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_vault_two_a(&mut self, token_vault_two_a: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_two_a = Some(token_vault_two_a);
         self
     }
     #[inline(always)]
     pub fn token_owner_account_two_b(
         &mut self,
-        token_owner_account_two_b: solana_program::pubkey::Pubkey,
+        token_owner_account_two_b: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_two_b = Some(token_owner_account_two_b);
         self
     }
     #[inline(always)]
-    pub fn token_vault_two_b(
-        &mut self,
-        token_vault_two_b: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_vault_two_b(&mut self, token_vault_two_b: solana_pubkey::Pubkey) -> &mut Self {
         self.token_vault_two_b = Some(token_vault_two_b);
         self
     }
     #[inline(always)]
-    pub fn tick_array_one0(
-        &mut self,
-        tick_array_one0: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_one0(&mut self, tick_array_one0: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_one0 = Some(tick_array_one0);
         self
     }
     #[inline(always)]
-    pub fn tick_array_one1(
-        &mut self,
-        tick_array_one1: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_one1(&mut self, tick_array_one1: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_one1 = Some(tick_array_one1);
         self
     }
     #[inline(always)]
-    pub fn tick_array_one2(
-        &mut self,
-        tick_array_one2: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_one2(&mut self, tick_array_one2: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_one2 = Some(tick_array_one2);
         self
     }
     #[inline(always)]
-    pub fn tick_array_two0(
-        &mut self,
-        tick_array_two0: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_two0(&mut self, tick_array_two0: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_two0 = Some(tick_array_two0);
         self
     }
     #[inline(always)]
-    pub fn tick_array_two1(
-        &mut self,
-        tick_array_two1: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_two1(&mut self, tick_array_two1: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_two1 = Some(tick_array_two1);
         self
     }
     #[inline(always)]
-    pub fn tick_array_two2(
-        &mut self,
-        tick_array_two2: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_two2(&mut self, tick_array_two2: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_two2 = Some(tick_array_two2);
         self
     }
     #[inline(always)]
-    pub fn oracle_one(&mut self, oracle_one: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn oracle_one(&mut self, oracle_one: solana_pubkey::Pubkey) -> &mut Self {
         self.oracle_one = Some(oracle_one);
         self
     }
     #[inline(always)]
-    pub fn oracle_two(&mut self, oracle_two: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn oracle_two(&mut self, oracle_two: solana_pubkey::Pubkey) -> &mut Self {
         self.oracle_two = Some(oracle_two);
         self
     }
@@ -435,10 +399,7 @@ impl TwoHopSwapBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -446,15 +407,15 @@ impl TwoHopSwapBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = TwoHopSwap {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             token_authority: self.token_authority.expect("token_authority is not set"),
@@ -521,98 +482,98 @@ impl TwoHopSwapBuilder {
 
 /// `two_hop_swap` CPI accounts.
 pub struct TwoHopSwapCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool_one: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool_one: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool_two: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool_two: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_one_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_one_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_one_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_one_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_one_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_one_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_one_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_one_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_two_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_two_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_two_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_two_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_two_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_two_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_two_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_two_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_one0: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_one0: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_one1: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_one1: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_one2: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_one2: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_two0: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_two0: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_two1: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_two1: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_two2: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_two2: &'b solana_account_info::AccountInfo<'a>,
 
-    pub oracle_one: &'b solana_program::account_info::AccountInfo<'a>,
+    pub oracle_one: &'b solana_account_info::AccountInfo<'a>,
 
-    pub oracle_two: &'b solana_program::account_info::AccountInfo<'a>,
+    pub oracle_two: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `two_hop_swap` CPI instruction.
 pub struct TwoHopSwapCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool_one: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool_one: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool_two: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool_two: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_one_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_one_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_one_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_one_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_one_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_one_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_one_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_one_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_two_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_two_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_two_a: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_two_a: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_two_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_two_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_two_b: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_two_b: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_one0: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_one0: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_one1: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_one1: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_one2: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_one2: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_two0: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_two0: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_two1: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_two1: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_two2: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_two2: &'b solana_account_info::AccountInfo<'a>,
 
-    pub oracle_one: &'b solana_program::account_info::AccountInfo<'a>,
+    pub oracle_one: &'b solana_account_info::AccountInfo<'a>,
 
-    pub oracle_two: &'b solana_program::account_info::AccountInfo<'a>,
+    pub oracle_two: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: TwoHopSwapInstructionArgs,
 }
 
 impl<'a, 'b> TwoHopSwapCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: TwoHopSwapCpiAccounts<'a, 'b>,
         args: TwoHopSwapInstructionArgs,
     ) -> Self {
@@ -642,25 +603,21 @@ impl<'a, 'b> TwoHopSwapCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -669,95 +626,91 @@ impl<'a, 'b> TwoHopSwapCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(20 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool_one.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool_two.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_one_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_one_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_one_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_one_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_two_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_two_a.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_two_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_two_b.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_one0.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_one1.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_one2.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_two0.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_two1.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_two2.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.oracle_one.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.oracle_two.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -767,7 +720,7 @@ impl<'a, 'b> TwoHopSwapCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -799,9 +752,9 @@ impl<'a, 'b> TwoHopSwapCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -836,7 +789,7 @@ pub struct TwoHopSwapCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(TwoHopSwapCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -873,7 +826,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -881,7 +834,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_authority(
         &mut self,
-        token_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        token_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_authority = Some(token_authority);
         self
@@ -889,7 +842,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpool_one(
         &mut self,
-        whirlpool_one: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpool_one: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpool_one = Some(whirlpool_one);
         self
@@ -897,7 +850,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpool_two(
         &mut self,
-        whirlpool_two: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpool_two: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpool_two = Some(whirlpool_two);
         self
@@ -905,7 +858,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_one_a(
         &mut self,
-        token_owner_account_one_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_one_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_one_a = Some(token_owner_account_one_a);
         self
@@ -913,7 +866,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_one_a(
         &mut self,
-        token_vault_one_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_one_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_one_a = Some(token_vault_one_a);
         self
@@ -921,7 +874,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_one_b(
         &mut self,
-        token_owner_account_one_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_one_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_one_b = Some(token_owner_account_one_b);
         self
@@ -929,7 +882,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_one_b(
         &mut self,
-        token_vault_one_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_one_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_one_b = Some(token_vault_one_b);
         self
@@ -937,7 +890,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_two_a(
         &mut self,
-        token_owner_account_two_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_two_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_two_a = Some(token_owner_account_two_a);
         self
@@ -945,7 +898,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_two_a(
         &mut self,
-        token_vault_two_a: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_two_a: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_two_a = Some(token_vault_two_a);
         self
@@ -953,7 +906,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_two_b(
         &mut self,
-        token_owner_account_two_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_two_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_two_b = Some(token_owner_account_two_b);
         self
@@ -961,7 +914,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_two_b(
         &mut self,
-        token_vault_two_b: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_two_b: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_two_b = Some(token_vault_two_b);
         self
@@ -969,7 +922,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_one0(
         &mut self,
-        tick_array_one0: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_one0: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_one0 = Some(tick_array_one0);
         self
@@ -977,7 +930,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_one1(
         &mut self,
-        tick_array_one1: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_one1: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_one1 = Some(tick_array_one1);
         self
@@ -985,7 +938,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_one2(
         &mut self,
-        tick_array_one2: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_one2: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_one2 = Some(tick_array_one2);
         self
@@ -993,7 +946,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_two0(
         &mut self,
-        tick_array_two0: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_two0: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_two0 = Some(tick_array_two0);
         self
@@ -1001,7 +954,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_two1(
         &mut self,
-        tick_array_two1: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_two1: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_two1 = Some(tick_array_two1);
         self
@@ -1009,7 +962,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_two2(
         &mut self,
-        tick_array_two2: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_two2: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_two2 = Some(tick_array_two2);
         self
@@ -1017,7 +970,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn oracle_one(
         &mut self,
-        oracle_one: &'b solana_program::account_info::AccountInfo<'a>,
+        oracle_one: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.oracle_one = Some(oracle_one);
         self
@@ -1025,7 +978,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn oracle_two(
         &mut self,
-        oracle_two: &'b solana_program::account_info::AccountInfo<'a>,
+        oracle_two: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.oracle_two = Some(oracle_two);
         self
@@ -1069,7 +1022,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -1085,11 +1038,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -1097,7 +1046,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -1105,7 +1054,7 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = TwoHopSwapInstructionArgs {
             amount: self.instruction.amount.clone().expect("amount is not set"),
             other_amount_threshold: self
@@ -1246,27 +1195,27 @@ impl<'a, 'b> TwoHopSwapCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct TwoHopSwapCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool_one: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool_two: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_one_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_one_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_one_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_one_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_two_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_two_a: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_two_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_two_b: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_one0: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_one1: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_one2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_two0: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_two1: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_two2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    oracle_one: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    oracle_two: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool_one: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool_two: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_one_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_one_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_one_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_one_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_two_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_two_a: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_two_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_two_b: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_one0: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_one1: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_one2: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_two0: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_two1: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_two2: Option<&'b solana_account_info::AccountInfo<'a>>,
+    oracle_one: Option<&'b solana_account_info::AccountInfo<'a>>,
+    oracle_two: Option<&'b solana_account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     other_amount_threshold: Option<u64>,
     amount_specified_is_input: Option<bool>,
@@ -1275,9 +1224,5 @@ struct TwoHopSwapCpiBuilderInstruction<'a, 'b> {
     sqrt_price_limit_one: Option<u128>,
     sqrt_price_limit_two: Option<u128>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/two_hop_swap_v2.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/two_hop_swap_v2.rs
@@ -12,60 +12,60 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct TwoHopSwapV2 {
-    pub whirlpool_one: solana_program::pubkey::Pubkey,
+    pub whirlpool_one: solana_pubkey::Pubkey,
 
-    pub whirlpool_two: solana_program::pubkey::Pubkey,
+    pub whirlpool_two: solana_pubkey::Pubkey,
 
-    pub token_mint_input: solana_program::pubkey::Pubkey,
+    pub token_mint_input: solana_pubkey::Pubkey,
 
-    pub token_mint_intermediate: solana_program::pubkey::Pubkey,
+    pub token_mint_intermediate: solana_pubkey::Pubkey,
 
-    pub token_mint_output: solana_program::pubkey::Pubkey,
+    pub token_mint_output: solana_pubkey::Pubkey,
 
-    pub token_program_input: solana_program::pubkey::Pubkey,
+    pub token_program_input: solana_pubkey::Pubkey,
 
-    pub token_program_intermediate: solana_program::pubkey::Pubkey,
+    pub token_program_intermediate: solana_pubkey::Pubkey,
 
-    pub token_program_output: solana_program::pubkey::Pubkey,
+    pub token_program_output: solana_pubkey::Pubkey,
 
-    pub token_owner_account_input: solana_program::pubkey::Pubkey,
+    pub token_owner_account_input: solana_pubkey::Pubkey,
 
-    pub token_vault_one_input: solana_program::pubkey::Pubkey,
+    pub token_vault_one_input: solana_pubkey::Pubkey,
 
-    pub token_vault_one_intermediate: solana_program::pubkey::Pubkey,
+    pub token_vault_one_intermediate: solana_pubkey::Pubkey,
 
-    pub token_vault_two_intermediate: solana_program::pubkey::Pubkey,
+    pub token_vault_two_intermediate: solana_pubkey::Pubkey,
 
-    pub token_vault_two_output: solana_program::pubkey::Pubkey,
+    pub token_vault_two_output: solana_pubkey::Pubkey,
 
-    pub token_owner_account_output: solana_program::pubkey::Pubkey,
+    pub token_owner_account_output: solana_pubkey::Pubkey,
 
-    pub token_authority: solana_program::pubkey::Pubkey,
+    pub token_authority: solana_pubkey::Pubkey,
 
-    pub tick_array_one0: solana_program::pubkey::Pubkey,
+    pub tick_array_one0: solana_pubkey::Pubkey,
 
-    pub tick_array_one1: solana_program::pubkey::Pubkey,
+    pub tick_array_one1: solana_pubkey::Pubkey,
 
-    pub tick_array_one2: solana_program::pubkey::Pubkey,
+    pub tick_array_one2: solana_pubkey::Pubkey,
 
-    pub tick_array_two0: solana_program::pubkey::Pubkey,
+    pub tick_array_two0: solana_pubkey::Pubkey,
 
-    pub tick_array_two1: solana_program::pubkey::Pubkey,
+    pub tick_array_two1: solana_pubkey::Pubkey,
 
-    pub tick_array_two2: solana_program::pubkey::Pubkey,
+    pub tick_array_two2: solana_pubkey::Pubkey,
 
-    pub oracle_one: solana_program::pubkey::Pubkey,
+    pub oracle_one: solana_pubkey::Pubkey,
 
-    pub oracle_two: solana_program::pubkey::Pubkey,
+    pub oracle_two: solana_pubkey::Pubkey,
 
-    pub memo_program: solana_program::pubkey::Pubkey,
+    pub memo_program: solana_pubkey::Pubkey,
 }
 
 impl TwoHopSwapV2 {
     pub fn instruction(
         &self,
         args: TwoHopSwapV2InstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -73,102 +73,96 @@ impl TwoHopSwapV2 {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: TwoHopSwapV2InstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(24 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.whirlpool_one,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.whirlpool_two,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_input,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_intermediate,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_mint_output,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_input,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_intermediate,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program_output,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_input,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_one_input,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_one_intermediate,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_two_intermediate,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_vault_two_output,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.token_owner_account_output,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_authority,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_one0,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_one1,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_one2,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_two0,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_two1,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.tick_array_two2,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.oracle_one,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.oracle_two,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.oracle_one, false));
+        accounts.push(solana_instruction::AccountMeta::new(self.oracle_two, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.memo_program,
             false,
         ));
@@ -177,7 +171,7 @@ impl TwoHopSwapV2 {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -248,30 +242,30 @@ pub struct TwoHopSwapV2InstructionArgs {
 ///   23. `[]` memo_program
 #[derive(Clone, Debug, Default)]
 pub struct TwoHopSwapV2Builder {
-    whirlpool_one: Option<solana_program::pubkey::Pubkey>,
-    whirlpool_two: Option<solana_program::pubkey::Pubkey>,
-    token_mint_input: Option<solana_program::pubkey::Pubkey>,
-    token_mint_intermediate: Option<solana_program::pubkey::Pubkey>,
-    token_mint_output: Option<solana_program::pubkey::Pubkey>,
-    token_program_input: Option<solana_program::pubkey::Pubkey>,
-    token_program_intermediate: Option<solana_program::pubkey::Pubkey>,
-    token_program_output: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_input: Option<solana_program::pubkey::Pubkey>,
-    token_vault_one_input: Option<solana_program::pubkey::Pubkey>,
-    token_vault_one_intermediate: Option<solana_program::pubkey::Pubkey>,
-    token_vault_two_intermediate: Option<solana_program::pubkey::Pubkey>,
-    token_vault_two_output: Option<solana_program::pubkey::Pubkey>,
-    token_owner_account_output: Option<solana_program::pubkey::Pubkey>,
-    token_authority: Option<solana_program::pubkey::Pubkey>,
-    tick_array_one0: Option<solana_program::pubkey::Pubkey>,
-    tick_array_one1: Option<solana_program::pubkey::Pubkey>,
-    tick_array_one2: Option<solana_program::pubkey::Pubkey>,
-    tick_array_two0: Option<solana_program::pubkey::Pubkey>,
-    tick_array_two1: Option<solana_program::pubkey::Pubkey>,
-    tick_array_two2: Option<solana_program::pubkey::Pubkey>,
-    oracle_one: Option<solana_program::pubkey::Pubkey>,
-    oracle_two: Option<solana_program::pubkey::Pubkey>,
-    memo_program: Option<solana_program::pubkey::Pubkey>,
+    whirlpool_one: Option<solana_pubkey::Pubkey>,
+    whirlpool_two: Option<solana_pubkey::Pubkey>,
+    token_mint_input: Option<solana_pubkey::Pubkey>,
+    token_mint_intermediate: Option<solana_pubkey::Pubkey>,
+    token_mint_output: Option<solana_pubkey::Pubkey>,
+    token_program_input: Option<solana_pubkey::Pubkey>,
+    token_program_intermediate: Option<solana_pubkey::Pubkey>,
+    token_program_output: Option<solana_pubkey::Pubkey>,
+    token_owner_account_input: Option<solana_pubkey::Pubkey>,
+    token_vault_one_input: Option<solana_pubkey::Pubkey>,
+    token_vault_one_intermediate: Option<solana_pubkey::Pubkey>,
+    token_vault_two_intermediate: Option<solana_pubkey::Pubkey>,
+    token_vault_two_output: Option<solana_pubkey::Pubkey>,
+    token_owner_account_output: Option<solana_pubkey::Pubkey>,
+    token_authority: Option<solana_pubkey::Pubkey>,
+    tick_array_one0: Option<solana_pubkey::Pubkey>,
+    tick_array_one1: Option<solana_pubkey::Pubkey>,
+    tick_array_one2: Option<solana_pubkey::Pubkey>,
+    tick_array_two0: Option<solana_pubkey::Pubkey>,
+    tick_array_two1: Option<solana_pubkey::Pubkey>,
+    tick_array_two2: Option<solana_pubkey::Pubkey>,
+    oracle_one: Option<solana_pubkey::Pubkey>,
+    oracle_two: Option<solana_pubkey::Pubkey>,
+    memo_program: Option<solana_pubkey::Pubkey>,
     amount: Option<u64>,
     other_amount_threshold: Option<u64>,
     amount_specified_is_input: Option<bool>,
@@ -280,7 +274,7 @@ pub struct TwoHopSwapV2Builder {
     sqrt_price_limit_one: Option<u128>,
     sqrt_price_limit_two: Option<u128>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl TwoHopSwapV2Builder {
@@ -288,51 +282,42 @@ impl TwoHopSwapV2Builder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool_one(&mut self, whirlpool_one: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool_one(&mut self, whirlpool_one: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool_one = Some(whirlpool_one);
         self
     }
     #[inline(always)]
-    pub fn whirlpool_two(&mut self, whirlpool_two: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool_two(&mut self, whirlpool_two: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool_two = Some(whirlpool_two);
         self
     }
     #[inline(always)]
-    pub fn token_mint_input(
-        &mut self,
-        token_mint_input: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_mint_input(&mut self, token_mint_input: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_input = Some(token_mint_input);
         self
     }
     #[inline(always)]
     pub fn token_mint_intermediate(
         &mut self,
-        token_mint_intermediate: solana_program::pubkey::Pubkey,
+        token_mint_intermediate: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_mint_intermediate = Some(token_mint_intermediate);
         self
     }
     #[inline(always)]
-    pub fn token_mint_output(
-        &mut self,
-        token_mint_output: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_mint_output(&mut self, token_mint_output: solana_pubkey::Pubkey) -> &mut Self {
         self.token_mint_output = Some(token_mint_output);
         self
     }
     #[inline(always)]
-    pub fn token_program_input(
-        &mut self,
-        token_program_input: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_program_input(&mut self, token_program_input: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program_input = Some(token_program_input);
         self
     }
     #[inline(always)]
     pub fn token_program_intermediate(
         &mut self,
-        token_program_intermediate: solana_program::pubkey::Pubkey,
+        token_program_intermediate: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_program_intermediate = Some(token_program_intermediate);
         self
@@ -340,7 +325,7 @@ impl TwoHopSwapV2Builder {
     #[inline(always)]
     pub fn token_program_output(
         &mut self,
-        token_program_output: solana_program::pubkey::Pubkey,
+        token_program_output: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_program_output = Some(token_program_output);
         self
@@ -348,7 +333,7 @@ impl TwoHopSwapV2Builder {
     #[inline(always)]
     pub fn token_owner_account_input(
         &mut self,
-        token_owner_account_input: solana_program::pubkey::Pubkey,
+        token_owner_account_input: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_input = Some(token_owner_account_input);
         self
@@ -356,7 +341,7 @@ impl TwoHopSwapV2Builder {
     #[inline(always)]
     pub fn token_vault_one_input(
         &mut self,
-        token_vault_one_input: solana_program::pubkey::Pubkey,
+        token_vault_one_input: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_vault_one_input = Some(token_vault_one_input);
         self
@@ -364,7 +349,7 @@ impl TwoHopSwapV2Builder {
     #[inline(always)]
     pub fn token_vault_one_intermediate(
         &mut self,
-        token_vault_one_intermediate: solana_program::pubkey::Pubkey,
+        token_vault_one_intermediate: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_vault_one_intermediate = Some(token_vault_one_intermediate);
         self
@@ -372,7 +357,7 @@ impl TwoHopSwapV2Builder {
     #[inline(always)]
     pub fn token_vault_two_intermediate(
         &mut self,
-        token_vault_two_intermediate: solana_program::pubkey::Pubkey,
+        token_vault_two_intermediate: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_vault_two_intermediate = Some(token_vault_two_intermediate);
         self
@@ -380,7 +365,7 @@ impl TwoHopSwapV2Builder {
     #[inline(always)]
     pub fn token_vault_two_output(
         &mut self,
-        token_vault_two_output: solana_program::pubkey::Pubkey,
+        token_vault_two_output: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_vault_two_output = Some(token_vault_two_output);
         self
@@ -388,79 +373,58 @@ impl TwoHopSwapV2Builder {
     #[inline(always)]
     pub fn token_owner_account_output(
         &mut self,
-        token_owner_account_output: solana_program::pubkey::Pubkey,
+        token_owner_account_output: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.token_owner_account_output = Some(token_owner_account_output);
         self
     }
     #[inline(always)]
-    pub fn token_authority(
-        &mut self,
-        token_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn token_authority(&mut self, token_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.token_authority = Some(token_authority);
         self
     }
     #[inline(always)]
-    pub fn tick_array_one0(
-        &mut self,
-        tick_array_one0: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_one0(&mut self, tick_array_one0: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_one0 = Some(tick_array_one0);
         self
     }
     #[inline(always)]
-    pub fn tick_array_one1(
-        &mut self,
-        tick_array_one1: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_one1(&mut self, tick_array_one1: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_one1 = Some(tick_array_one1);
         self
     }
     #[inline(always)]
-    pub fn tick_array_one2(
-        &mut self,
-        tick_array_one2: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_one2(&mut self, tick_array_one2: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_one2 = Some(tick_array_one2);
         self
     }
     #[inline(always)]
-    pub fn tick_array_two0(
-        &mut self,
-        tick_array_two0: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_two0(&mut self, tick_array_two0: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_two0 = Some(tick_array_two0);
         self
     }
     #[inline(always)]
-    pub fn tick_array_two1(
-        &mut self,
-        tick_array_two1: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_two1(&mut self, tick_array_two1: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_two1 = Some(tick_array_two1);
         self
     }
     #[inline(always)]
-    pub fn tick_array_two2(
-        &mut self,
-        tick_array_two2: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_two2(&mut self, tick_array_two2: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_two2 = Some(tick_array_two2);
         self
     }
     #[inline(always)]
-    pub fn oracle_one(&mut self, oracle_one: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn oracle_one(&mut self, oracle_one: solana_pubkey::Pubkey) -> &mut Self {
         self.oracle_one = Some(oracle_one);
         self
     }
     #[inline(always)]
-    pub fn oracle_two(&mut self, oracle_two: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn oracle_two(&mut self, oracle_two: solana_pubkey::Pubkey) -> &mut Self {
         self.oracle_two = Some(oracle_two);
         self
     }
     #[inline(always)]
-    pub fn memo_program(&mut self, memo_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn memo_program(&mut self, memo_program: solana_pubkey::Pubkey) -> &mut Self {
         self.memo_program = Some(memo_program);
         self
     }
@@ -510,10 +474,7 @@ impl TwoHopSwapV2Builder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -521,13 +482,13 @@ impl TwoHopSwapV2Builder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = TwoHopSwapV2 {
             whirlpool_one: self.whirlpool_one.expect("whirlpool_one is not set"),
             whirlpool_two: self.whirlpool_two.expect("whirlpool_two is not set"),
@@ -605,114 +566,114 @@ impl TwoHopSwapV2Builder {
 
 /// `two_hop_swap_v2` CPI accounts.
 pub struct TwoHopSwapV2CpiAccounts<'a, 'b> {
-    pub whirlpool_one: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool_one: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool_two: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool_two: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_input: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_input: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_intermediate: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_intermediate: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_output: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_output: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_input: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_input: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_intermediate: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_intermediate: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_output: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_output: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_input: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_input: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_one_input: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_one_input: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_one_intermediate: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_one_intermediate: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_two_intermediate: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_two_intermediate: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_two_output: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_two_output: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_output: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_output: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_one0: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_one0: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_one1: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_one1: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_one2: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_one2: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_two0: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_two0: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_two1: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_two1: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_two2: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_two2: &'b solana_account_info::AccountInfo<'a>,
 
-    pub oracle_one: &'b solana_program::account_info::AccountInfo<'a>,
+    pub oracle_one: &'b solana_account_info::AccountInfo<'a>,
 
-    pub oracle_two: &'b solana_program::account_info::AccountInfo<'a>,
+    pub oracle_two: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `two_hop_swap_v2` CPI instruction.
 pub struct TwoHopSwapV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool_one: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool_one: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool_two: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool_two: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_input: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_input: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_intermediate: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_intermediate: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_mint_output: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_mint_output: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_input: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_input: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_intermediate: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_intermediate: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program_output: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program_output: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_input: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_input: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_one_input: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_one_input: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_one_intermediate: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_one_intermediate: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_two_intermediate: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_two_intermediate: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_vault_two_output: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_two_output: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_owner_account_output: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner_account_output: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_one0: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_one0: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_one1: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_one1: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_one2: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_one2: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_two0: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_two0: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_two1: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_two1: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_two2: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_two2: &'b solana_account_info::AccountInfo<'a>,
 
-    pub oracle_one: &'b solana_program::account_info::AccountInfo<'a>,
+    pub oracle_one: &'b solana_account_info::AccountInfo<'a>,
 
-    pub oracle_two: &'b solana_program::account_info::AccountInfo<'a>,
+    pub oracle_two: &'b solana_account_info::AccountInfo<'a>,
 
-    pub memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memo_program: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: TwoHopSwapV2InstructionArgs,
 }
 
 impl<'a, 'b> TwoHopSwapV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: TwoHopSwapV2CpiAccounts<'a, 'b>,
         args: TwoHopSwapV2InstructionArgs,
     ) -> Self {
@@ -746,25 +707,21 @@ impl<'a, 'b> TwoHopSwapV2Cpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -773,111 +730,107 @@ impl<'a, 'b> TwoHopSwapV2Cpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(24 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool_one.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool_two.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_input.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_intermediate.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_mint_output.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_input.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_intermediate.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program_output.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_input.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_one_input.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_one_intermediate.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_two_intermediate.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_vault_two_output.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.token_owner_account_output.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_authority.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_one0.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_one1.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_one2.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_two0.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_two1.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.tick_array_two2.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.oracle_one.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.oracle_two.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.memo_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -887,7 +840,7 @@ impl<'a, 'b> TwoHopSwapV2Cpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -923,9 +876,9 @@ impl<'a, 'b> TwoHopSwapV2Cpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -964,7 +917,7 @@ pub struct TwoHopSwapV2CpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(TwoHopSwapV2CpiBuilderInstruction {
             __program: program,
             whirlpool_one: None,
@@ -1006,7 +959,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpool_one(
         &mut self,
-        whirlpool_one: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpool_one: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpool_one = Some(whirlpool_one);
         self
@@ -1014,7 +967,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn whirlpool_two(
         &mut self,
-        whirlpool_two: &'b solana_program::account_info::AccountInfo<'a>,
+        whirlpool_two: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.whirlpool_two = Some(whirlpool_two);
         self
@@ -1022,7 +975,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_input(
         &mut self,
-        token_mint_input: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_input: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_input = Some(token_mint_input);
         self
@@ -1030,7 +983,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_intermediate(
         &mut self,
-        token_mint_intermediate: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_intermediate: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_intermediate = Some(token_mint_intermediate);
         self
@@ -1038,7 +991,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_mint_output(
         &mut self,
-        token_mint_output: &'b solana_program::account_info::AccountInfo<'a>,
+        token_mint_output: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_mint_output = Some(token_mint_output);
         self
@@ -1046,7 +999,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program_input(
         &mut self,
-        token_program_input: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_input: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_input = Some(token_program_input);
         self
@@ -1054,7 +1007,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program_intermediate(
         &mut self,
-        token_program_intermediate: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_intermediate: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_intermediate = Some(token_program_intermediate);
         self
@@ -1062,7 +1015,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program_output(
         &mut self,
-        token_program_output: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program_output: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program_output = Some(token_program_output);
         self
@@ -1070,7 +1023,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_input(
         &mut self,
-        token_owner_account_input: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_input: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_input = Some(token_owner_account_input);
         self
@@ -1078,7 +1031,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_one_input(
         &mut self,
-        token_vault_one_input: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_one_input: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_one_input = Some(token_vault_one_input);
         self
@@ -1086,7 +1039,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_one_intermediate(
         &mut self,
-        token_vault_one_intermediate: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_one_intermediate: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_one_intermediate = Some(token_vault_one_intermediate);
         self
@@ -1094,7 +1047,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_two_intermediate(
         &mut self,
-        token_vault_two_intermediate: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_two_intermediate: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_two_intermediate = Some(token_vault_two_intermediate);
         self
@@ -1102,7 +1055,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_vault_two_output(
         &mut self,
-        token_vault_two_output: &'b solana_program::account_info::AccountInfo<'a>,
+        token_vault_two_output: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_two_output = Some(token_vault_two_output);
         self
@@ -1110,7 +1063,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_owner_account_output(
         &mut self,
-        token_owner_account_output: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner_account_output: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner_account_output = Some(token_owner_account_output);
         self
@@ -1118,7 +1071,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_authority(
         &mut self,
-        token_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        token_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_authority = Some(token_authority);
         self
@@ -1126,7 +1079,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_one0(
         &mut self,
-        tick_array_one0: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_one0: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_one0 = Some(tick_array_one0);
         self
@@ -1134,7 +1087,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_one1(
         &mut self,
-        tick_array_one1: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_one1: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_one1 = Some(tick_array_one1);
         self
@@ -1142,7 +1095,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_one2(
         &mut self,
-        tick_array_one2: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_one2: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_one2 = Some(tick_array_one2);
         self
@@ -1150,7 +1103,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_two0(
         &mut self,
-        tick_array_two0: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_two0: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_two0 = Some(tick_array_two0);
         self
@@ -1158,7 +1111,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_two1(
         &mut self,
-        tick_array_two1: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_two1: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_two1 = Some(tick_array_two1);
         self
@@ -1166,7 +1119,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_two2(
         &mut self,
-        tick_array_two2: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_two2: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_two2 = Some(tick_array_two2);
         self
@@ -1174,7 +1127,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn oracle_one(
         &mut self,
-        oracle_one: &'b solana_program::account_info::AccountInfo<'a>,
+        oracle_one: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.oracle_one = Some(oracle_one);
         self
@@ -1182,7 +1135,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn oracle_two(
         &mut self,
-        oracle_two: &'b solana_program::account_info::AccountInfo<'a>,
+        oracle_two: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.oracle_two = Some(oracle_two);
         self
@@ -1190,7 +1143,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn memo_program(
         &mut self,
-        memo_program: &'b solana_program::account_info::AccountInfo<'a>,
+        memo_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.memo_program = Some(memo_program);
         self
@@ -1243,7 +1196,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -1259,11 +1212,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -1271,7 +1220,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -1279,7 +1228,7 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = TwoHopSwapV2InstructionArgs {
             amount: self.instruction.amount.clone().expect("amount is not set"),
             other_amount_threshold: self
@@ -1441,31 +1390,31 @@ impl<'a, 'b> TwoHopSwapV2CpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct TwoHopSwapV2CpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool_one: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    whirlpool_two: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_input: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_intermediate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_mint_output: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_input: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_intermediate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_program_output: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_input: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_one_input: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_one_intermediate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_two_intermediate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_vault_two_output: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_owner_account_output: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    token_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_one0: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_one1: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_one2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_two0: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_two1: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_two2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    oracle_one: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    oracle_two: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    memo_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool_one: Option<&'b solana_account_info::AccountInfo<'a>>,
+    whirlpool_two: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_input: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_intermediate: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_mint_output: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_input: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_intermediate: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_program_output: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_input: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_one_input: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_one_intermediate: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_two_intermediate: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_vault_two_output: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_owner_account_output: Option<&'b solana_account_info::AccountInfo<'a>>,
+    token_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_one0: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_one1: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_one2: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_two0: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_two1: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_two2: Option<&'b solana_account_info::AccountInfo<'a>>,
+    oracle_one: Option<&'b solana_account_info::AccountInfo<'a>>,
+    oracle_two: Option<&'b solana_account_info::AccountInfo<'a>>,
+    memo_program: Option<&'b solana_account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     other_amount_threshold: Option<u64>,
     amount_specified_is_input: Option<bool>,
@@ -1475,9 +1424,5 @@ struct TwoHopSwapV2CpiBuilderInstruction<'a, 'b> {
     sqrt_price_limit_two: Option<u128>,
     remaining_accounts_info: Option<RemainingAccountsInfo>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/update_fees_and_rewards.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/instructions/update_fees_and_rewards.rs
@@ -11,46 +11,40 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct UpdateFeesAndRewards {
-    pub whirlpool: solana_program::pubkey::Pubkey,
+    pub whirlpool: solana_pubkey::Pubkey,
 
-    pub position: solana_program::pubkey::Pubkey,
+    pub position: solana_pubkey::Pubkey,
 
-    pub tick_array_lower: solana_program::pubkey::Pubkey,
+    pub tick_array_lower: solana_pubkey::Pubkey,
 
-    pub tick_array_upper: solana_program::pubkey::Pubkey,
+    pub tick_array_upper: solana_pubkey::Pubkey,
 }
 
 impl UpdateFeesAndRewards {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.whirlpool,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.position,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.whirlpool, false));
+        accounts.push(solana_instruction::AccountMeta::new(self.position, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.tick_array_lower,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.tick_array_upper,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&UpdateFeesAndRewardsInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -88,11 +82,11 @@ impl Default for UpdateFeesAndRewardsInstructionData {
 ///   3. `[]` tick_array_upper
 #[derive(Clone, Debug, Default)]
 pub struct UpdateFeesAndRewardsBuilder {
-    whirlpool: Option<solana_program::pubkey::Pubkey>,
-    position: Option<solana_program::pubkey::Pubkey>,
-    tick_array_lower: Option<solana_program::pubkey::Pubkey>,
-    tick_array_upper: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    whirlpool: Option<solana_pubkey::Pubkey>,
+    position: Option<solana_pubkey::Pubkey>,
+    tick_array_lower: Option<solana_pubkey::Pubkey>,
+    tick_array_upper: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl UpdateFeesAndRewardsBuilder {
@@ -100,37 +94,28 @@ impl UpdateFeesAndRewardsBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn whirlpool(&mut self, whirlpool: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: solana_pubkey::Pubkey) -> &mut Self {
         self.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn position(&mut self, position: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn position(&mut self, position: solana_pubkey::Pubkey) -> &mut Self {
         self.position = Some(position);
         self
     }
     #[inline(always)]
-    pub fn tick_array_lower(
-        &mut self,
-        tick_array_lower: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_lower(&mut self, tick_array_lower: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_lower = Some(tick_array_lower);
         self
     }
     #[inline(always)]
-    pub fn tick_array_upper(
-        &mut self,
-        tick_array_upper: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn tick_array_upper(&mut self, tick_array_upper: solana_pubkey::Pubkey) -> &mut Self {
         self.tick_array_upper = Some(tick_array_upper);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -138,13 +123,13 @@ impl UpdateFeesAndRewardsBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = UpdateFeesAndRewards {
             whirlpool: self.whirlpool.expect("whirlpool is not set"),
             position: self.position.expect("position is not set"),
@@ -158,32 +143,32 @@ impl UpdateFeesAndRewardsBuilder {
 
 /// `update_fees_and_rewards` CPI accounts.
 pub struct UpdateFeesAndRewardsCpiAccounts<'a, 'b> {
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `update_fees_and_rewards` CPI instruction.
 pub struct UpdateFeesAndRewardsCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
+    pub whirlpool: &'b solana_account_info::AccountInfo<'a>,
 
-    pub position: &'b solana_program::account_info::AccountInfo<'a>,
+    pub position: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
 
-    pub tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+    pub tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> UpdateFeesAndRewardsCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: UpdateFeesAndRewardsCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -195,25 +180,21 @@ impl<'a, 'b> UpdateFeesAndRewardsCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -222,31 +203,27 @@ impl<'a, 'b> UpdateFeesAndRewardsCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.whirlpool.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.position.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.tick_array_lower.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.tick_array_upper.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -254,7 +231,7 @@ impl<'a, 'b> UpdateFeesAndRewardsCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&UpdateFeesAndRewardsInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::WHIRLPOOL_ID,
             accounts,
             data,
@@ -270,9 +247,9 @@ impl<'a, 'b> UpdateFeesAndRewardsCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -291,7 +268,7 @@ pub struct UpdateFeesAndRewardsCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> UpdateFeesAndRewardsCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateFeesAndRewardsCpiBuilderInstruction {
             __program: program,
             whirlpool: None,
@@ -303,25 +280,19 @@ impl<'a, 'b> UpdateFeesAndRewardsCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn whirlpool(
-        &mut self,
-        whirlpool: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn whirlpool(&mut self, whirlpool: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.whirlpool = Some(whirlpool);
         self
     }
     #[inline(always)]
-    pub fn position(
-        &mut self,
-        position: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn position(&mut self, position: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.position = Some(position);
         self
     }
     #[inline(always)]
     pub fn tick_array_lower(
         &mut self,
-        tick_array_lower: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_lower: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_lower = Some(tick_array_lower);
         self
@@ -329,7 +300,7 @@ impl<'a, 'b> UpdateFeesAndRewardsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn tick_array_upper(
         &mut self,
-        tick_array_upper: &'b solana_program::account_info::AccountInfo<'a>,
+        tick_array_upper: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.tick_array_upper = Some(tick_array_upper);
         self
@@ -338,7 +309,7 @@ impl<'a, 'b> UpdateFeesAndRewardsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -354,11 +325,7 @@ impl<'a, 'b> UpdateFeesAndRewardsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -366,7 +333,7 @@ impl<'a, 'b> UpdateFeesAndRewardsCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -374,7 +341,7 @@ impl<'a, 'b> UpdateFeesAndRewardsCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = UpdateFeesAndRewardsCpi {
             __program: self.instruction.__program,
 
@@ -401,15 +368,11 @@ impl<'a, 'b> UpdateFeesAndRewardsCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct UpdateFeesAndRewardsCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    whirlpool: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    position: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_lower: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tick_array_upper: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    whirlpool: Option<&'b solana_account_info::AccountInfo<'a>>,
+    position: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_lower: Option<&'b solana_account_info::AccountInfo<'a>>,
+    tick_array_upper: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/programs.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/programs.rs
@@ -5,7 +5,7 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
-use solana_program::{pubkey, pubkey::Pubkey};
+use solana_pubkey::{pubkey, Pubkey};
 
 /// `whirlpool` program ID.
 pub const WHIRLPOOL_ID: Pubkey = pubkey!("whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc");

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/shared.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/shared.rs
@@ -8,8 +8,8 @@
 #[cfg(feature = "fetch")]
 #[derive(Debug, Clone)]
 pub struct DecodedAccount<T> {
-    pub address: solana_program::pubkey::Pubkey,
-    pub account: solana_sdk::account::Account,
+    pub address: solana_pubkey::Pubkey,
+    pub account: solana_account::Account,
     pub data: T,
 }
 
@@ -17,5 +17,5 @@ pub struct DecodedAccount<T> {
 #[derive(Debug, Clone)]
 pub enum MaybeAccount<T> {
     Exists(DecodedAccount<T>),
-    NotFound(solana_program::pubkey::Pubkey),
+    NotFound(solana_pubkey::Pubkey),
 }

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/types/whirlpool_reward_info.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/generated_sdk/types/whirlpool_reward_info.rs
@@ -7,7 +7,7 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/lib.rs
+++ b/packages/renderers-vixen-parser/e2e/orca-whirlpool-parser/src/lib.rs
@@ -3,7 +3,7 @@ mod generated_sdk;
 pub use generated::*;
 pub use generated_parser::*;
 use generated_sdk as generated;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 pub const ID: Pubkey = WHIRLPOOL_ID;
 

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/Cargo.lock
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/Cargo.lock
@@ -45,18 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,12 +162,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -198,29 +180,6 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-
-[[package]]
-name = "blake3"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -315,33 +274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "bv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8834bb1d8ee5dc048ee3124f2c7c1afcc6bc9aed03f11e9dfd8c69470a5db340"
-dependencies = [
- "feature-probe",
- "serde",
-]
-
-[[package]]
-name = "bytemuck"
-version = "1.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,32 +303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "console_log"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89f72f65e8501878b8a004d5a1afb780987e2ce2b4532c562e367a72c57499f"
-dependencies = [
- "log",
- "web-sys",
-]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,12 +319,6 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -439,9 +339,9 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
- "rand_core 0.6.4",
+ "rand_core",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -460,22 +360,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -505,12 +395,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "feature-probe"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "fiat-crypto"
@@ -602,17 +486,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -854,71 +727,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "libsecp256k1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
-dependencies = [
- "arrayref",
- "base64 0.12.3",
- "digest 0.9.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
-dependencies = [
- "libsecp256k1-core",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -955,15 +767,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,16 +799,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,15 +807,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1048,12 +832,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "parking_lot"
@@ -1256,36 +1034,13 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1295,16 +1050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1314,15 +1060,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1419,15 +1156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,36 +1168,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest 0.10.7",
- "keccak",
+ "digest",
 ]
 
 [[package]]
@@ -1504,46 +1209,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-account"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f949fe4edaeaea78c844023bfc1c898e0b1f5a100f8a8d2d0f85d0a7b090258"
-dependencies = [
- "solana-account-info",
- "solana-clock",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
 name = "solana-account-info"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c17d606a298a205fae325489fbed88ee6dc4463c111672172327e741c8905d"
 dependencies = [
- "bincode",
- "serde",
  "solana-program-error",
  "solana-program-memory",
  "solana-pubkey",
-]
-
-[[package]]
-name = "solana-address-lookup-table-interface"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1673f67efe870b64a65cb39e6194be5b26527691ce5922909939961a6e6b395"
-dependencies = [
- "bincode",
- "bytemuck",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-slot-hashes",
 ]
 
 [[package]]
@@ -1553,63 +1226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52e52720efe60465b052b9e7445a01c17550666beec855cce66f44766697bc2"
 dependencies = [
  "parking_lot",
-]
-
-[[package]]
-name = "solana-big-mod-exp"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db7f2bbac3e62cfd139065d15bcda9e2428883ba61fc8d27ccb251081e7567"
-dependencies = [
- "num-bigint",
- "num-traits",
- "solana-define-syscall",
-]
-
-[[package]]
-name = "solana-bincode"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a3787b8cf9c9fe3dd360800e8b70982b9e5a8af9e11c354b6665dd4a003adc"
-dependencies = [
- "bincode",
- "serde",
- "solana-instruction",
-]
-
-[[package]]
-name = "solana-blake3-hasher"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0801e25a1b31a14494fc80882a036be0ffd290efc4c2d640bfcca120a4672"
-dependencies = [
- "blake3",
- "solana-define-syscall",
- "solana-hash",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-borsh"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718333bcd0a1a7aed6655aa66bef8d7fb047944922b2d3a18f49cbc13e73d004"
-dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.7",
-]
-
-[[package]]
-name = "solana-clock"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c2177a1b9fe8326004f1151a5acd124420b737811080b1035df31349e4d892"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
 ]
 
 [[package]]
@@ -1642,96 +1258,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf784bb2cb3e02cac9801813c30187344228d2ae952534902108f6150573a33d"
 
 [[package]]
-name = "solana-epoch-rewards"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b575d3dd323b9ea10bb6fe89bf6bf93e249b215ba8ed7f68f1a3633f384db7"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-hash",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-epoch-schedule"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce071fbddecc55d727b1d7ed16a629afe4f6e4c217bc8d00af3b785f6f67ed"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-example-mocks"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84461d56cbb8bb8d539347151e0525b53910102e4bced875d49d5139708e39d3"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-address-lookup-table-interface",
- "solana-clock",
- "solana-hash",
- "solana-instruction",
- "solana-keccak-hasher",
- "solana-message",
- "solana-nonce",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-feature-gate-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9c7fbf3e58b64a667c5f35e90af580538a95daea7001ff7806c0662d301bdf"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-fee-calculator"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89bc408da0fb3812bc3008189d148b4d3e08252c79ad810b245482a3f70cd8d"
-dependencies = [
- "log",
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "solana-hash"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf7bcb14392900fe02e4e34e90234fbf0c673d4e327888410ba99fa2ba0f4e99"
 dependencies = [
- "borsh 1.5.7",
  "bs58",
- "bytemuck",
- "bytemuck_derive",
  "js-sys",
- "serde",
- "serde_derive",
  "solana-atomic-u64",
  "solana-sanitize",
  "wasm-bindgen",
@@ -1743,124 +1276,11 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce496a475e5062ba5de97215ab39d9c358f9c9df4bb7f3a45a1f1a8bd9065ed"
 dependencies = [
- "bincode",
- "borsh 1.5.7",
  "getrandom 0.2.16",
  "js-sys",
  "num-traits",
- "serde",
- "serde_derive",
  "solana-define-syscall",
  "solana-pubkey",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-instructions-sysvar"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427f2d0d6dc0bb49f16cef5e7f975180d2e80aab9bdd3b2af68e2d029ec63f43"
-dependencies = [
- "bitflags",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-serialize-utils",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-keccak-hasher"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7aeb957fbd42a451b99235df4942d96db7ef678e8d5061ef34c9b34cae12f79"
-dependencies = [
- "sha3",
- "solana-define-syscall",
- "solana-hash",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-last-restart-slot"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6360ac2fdc72e7463565cd256eedcf10d7ef0c28a1249d261ec168c1b55cdd"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-loader-v2-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ab08006dad78ae7cd30df8eea0539e207d08d91eaefb3e1d49a446e1c49654"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-loader-v3-interface"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4be76cfa9afd84ca2f35ebc09f0da0f0092935ccdac0595d98447f259538c2"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-loader-v4-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706a777242f1f39a83e2a96a2a6cb034cb41169c6ecbee2cf09cb873d9659e7e"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-message"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6bf99c4570173710107a1f233f3bee226feea5fc817308707d4f7cb100a72d"
-dependencies = [
- "bincode",
- "blake3",
- "lazy_static",
- "serde",
- "serde_derive",
- "solana-bincode",
- "solana-hash",
- "solana-instruction",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-short-vec",
- "solana-system-interface",
- "solana-transaction-error",
  "wasm-bindgen",
 ]
 
@@ -1871,106 +1291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36a1a14399afaabc2781a1db09cb14ee4cc4ee5c7a5a3cfcc601811379a8092"
 dependencies = [
  "solana-define-syscall",
-]
-
-[[package]]
-name = "solana-native-token"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e9de00960197412e4be3902a6cd35e60817c511137aca6c34c66cd5d4017ec"
-
-[[package]]
-name = "solana-nonce"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703e22eb185537e06204a5bd9d509b948f0066f2d1d814a6f475dafb3ddf1325"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-fee-calculator",
- "solana-hash",
- "solana-pubkey",
- "solana-sha256-hasher",
-]
-
-[[package]]
-name = "solana-program"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "586469467e93ceb79048f8d8e3a619bf61d05396ee7de95cb40280301a589d05"
-dependencies = [
- "bincode",
- "blake3",
- "borsh 0.10.4",
- "borsh 1.5.7",
- "bs58",
- "bytemuck",
- "console_error_panic_hook",
- "console_log",
- "getrandom 0.2.16",
- "lazy_static",
- "log",
- "memoffset",
- "num-bigint",
- "num-derive",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-account-info",
- "solana-address-lookup-table-interface",
- "solana-atomic-u64",
- "solana-big-mod-exp",
- "solana-bincode",
- "solana-blake3-hasher",
- "solana-borsh",
- "solana-clock",
- "solana-cpi",
- "solana-decode-error",
- "solana-define-syscall",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-example-mocks",
- "solana-feature-gate-interface",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-keccak-hasher",
- "solana-last-restart-slot",
- "solana-loader-v2-interface",
- "solana-loader-v3-interface",
- "solana-loader-v4-interface",
- "solana-message",
- "solana-msg",
- "solana-native-token",
- "solana-nonce",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-secp256k1-recover",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-sha256-hasher",
- "solana-short-vec",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stable-layout",
- "solana-stake-interface",
- "solana-system-interface",
- "solana-sysvar",
- "solana-sysvar-id",
- "solana-vote-interface",
- "thiserror 2.0.12",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1991,10 +1311,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8ae2c1a8d0d4ae865882d5770a7ebca92bab9c685e43f0461682c6c05a35bfa"
 dependencies = [
- "borsh 1.5.7",
  "num-traits",
- "serde",
- "serde_derive",
  "solana-decode-error",
  "solana-instruction",
  "solana-msg",
@@ -2012,21 +1329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-program-option"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc677a2e9bc616eda6dbdab834d463372b92848b2bfe4a1ed4e4b4adba3397d0"
-
-[[package]]
-name = "solana-program-pack"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319f0ef15e6e12dc37c597faccb7d62525a509fec5f6975ecb9419efddeb277b"
-dependencies = [
- "solana-program-error",
-]
-
-[[package]]
 name = "solana-pubkey"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,15 +1337,11 @@ dependencies = [
  "borsh 0.10.4",
  "borsh 1.5.7",
  "bs58",
- "bytemuck",
- "bytemuck_derive",
  "curve25519-dalek",
  "five8_const",
  "getrandom 0.2.16",
  "js-sys",
  "num-traits",
- "serde",
- "serde_derive",
  "solana-atomic-u64",
  "solana-decode-error",
  "solana-define-syscall",
@@ -2053,75 +1351,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-rent"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1aea8fdea9de98ca6e8c2da5827707fb3842833521b528a713810ca685d2480"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
 name = "solana-sanitize"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
-
-[[package]]
-name = "solana-sdk-ids"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5d8b9cc68d5c88b062a33e23a6466722467dde0035152d8fb1afbcdf350a5f"
-dependencies = [
- "solana-pubkey",
-]
-
-[[package]]
-name = "solana-sdk-macro"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86280da8b99d03560f6ab5aca9de2e38805681df34e0bb8f238e69b29433b9df"
-dependencies = [
- "bs58",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "solana-secp256k1-recover"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa3120b6cdaa270f39444f5093a90a7b03d296d362878f7a6991d6de3bbe496"
-dependencies = [
- "libsecp256k1",
- "solana-define-syscall",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-serde-varint"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc07d00200d82e6def2f7f7a45738e3406b17fe54a18adcf0defa16a97ccadb"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "solana-serialize-utils"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817a284b63197d2b27afdba829c5ab34231da4a9b4e763466a003c40ca4f535e"
-dependencies = [
- "solana-instruction",
- "solana-pubkey",
- "solana-sanitize",
-]
 
 [[package]]
 name = "solana-sha256-hasher"
@@ -2129,44 +1362,9 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0037386961c0d633421f53560ad7c80675c0447cba4d1bb66d60974dd486c7ea"
 dependencies = [
- "sha2 0.10.8",
+ "sha2",
  "solana-define-syscall",
  "solana-hash",
-]
-
-[[package]]
-name = "solana-short-vec"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c54c66f19b9766a56fa0057d060de8378676cb64987533fa088861858fc5a69"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "solana-slot-hashes"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8691982114513763e88d04094c9caa0376b867a29577939011331134c301ce"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-hash",
- "solana-sdk-ids",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-slot-history"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ccc1b2067ca22754d5283afb2b0126d61eae734fc616d23871b0943b0d935e"
-dependencies = [
- "bv",
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sysvar-id",
 ]
 
 [[package]]
@@ -2177,124 +1375,6 @@ checksum = "9f14f7d02af8f2bc1b5efeeae71bc1c2b7f0f65cd75bcc7d8180f2c762a57f54"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
-]
-
-[[package]]
-name = "solana-stake-interface"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5269e89fde216b4d7e1d1739cf5303f8398a1ff372a81232abbee80e554a838c"
-dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.7",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-system-interface",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-system-interface"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7c18cb1a91c6be5f5a8ac9276a1d7c737e39a21beba9ea710ab4b9c63bc90"
-dependencies = [
- "js-sys",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-decode-error",
- "solana-instruction",
- "solana-pubkey",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-sysvar"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6b44740d7f0c9f375d045c165bc0aab4a90658f92d6835aeb0649afaeaff9a"
-dependencies = [
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "lazy_static",
- "serde",
- "serde_derive",
- "solana-account-info",
- "solana-clock",
- "solana-define-syscall",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-last-restart-slot",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stake-interface",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-sysvar-id"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5762b273d3325b047cfda250787f8d796d781746860d5d0a746ee29f3e8812c1"
-dependencies = [
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-transaction-error"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a9dc8fdb61c6088baab34fc3a8b8473a03a7a5fd404ed8dd502fa79b67cb1"
-dependencies = [
- "solana-instruction",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-vote-interface"
-version = "2.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f039b0788337bedc6c5450d2f237718f938defb5ce0e0ad8ef507e78dcd370"
-dependencies = [
- "bincode",
- "num-derive",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-decode-error",
- "solana-hash",
- "solana-instruction",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-short-vec",
- "solana-system-interface",
 ]
 
 [[package]]
@@ -2369,16 +1449,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2386,17 +1457,6 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2504,7 +1564,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "flate2",
  "h2",
@@ -2552,7 +1612,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -2653,12 +1713,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2728,16 +1782,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2860,7 +1904,7 @@ version = "0.2.0"
 source = "git+https://github.com/rpcpool/yellowstone-vixen?branch=main#aa588e10c6842dada13702a8008cadd1b728aa3f"
 dependencies = [
  "bs58",
- "thiserror 1.0.69",
+ "thiserror",
  "yellowstone-grpc-proto",
  "yellowstone-vixen-proto",
 ]
@@ -2882,10 +1926,17 @@ dependencies = [
  "num-traits",
  "prost",
  "prost-build",
- "solana-program",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey",
  "strum",
  "strum_macros",
- "thiserror 1.0.69",
+ "thiserror",
  "tonic",
  "tracing",
  "yellowstone-vixen-core",

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/Cargo.toml
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/Cargo.toml
@@ -9,7 +9,14 @@ edition = "2021"
 [dependencies]
 prost = "0.13.1"
 tonic = { version = "0.12.1", features = ["gzip", "zstd"] }
-solana-program = "^2.1.6"
+solana-account-info = "2.2.1"
+solana-cpi = "2.2.1"
+solana-decode-error = "2.2.1"
+solana-pubkey = { version = "2.2.1", features = ["curve25519", "borsh"] }
+solana-instruction = "2.2.1"
+solana-msg = "2.2.1"
+solana-program-entrypoint = "2.2.1"
+solana-program-error = "2.2.1"
 borsh = "^0.10"
 yellowstone-vixen-core = { git = "https://github.com/rpcpool/yellowstone-vixen", branch = "main",features = ["proto"] }
 num-derive = "0.4"

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_parser/accounts_parser.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_parser/accounts_parser.rs
@@ -93,7 +93,7 @@ impl yellowstone_vixen_core::Parser for AccountParser {
         let inner = acct
             .account
             .as_ref()
-            .ok_or(solana_program::program_error::ProgramError::InvalidArgument)?;
+            .ok_or(solana_program_error::ProgramError::InvalidArgument)?;
         RaydiumAmmProgramState::try_unpack(&inner.data)
     }
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/accounts/amm_config.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/accounts/amm_config.rs
@@ -7,7 +7,7 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -35,12 +35,10 @@ impl AmmConfig {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for AmmConfig {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for AmmConfig {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -49,7 +47,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for AmmConfig {
 #[cfg(feature = "fetch")]
 pub fn fetch_amm_config(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<AmmConfig>, std::io::Error> {
     let accounts = fetch_all_amm_config(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -58,7 +56,7 @@ pub fn fetch_amm_config(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_amm_config(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<AmmConfig>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -83,7 +81,7 @@ pub fn fetch_all_amm_config(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_amm_config(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<AmmConfig>, std::io::Error> {
     let accounts = fetch_all_maybe_amm_config(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -92,7 +90,7 @@ pub fn fetch_maybe_amm_config(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_amm_config(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<AmmConfig>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/accounts/amm_info.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/accounts/amm_info.rs
@@ -9,7 +9,7 @@ use crate::generated::types::Fees;
 use crate::generated::types::OutPutData;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -105,12 +105,10 @@ impl AmmInfo {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for AmmInfo {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for AmmInfo {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -119,7 +117,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for AmmInfo {
 #[cfg(feature = "fetch")]
 pub fn fetch_amm_info(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<AmmInfo>, std::io::Error> {
     let accounts = fetch_all_amm_info(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -128,7 +126,7 @@ pub fn fetch_amm_info(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_amm_info(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<AmmInfo>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -153,7 +151,7 @@ pub fn fetch_all_amm_info(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_amm_info(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<AmmInfo>, std::io::Error> {
     let accounts = fetch_all_maybe_amm_info(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -162,7 +160,7 @@ pub fn fetch_maybe_amm_info(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_amm_info(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<AmmInfo>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/accounts/target_orders.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/accounts/target_orders.rs
@@ -51,12 +51,10 @@ impl TargetOrders {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for TargetOrders {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for TargetOrders {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -65,7 +63,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for TargetOrder
 #[cfg(feature = "fetch")]
 pub fn fetch_target_orders(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<TargetOrders>, std::io::Error> {
     let accounts = fetch_all_target_orders(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -74,7 +72,7 @@ pub fn fetch_target_orders(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_target_orders(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<TargetOrders>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -99,7 +97,7 @@ pub fn fetch_all_target_orders(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_target_orders(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<TargetOrders>, std::io::Error> {
     let accounts = fetch_all_maybe_target_orders(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -108,7 +106,7 @@ pub fn fetch_maybe_target_orders(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_target_orders(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<TargetOrders>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/errors/raydium_amm.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/errors/raydium_amm.rs
@@ -183,13 +183,13 @@ pub enum RaydiumAmmError {
     UnknownAmmError = 0x38,
 }
 
-impl solana_program::program_error::PrintProgramError for RaydiumAmmError {
+impl solana_program_error::PrintProgramError for RaydiumAmmError {
     fn print<E>(&self) {
-        solana_program::msg!(&self.to_string());
+        solana_msg::msg!(&self.to_string());
     }
 }
 
-impl<T> solana_program::decode_error::DecodeError<T> for RaydiumAmmError {
+impl<T> solana_decode_error::DecodeError<T> for RaydiumAmmError {
     fn type_of() -> &'static str {
         "RaydiumAmmError"
     }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/admin_cancel_orders.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/admin_cancel_orders.rs
@@ -11,46 +11,46 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct AdminCancelOrders {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub amm_open_orders: solana_program::pubkey::Pubkey,
+    pub amm_open_orders: solana_pubkey::Pubkey,
 
-    pub amm_target_orders: solana_program::pubkey::Pubkey,
+    pub amm_target_orders: solana_pubkey::Pubkey,
 
-    pub pool_coin_token_account: solana_program::pubkey::Pubkey,
+    pub pool_coin_token_account: solana_pubkey::Pubkey,
 
-    pub pool_pc_token_account: solana_program::pubkey::Pubkey,
+    pub pool_pc_token_account: solana_pubkey::Pubkey,
 
-    pub amm_owner_account: solana_program::pubkey::Pubkey,
+    pub amm_owner_account: solana_pubkey::Pubkey,
 
-    pub amm_config: solana_program::pubkey::Pubkey,
+    pub amm_config: solana_pubkey::Pubkey,
 
-    pub serum_program: solana_program::pubkey::Pubkey,
+    pub serum_program: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub serum_coin_vault_account: solana_program::pubkey::Pubkey,
+    pub serum_coin_vault_account: solana_pubkey::Pubkey,
 
-    pub serum_pc_vault_account: solana_program::pubkey::Pubkey,
+    pub serum_pc_vault_account: solana_pubkey::Pubkey,
 
-    pub serum_vault_signer: solana_program::pubkey::Pubkey,
+    pub serum_vault_signer: solana_pubkey::Pubkey,
 
-    pub serum_event_q: solana_program::pubkey::Pubkey,
+    pub serum_event_q: solana_pubkey::Pubkey,
 
-    pub serum_bids: solana_program::pubkey::Pubkey,
+    pub serum_bids: solana_pubkey::Pubkey,
 
-    pub serum_asks: solana_program::pubkey::Pubkey,
+    pub serum_asks: solana_pubkey::Pubkey,
 }
 
 impl AdminCancelOrders {
     pub fn instruction(
         &self,
         args: AdminCancelOrdersInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -58,82 +58,73 @@ impl AdminCancelOrders {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: AdminCancelOrdersInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(17 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_target_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_owner_account,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm_config,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.amm_config, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_coin_vault_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_pc_vault_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_vault_signer,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_event_q,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_bids,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_asks,
-            false,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_bids, false));
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_asks, false));
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&AdminCancelOrdersInstructionData::new()).unwrap();
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -190,25 +181,25 @@ pub struct AdminCancelOrdersInstructionArgs {
 ///   16. `[writable]` serum_asks
 #[derive(Clone, Debug, Default)]
 pub struct AdminCancelOrdersBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    amm_target_orders: Option<solana_program::pubkey::Pubkey>,
-    pool_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    amm_owner_account: Option<solana_program::pubkey::Pubkey>,
-    amm_config: Option<solana_program::pubkey::Pubkey>,
-    serum_program: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    serum_coin_vault_account: Option<solana_program::pubkey::Pubkey>,
-    serum_pc_vault_account: Option<solana_program::pubkey::Pubkey>,
-    serum_vault_signer: Option<solana_program::pubkey::Pubkey>,
-    serum_event_q: Option<solana_program::pubkey::Pubkey>,
-    serum_bids: Option<solana_program::pubkey::Pubkey>,
-    serum_asks: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    amm_open_orders: Option<solana_pubkey::Pubkey>,
+    amm_target_orders: Option<solana_pubkey::Pubkey>,
+    pool_coin_token_account: Option<solana_pubkey::Pubkey>,
+    pool_pc_token_account: Option<solana_pubkey::Pubkey>,
+    amm_owner_account: Option<solana_pubkey::Pubkey>,
+    amm_config: Option<solana_pubkey::Pubkey>,
+    serum_program: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    serum_coin_vault_account: Option<solana_pubkey::Pubkey>,
+    serum_pc_vault_account: Option<solana_pubkey::Pubkey>,
+    serum_vault_signer: Option<solana_pubkey::Pubkey>,
+    serum_event_q: Option<solana_pubkey::Pubkey>,
+    serum_bids: Option<solana_pubkey::Pubkey>,
+    serum_asks: Option<solana_pubkey::Pubkey>,
     limit: Option<u16>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl AdminCancelOrdersBuilder {
@@ -217,40 +208,34 @@ impl AdminCancelOrdersBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn amm_open_orders(
-        &mut self,
-        amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_open_orders(&mut self, amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
-    pub fn amm_target_orders(
-        &mut self,
-        amm_target_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_target_orders(&mut self, amm_target_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_target_orders = Some(amm_target_orders);
         self
     }
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: solana_program::pubkey::Pubkey,
+        pool_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -258,38 +243,35 @@ impl AdminCancelOrdersBuilder {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: solana_program::pubkey::Pubkey,
+        pool_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_pc_token_account = Some(pool_pc_token_account);
         self
     }
     #[inline(always)]
-    pub fn amm_owner_account(
-        &mut self,
-        amm_owner_account: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_owner_account(&mut self, amm_owner_account: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_owner_account = Some(amm_owner_account);
         self
     }
     #[inline(always)]
-    pub fn amm_config(&mut self, amm_config: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_config(&mut self, amm_config: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_config = Some(amm_config);
         self
     }
     #[inline(always)]
-    pub fn serum_program(&mut self, serum_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_program(&mut self, serum_program: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_program = Some(serum_program);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
     pub fn serum_coin_vault_account(
         &mut self,
-        serum_coin_vault_account: solana_program::pubkey::Pubkey,
+        serum_coin_vault_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.serum_coin_vault_account = Some(serum_coin_vault_account);
         self
@@ -297,31 +279,28 @@ impl AdminCancelOrdersBuilder {
     #[inline(always)]
     pub fn serum_pc_vault_account(
         &mut self,
-        serum_pc_vault_account: solana_program::pubkey::Pubkey,
+        serum_pc_vault_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.serum_pc_vault_account = Some(serum_pc_vault_account);
         self
     }
     #[inline(always)]
-    pub fn serum_vault_signer(
-        &mut self,
-        serum_vault_signer: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_vault_signer(&mut self, serum_vault_signer: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_vault_signer = Some(serum_vault_signer);
         self
     }
     #[inline(always)]
-    pub fn serum_event_q(&mut self, serum_event_q: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_event_q(&mut self, serum_event_q: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_event_q = Some(serum_event_q);
         self
     }
     #[inline(always)]
-    pub fn serum_bids(&mut self, serum_bids: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_bids(&mut self, serum_bids: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_bids = Some(serum_bids);
         self
     }
     #[inline(always)]
-    pub fn serum_asks(&mut self, serum_asks: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_asks(&mut self, serum_asks: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_asks = Some(serum_asks);
         self
     }
@@ -332,10 +311,7 @@ impl AdminCancelOrdersBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -343,15 +319,15 @@ impl AdminCancelOrdersBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = AdminCancelOrders {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             amm: self.amm.expect("amm is not set"),
@@ -395,86 +371,86 @@ impl AdminCancelOrdersBuilder {
 
 /// `admin_cancel_orders` CPI accounts.
 pub struct AdminCancelOrdersCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_owner_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_q: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_q: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `admin_cancel_orders` CPI instruction.
 pub struct AdminCancelOrdersCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_owner_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_q: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_q: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: AdminCancelOrdersInstructionArgs,
 }
 
 impl<'a, 'b> AdminCancelOrdersCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: AdminCancelOrdersCpiAccounts<'a, 'b>,
         args: AdminCancelOrdersInstructionArgs,
     ) -> Self {
@@ -501,25 +477,21 @@ impl<'a, 'b> AdminCancelOrdersCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -528,83 +500,79 @@ impl<'a, 'b> AdminCancelOrdersCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(17 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_target_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_owner_account.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_coin_vault_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_pc_vault_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_vault_signer.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_event_q.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_bids.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_asks.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -614,7 +582,7 @@ impl<'a, 'b> AdminCancelOrdersCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -643,9 +611,9 @@ impl<'a, 'b> AdminCancelOrdersCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -677,7 +645,7 @@ pub struct AdminCancelOrdersCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(AdminCancelOrdersCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -705,20 +673,20 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -726,7 +694,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_open_orders(
         &mut self,
-        amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_open_orders = Some(amm_open_orders);
         self
@@ -734,7 +702,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_target_orders(
         &mut self,
-        amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_target_orders = Some(amm_target_orders);
         self
@@ -742,7 +710,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -750,7 +718,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -758,7 +726,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_owner_account(
         &mut self,
-        amm_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_owner_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_owner_account = Some(amm_owner_account);
         self
@@ -766,7 +734,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_config(
         &mut self,
-        amm_config: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_config = Some(amm_config);
         self
@@ -774,7 +742,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_program(
         &mut self,
-        serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_program = Some(serum_program);
         self
@@ -782,7 +750,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -790,7 +758,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_coin_vault_account(
         &mut self,
-        serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_coin_vault_account = Some(serum_coin_vault_account);
         self
@@ -798,7 +766,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_pc_vault_account(
         &mut self,
-        serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_pc_vault_account = Some(serum_pc_vault_account);
         self
@@ -806,7 +774,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_vault_signer(
         &mut self,
-        serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_vault_signer = Some(serum_vault_signer);
         self
@@ -814,7 +782,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_event_q(
         &mut self,
-        serum_event_q: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_event_q: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_event_q = Some(serum_event_q);
         self
@@ -822,7 +790,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_bids(
         &mut self,
-        serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_bids: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_bids = Some(serum_bids);
         self
@@ -830,7 +798,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_asks(
         &mut self,
-        serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_asks: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_asks = Some(serum_asks);
         self
@@ -844,7 +812,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -860,11 +828,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -872,7 +836,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -880,7 +844,7 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = AdminCancelOrdersInstructionArgs {
             limit: self.instruction.limit.clone().expect("limit is not set"),
         };
@@ -970,29 +934,25 @@ impl<'a, 'b> AdminCancelOrdersCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct AdminCancelOrdersCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_target_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_owner_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_coin_vault_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_pc_vault_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_vault_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_event_q: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_bids: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_asks: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_target_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_owner_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_coin_vault_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_pc_vault_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_vault_signer: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_event_q: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_bids: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_asks: Option<&'b solana_account_info::AccountInfo<'a>>,
     limit: Option<u16>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/create_config_account.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/create_config_account.rs
@@ -11,49 +11,44 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct CreateConfigAccount {
-    pub admin: solana_program::pubkey::Pubkey,
+    pub admin: solana_pubkey::Pubkey,
 
-    pub amm_config: solana_program::pubkey::Pubkey,
+    pub amm_config: solana_pubkey::Pubkey,
 
-    pub owner: solana_program::pubkey::Pubkey,
+    pub owner: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 }
 
 impl CreateConfigAccount {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.admin, true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm_config,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.admin, true));
+        accounts.push(solana_instruction::AccountMeta::new(self.amm_config, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.owner, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&CreateConfigAccountInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -92,12 +87,12 @@ impl Default for CreateConfigAccountInstructionData {
 ///   4. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct CreateConfigAccountBuilder {
-    admin: Option<solana_program::pubkey::Pubkey>,
-    amm_config: Option<solana_program::pubkey::Pubkey>,
-    owner: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    admin: Option<solana_pubkey::Pubkey>,
+    amm_config: Option<solana_pubkey::Pubkey>,
+    owner: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl CreateConfigAccountBuilder {
@@ -105,38 +100,35 @@ impl CreateConfigAccountBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn admin(&mut self, admin: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn admin(&mut self, admin: solana_pubkey::Pubkey) -> &mut Self {
         self.admin = Some(admin);
         self
     }
     #[inline(always)]
-    pub fn amm_config(&mut self, amm_config: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_config(&mut self, amm_config: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_config = Some(amm_config);
         self
     }
     #[inline(always)]
-    pub fn owner(&mut self, owner: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn owner(&mut self, owner: solana_pubkey::Pubkey) -> &mut Self {
         self.owner = Some(owner);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -144,21 +136,21 @@ impl CreateConfigAccountBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = CreateConfigAccount {
             admin: self.admin.expect("admin is not set"),
             amm_config: self.amm_config.expect("amm_config is not set"),
             owner: self.owner.expect("owner is not set"),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
         };
@@ -169,36 +161,36 @@ impl CreateConfigAccountBuilder {
 
 /// `create_config_account` CPI accounts.
 pub struct CreateConfigAccountCpiAccounts<'a, 'b> {
-    pub admin: &'b solana_program::account_info::AccountInfo<'a>,
+    pub admin: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `create_config_account` CPI instruction.
 pub struct CreateConfigAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub admin: &'b solana_program::account_info::AccountInfo<'a>,
+    pub admin: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> CreateConfigAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: CreateConfigAccountCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -211,25 +203,21 @@ impl<'a, 'b> CreateConfigAccountCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -238,35 +226,28 @@ impl<'a, 'b> CreateConfigAccountCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.admin.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(*self.admin.key, true));
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.owner.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -274,7 +255,7 @@ impl<'a, 'b> CreateConfigAccountCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&CreateConfigAccountInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -291,9 +272,9 @@ impl<'a, 'b> CreateConfigAccountCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -313,7 +294,7 @@ pub struct CreateConfigAccountCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> CreateConfigAccountCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateConfigAccountCpiBuilderInstruction {
             __program: program,
             admin: None,
@@ -326,33 +307,33 @@ impl<'a, 'b> CreateConfigAccountCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn admin(&mut self, admin: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn admin(&mut self, admin: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.admin = Some(admin);
         self
     }
     #[inline(always)]
     pub fn amm_config(
         &mut self,
-        amm_config: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_config = Some(amm_config);
         self
     }
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -360,7 +341,7 @@ impl<'a, 'b> CreateConfigAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -376,11 +357,7 @@ impl<'a, 'b> CreateConfigAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -388,7 +365,7 @@ impl<'a, 'b> CreateConfigAccountCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -396,7 +373,7 @@ impl<'a, 'b> CreateConfigAccountCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = CreateConfigAccountCpi {
             __program: self.instruction.__program,
 
@@ -422,16 +399,12 @@ impl<'a, 'b> CreateConfigAccountCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct CreateConfigAccountCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    admin: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    admin: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/deposit.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/deposit.rs
@@ -11,40 +11,37 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct Deposit {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub amm_open_orders: solana_program::pubkey::Pubkey,
+    pub amm_open_orders: solana_pubkey::Pubkey,
 
-    pub amm_target_orders: solana_program::pubkey::Pubkey,
+    pub amm_target_orders: solana_pubkey::Pubkey,
 
-    pub lp_mint_address: solana_program::pubkey::Pubkey,
+    pub lp_mint_address: solana_pubkey::Pubkey,
 
-    pub pool_coin_token_account: solana_program::pubkey::Pubkey,
+    pub pool_coin_token_account: solana_pubkey::Pubkey,
 
-    pub pool_pc_token_account: solana_program::pubkey::Pubkey,
+    pub pool_pc_token_account: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub user_coin_token_account: solana_program::pubkey::Pubkey,
+    pub user_coin_token_account: solana_pubkey::Pubkey,
 
-    pub user_pc_token_account: solana_program::pubkey::Pubkey,
+    pub user_pc_token_account: solana_pubkey::Pubkey,
 
-    pub user_lp_token_account: solana_program::pubkey::Pubkey,
+    pub user_lp_token_account: solana_pubkey::Pubkey,
 
-    pub user_owner: solana_program::pubkey::Pubkey,
+    pub user_owner: solana_pubkey::Pubkey,
 
-    pub serum_event_queue: solana_program::pubkey::Pubkey,
+    pub serum_event_queue: solana_pubkey::Pubkey,
 }
 
 impl Deposit {
-    pub fn instruction(
-        &self,
-        args: DepositInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: DepositInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -52,61 +49,59 @@ impl Deposit {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: DepositInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm, false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.amm, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_target_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.lp_mint_address,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.user_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.user_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.user_lp_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.user_owner,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_event_queue,
             false,
         ));
@@ -115,7 +110,7 @@ impl Deposit {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -169,24 +164,24 @@ pub struct DepositInstructionArgs {
 ///   13. `[]` serum_event_queue
 #[derive(Clone, Debug, Default)]
 pub struct DepositBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    amm_target_orders: Option<solana_program::pubkey::Pubkey>,
-    lp_mint_address: Option<solana_program::pubkey::Pubkey>,
-    pool_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    user_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    user_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    user_lp_token_account: Option<solana_program::pubkey::Pubkey>,
-    user_owner: Option<solana_program::pubkey::Pubkey>,
-    serum_event_queue: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    amm_open_orders: Option<solana_pubkey::Pubkey>,
+    amm_target_orders: Option<solana_pubkey::Pubkey>,
+    lp_mint_address: Option<solana_pubkey::Pubkey>,
+    pool_coin_token_account: Option<solana_pubkey::Pubkey>,
+    pool_pc_token_account: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    user_coin_token_account: Option<solana_pubkey::Pubkey>,
+    user_pc_token_account: Option<solana_pubkey::Pubkey>,
+    user_lp_token_account: Option<solana_pubkey::Pubkey>,
+    user_owner: Option<solana_pubkey::Pubkey>,
+    serum_event_queue: Option<solana_pubkey::Pubkey>,
     max_coin_amount: Option<u64>,
     max_pc_amount: Option<u64>,
     base_side: Option<u64>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl DepositBuilder {
@@ -195,48 +190,39 @@ impl DepositBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn amm_open_orders(
-        &mut self,
-        amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_open_orders(&mut self, amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
-    pub fn amm_target_orders(
-        &mut self,
-        amm_target_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_target_orders(&mut self, amm_target_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_target_orders = Some(amm_target_orders);
         self
     }
     #[inline(always)]
-    pub fn lp_mint_address(
-        &mut self,
-        lp_mint_address: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn lp_mint_address(&mut self, lp_mint_address: solana_pubkey::Pubkey) -> &mut Self {
         self.lp_mint_address = Some(lp_mint_address);
         self
     }
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: solana_program::pubkey::Pubkey,
+        pool_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -244,20 +230,20 @@ impl DepositBuilder {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: solana_program::pubkey::Pubkey,
+        pool_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_pc_token_account = Some(pool_pc_token_account);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
     pub fn user_coin_token_account(
         &mut self,
-        user_coin_token_account: solana_program::pubkey::Pubkey,
+        user_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.user_coin_token_account = Some(user_coin_token_account);
         self
@@ -265,7 +251,7 @@ impl DepositBuilder {
     #[inline(always)]
     pub fn user_pc_token_account(
         &mut self,
-        user_pc_token_account: solana_program::pubkey::Pubkey,
+        user_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.user_pc_token_account = Some(user_pc_token_account);
         self
@@ -273,21 +259,18 @@ impl DepositBuilder {
     #[inline(always)]
     pub fn user_lp_token_account(
         &mut self,
-        user_lp_token_account: solana_program::pubkey::Pubkey,
+        user_lp_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.user_lp_token_account = Some(user_lp_token_account);
         self
     }
     #[inline(always)]
-    pub fn user_owner(&mut self, user_owner: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn user_owner(&mut self, user_owner: solana_pubkey::Pubkey) -> &mut Self {
         self.user_owner = Some(user_owner);
         self
     }
     #[inline(always)]
-    pub fn serum_event_queue(
-        &mut self,
-        serum_event_queue: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_event_queue(&mut self, serum_event_queue: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_event_queue = Some(serum_event_queue);
         self
     }
@@ -308,10 +291,7 @@ impl DepositBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -319,15 +299,15 @@ impl DepositBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = Deposit {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             amm: self.amm.expect("amm is not set"),
@@ -376,74 +356,74 @@ impl DepositBuilder {
 
 /// `deposit` CPI accounts.
 pub struct DepositCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `deposit` CPI instruction.
 pub struct DepositCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: DepositInstructionArgs,
 }
 
 impl<'a, 'b> DepositCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: DepositCpiAccounts<'a, 'b>,
         args: DepositInstructionArgs,
     ) -> Self {
@@ -467,25 +447,21 @@ impl<'a, 'b> DepositCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -494,71 +470,64 @@ impl<'a, 'b> DepositCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.amm.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.amm.key, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_target_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.lp_mint_address.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.user_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.user_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.user_lp_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.user_owner.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_event_queue.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -568,7 +537,7 @@ impl<'a, 'b> DepositCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -594,9 +563,9 @@ impl<'a, 'b> DepositCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -625,7 +594,7 @@ pub struct DepositCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DepositCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -652,20 +621,20 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -673,7 +642,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_open_orders(
         &mut self,
-        amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_open_orders = Some(amm_open_orders);
         self
@@ -681,7 +650,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_target_orders(
         &mut self,
-        amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_target_orders = Some(amm_target_orders);
         self
@@ -689,7 +658,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn lp_mint_address(
         &mut self,
-        lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+        lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.lp_mint_address = Some(lp_mint_address);
         self
@@ -697,7 +666,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -705,7 +674,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -713,7 +682,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -721,7 +690,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_coin_token_account(
         &mut self,
-        user_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        user_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_coin_token_account = Some(user_coin_token_account);
         self
@@ -729,7 +698,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_pc_token_account(
         &mut self,
-        user_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        user_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_pc_token_account = Some(user_pc_token_account);
         self
@@ -737,7 +706,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_lp_token_account(
         &mut self,
-        user_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        user_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_lp_token_account = Some(user_lp_token_account);
         self
@@ -745,7 +714,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_owner(
         &mut self,
-        user_owner: &'b solana_program::account_info::AccountInfo<'a>,
+        user_owner: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_owner = Some(user_owner);
         self
@@ -753,7 +722,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_event_queue(
         &mut self,
-        serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_event_queue = Some(serum_event_queue);
         self
@@ -777,7 +746,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -793,11 +762,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -805,7 +770,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -813,7 +778,7 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = DepositInstructionArgs {
             max_coin_amount: self
                 .instruction
@@ -908,28 +873,24 @@ impl<'a, 'b> DepositCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct DepositCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_target_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    lp_mint_address: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_lp_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_event_queue: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_target_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    lp_mint_address: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_lp_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_owner: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_event_queue: Option<&'b solana_account_info::AccountInfo<'a>>,
     max_coin_amount: Option<u64>,
     max_pc_amount: Option<u64>,
     base_side: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/initialize.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/initialize.rs
@@ -11,48 +11,45 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct Initialize {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub amm_open_orders: solana_program::pubkey::Pubkey,
+    pub amm_open_orders: solana_pubkey::Pubkey,
 
-    pub lp_mint_address: solana_program::pubkey::Pubkey,
+    pub lp_mint_address: solana_pubkey::Pubkey,
 
-    pub coin_mint_address: solana_program::pubkey::Pubkey,
+    pub coin_mint_address: solana_pubkey::Pubkey,
 
-    pub pc_mint_address: solana_program::pubkey::Pubkey,
+    pub pc_mint_address: solana_pubkey::Pubkey,
 
-    pub pool_coin_token_account: solana_program::pubkey::Pubkey,
+    pub pool_coin_token_account: solana_pubkey::Pubkey,
 
-    pub pool_pc_token_account: solana_program::pubkey::Pubkey,
+    pub pool_pc_token_account: solana_pubkey::Pubkey,
 
-    pub pool_withdraw_queue: solana_program::pubkey::Pubkey,
+    pub pool_withdraw_queue: solana_pubkey::Pubkey,
 
-    pub pool_target_orders_account: solana_program::pubkey::Pubkey,
+    pub pool_target_orders_account: solana_pubkey::Pubkey,
 
-    pub user_lp_token_account: solana_program::pubkey::Pubkey,
+    pub user_lp_token_account: solana_pubkey::Pubkey,
 
-    pub pool_temp_lp_token_account: solana_program::pubkey::Pubkey,
+    pub pool_temp_lp_token_account: solana_pubkey::Pubkey,
 
-    pub serum_program: solana_program::pubkey::Pubkey,
+    pub serum_program: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub user_wallet: solana_program::pubkey::Pubkey,
+    pub user_wallet: solana_pubkey::Pubkey,
 }
 
 impl Initialize {
-    pub fn instruction(
-        &self,
-        args: InitializeInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: InitializeInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -60,85 +57,80 @@ impl Initialize {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: InitializeInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(18 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm, false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.amm, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.lp_mint_address,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.coin_mint_address,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.pc_mint_address,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.pool_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.pool_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_withdraw_queue,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_target_orders_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.user_lp_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.pool_temp_lp_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.user_wallet,
-            true,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.user_wallet, true));
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&InitializeInstructionData::new()).unwrap();
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -195,27 +187,27 @@ pub struct InitializeInstructionArgs {
 ///   17. `[writable, signer]` user_wallet
 #[derive(Clone, Debug, Default)]
 pub struct InitializeBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    lp_mint_address: Option<solana_program::pubkey::Pubkey>,
-    coin_mint_address: Option<solana_program::pubkey::Pubkey>,
-    pc_mint_address: Option<solana_program::pubkey::Pubkey>,
-    pool_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_withdraw_queue: Option<solana_program::pubkey::Pubkey>,
-    pool_target_orders_account: Option<solana_program::pubkey::Pubkey>,
-    user_lp_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_temp_lp_token_account: Option<solana_program::pubkey::Pubkey>,
-    serum_program: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    user_wallet: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    amm_open_orders: Option<solana_pubkey::Pubkey>,
+    lp_mint_address: Option<solana_pubkey::Pubkey>,
+    coin_mint_address: Option<solana_pubkey::Pubkey>,
+    pc_mint_address: Option<solana_pubkey::Pubkey>,
+    pool_coin_token_account: Option<solana_pubkey::Pubkey>,
+    pool_pc_token_account: Option<solana_pubkey::Pubkey>,
+    pool_withdraw_queue: Option<solana_pubkey::Pubkey>,
+    pool_target_orders_account: Option<solana_pubkey::Pubkey>,
+    user_lp_token_account: Option<solana_pubkey::Pubkey>,
+    pool_temp_lp_token_account: Option<solana_pubkey::Pubkey>,
+    serum_program: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    user_wallet: Option<solana_pubkey::Pubkey>,
     nonce: Option<u8>,
     open_time: Option<u64>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializeBuilder {
@@ -224,68 +216,56 @@ impl InitializeBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn amm_open_orders(
-        &mut self,
-        amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_open_orders(&mut self, amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
-    pub fn lp_mint_address(
-        &mut self,
-        lp_mint_address: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn lp_mint_address(&mut self, lp_mint_address: solana_pubkey::Pubkey) -> &mut Self {
         self.lp_mint_address = Some(lp_mint_address);
         self
     }
     #[inline(always)]
-    pub fn coin_mint_address(
-        &mut self,
-        coin_mint_address: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn coin_mint_address(&mut self, coin_mint_address: solana_pubkey::Pubkey) -> &mut Self {
         self.coin_mint_address = Some(coin_mint_address);
         self
     }
     #[inline(always)]
-    pub fn pc_mint_address(
-        &mut self,
-        pc_mint_address: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn pc_mint_address(&mut self, pc_mint_address: solana_pubkey::Pubkey) -> &mut Self {
         self.pc_mint_address = Some(pc_mint_address);
         self
     }
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: solana_program::pubkey::Pubkey,
+        pool_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -293,23 +273,20 @@ impl InitializeBuilder {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: solana_program::pubkey::Pubkey,
+        pool_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_pc_token_account = Some(pool_pc_token_account);
         self
     }
     #[inline(always)]
-    pub fn pool_withdraw_queue(
-        &mut self,
-        pool_withdraw_queue: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn pool_withdraw_queue(&mut self, pool_withdraw_queue: solana_pubkey::Pubkey) -> &mut Self {
         self.pool_withdraw_queue = Some(pool_withdraw_queue);
         self
     }
     #[inline(always)]
     pub fn pool_target_orders_account(
         &mut self,
-        pool_target_orders_account: solana_program::pubkey::Pubkey,
+        pool_target_orders_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_target_orders_account = Some(pool_target_orders_account);
         self
@@ -317,7 +294,7 @@ impl InitializeBuilder {
     #[inline(always)]
     pub fn user_lp_token_account(
         &mut self,
-        user_lp_token_account: solana_program::pubkey::Pubkey,
+        user_lp_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.user_lp_token_account = Some(user_lp_token_account);
         self
@@ -325,23 +302,23 @@ impl InitializeBuilder {
     #[inline(always)]
     pub fn pool_temp_lp_token_account(
         &mut self,
-        pool_temp_lp_token_account: solana_program::pubkey::Pubkey,
+        pool_temp_lp_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_temp_lp_token_account = Some(pool_temp_lp_token_account);
         self
     }
     #[inline(always)]
-    pub fn serum_program(&mut self, serum_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_program(&mut self, serum_program: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_program = Some(serum_program);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
-    pub fn user_wallet(&mut self, user_wallet: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn user_wallet(&mut self, user_wallet: solana_pubkey::Pubkey) -> &mut Self {
         self.user_wallet = Some(user_wallet);
         self
     }
@@ -357,10 +334,7 @@ impl InitializeBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -368,21 +342,21 @@ impl InitializeBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = Initialize {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
             amm: self.amm.expect("amm is not set"),
@@ -426,90 +400,90 @@ impl InitializeBuilder {
 
 /// `initialize` CPI accounts.
 pub struct InitializeCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub coin_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub coin_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pc_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pc_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_target_orders_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_target_orders_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_temp_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_temp_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_wallet: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_wallet: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize` CPI instruction.
 pub struct InitializeCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub coin_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub coin_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pc_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pc_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_target_orders_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_target_orders_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_temp_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_temp_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_wallet: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_wallet: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: InitializeInstructionArgs,
 }
 
 impl<'a, 'b> InitializeCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializeCpiAccounts<'a, 'b>,
         args: InitializeInstructionArgs,
     ) -> Self {
@@ -537,25 +511,21 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -564,87 +534,80 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(18 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.amm.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.amm.key, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.lp_mint_address.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.coin_mint_address.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.pc_mint_address.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.pool_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.pool_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_withdraw_queue.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_target_orders_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.user_lp_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.pool_temp_lp_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.user_wallet.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -654,7 +617,7 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -684,9 +647,9 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -719,7 +682,7 @@ pub struct InitializeCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializeCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -749,7 +712,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -757,25 +720,25 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -783,7 +746,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_open_orders(
         &mut self,
-        amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_open_orders = Some(amm_open_orders);
         self
@@ -791,7 +754,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn lp_mint_address(
         &mut self,
-        lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+        lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.lp_mint_address = Some(lp_mint_address);
         self
@@ -799,7 +762,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn coin_mint_address(
         &mut self,
-        coin_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+        coin_mint_address: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.coin_mint_address = Some(coin_mint_address);
         self
@@ -807,7 +770,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pc_mint_address(
         &mut self,
-        pc_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+        pc_mint_address: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pc_mint_address = Some(pc_mint_address);
         self
@@ -815,7 +778,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -823,7 +786,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -831,7 +794,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_withdraw_queue(
         &mut self,
-        pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_withdraw_queue = Some(pool_withdraw_queue);
         self
@@ -839,7 +802,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_target_orders_account(
         &mut self,
-        pool_target_orders_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_target_orders_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_target_orders_account = Some(pool_target_orders_account);
         self
@@ -847,7 +810,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_lp_token_account(
         &mut self,
-        user_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        user_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_lp_token_account = Some(user_lp_token_account);
         self
@@ -855,7 +818,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_temp_lp_token_account(
         &mut self,
-        pool_temp_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_temp_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_temp_lp_token_account = Some(pool_temp_lp_token_account);
         self
@@ -863,7 +826,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_program(
         &mut self,
-        serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_program = Some(serum_program);
         self
@@ -871,7 +834,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -879,7 +842,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_wallet(
         &mut self,
-        user_wallet: &'b solana_program::account_info::AccountInfo<'a>,
+        user_wallet: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_wallet = Some(user_wallet);
         self
@@ -898,7 +861,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -914,11 +877,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -926,7 +885,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -934,7 +893,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = InitializeInstructionArgs {
             nonce: self.instruction.nonce.clone().expect("nonce is not set"),
             open_time: self
@@ -1040,31 +999,27 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializeCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    lp_mint_address: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    coin_mint_address: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pc_mint_address: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_withdraw_queue: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_target_orders_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_lp_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_temp_lp_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_wallet: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    lp_mint_address: Option<&'b solana_account_info::AccountInfo<'a>>,
+    coin_mint_address: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pc_mint_address: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_withdraw_queue: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_target_orders_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_lp_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_temp_lp_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_wallet: Option<&'b solana_account_info::AccountInfo<'a>>,
     nonce: Option<u8>,
     open_time: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/initialize2.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/initialize2.rs
@@ -11,54 +11,51 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct Initialize2 {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub spl_associated_token_account: solana_program::pubkey::Pubkey,
+    pub spl_associated_token_account: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub amm_open_orders: solana_program::pubkey::Pubkey,
+    pub amm_open_orders: solana_pubkey::Pubkey,
 
-    pub lp_mint: solana_program::pubkey::Pubkey,
+    pub lp_mint: solana_pubkey::Pubkey,
 
-    pub coin_mint: solana_program::pubkey::Pubkey,
+    pub coin_mint: solana_pubkey::Pubkey,
 
-    pub pc_mint: solana_program::pubkey::Pubkey,
+    pub pc_mint: solana_pubkey::Pubkey,
 
-    pub pool_coin_token_account: solana_program::pubkey::Pubkey,
+    pub pool_coin_token_account: solana_pubkey::Pubkey,
 
-    pub pool_pc_token_account: solana_program::pubkey::Pubkey,
+    pub pool_pc_token_account: solana_pubkey::Pubkey,
 
-    pub pool_withdraw_queue: solana_program::pubkey::Pubkey,
+    pub pool_withdraw_queue: solana_pubkey::Pubkey,
 
-    pub amm_target_orders: solana_program::pubkey::Pubkey,
+    pub amm_target_orders: solana_pubkey::Pubkey,
 
-    pub pool_temp_lp: solana_program::pubkey::Pubkey,
+    pub pool_temp_lp: solana_pubkey::Pubkey,
 
-    pub serum_program: solana_program::pubkey::Pubkey,
+    pub serum_program: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub user_wallet: solana_program::pubkey::Pubkey,
+    pub user_wallet: solana_pubkey::Pubkey,
 
-    pub user_token_coin: solana_program::pubkey::Pubkey,
+    pub user_token_coin: solana_pubkey::Pubkey,
 
-    pub user_token_pc: solana_program::pubkey::Pubkey,
+    pub user_token_pc: solana_pubkey::Pubkey,
 
-    pub user_lp_token_account: solana_program::pubkey::Pubkey,
+    pub user_lp_token_account: solana_pubkey::Pubkey,
 }
 
 impl Initialize2 {
-    pub fn instruction(
-        &self,
-        args: Initialize2InstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: Initialize2InstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -66,88 +63,80 @@ impl Initialize2 {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: Initialize2InstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(21 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.spl_associated_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm, false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.amm, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.lp_mint,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.lp_mint, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.coin_mint,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.pc_mint,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_withdraw_queue,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_target_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_temp_lp,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.user_wallet,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.user_wallet, true));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.user_token_coin,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.user_token_pc,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.user_lp_token_account,
             false,
         ));
@@ -156,7 +145,7 @@ impl Initialize2 {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -218,32 +207,32 @@ pub struct Initialize2InstructionArgs {
 ///   20. `[writable]` user_lp_token_account
 #[derive(Clone, Debug, Default)]
 pub struct Initialize2Builder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    spl_associated_token_account: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    lp_mint: Option<solana_program::pubkey::Pubkey>,
-    coin_mint: Option<solana_program::pubkey::Pubkey>,
-    pc_mint: Option<solana_program::pubkey::Pubkey>,
-    pool_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_withdraw_queue: Option<solana_program::pubkey::Pubkey>,
-    amm_target_orders: Option<solana_program::pubkey::Pubkey>,
-    pool_temp_lp: Option<solana_program::pubkey::Pubkey>,
-    serum_program: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    user_wallet: Option<solana_program::pubkey::Pubkey>,
-    user_token_coin: Option<solana_program::pubkey::Pubkey>,
-    user_token_pc: Option<solana_program::pubkey::Pubkey>,
-    user_lp_token_account: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    spl_associated_token_account: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    amm_open_orders: Option<solana_pubkey::Pubkey>,
+    lp_mint: Option<solana_pubkey::Pubkey>,
+    coin_mint: Option<solana_pubkey::Pubkey>,
+    pc_mint: Option<solana_pubkey::Pubkey>,
+    pool_coin_token_account: Option<solana_pubkey::Pubkey>,
+    pool_pc_token_account: Option<solana_pubkey::Pubkey>,
+    pool_withdraw_queue: Option<solana_pubkey::Pubkey>,
+    amm_target_orders: Option<solana_pubkey::Pubkey>,
+    pool_temp_lp: Option<solana_pubkey::Pubkey>,
+    serum_program: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    user_wallet: Option<solana_pubkey::Pubkey>,
+    user_token_coin: Option<solana_pubkey::Pubkey>,
+    user_token_pc: Option<solana_pubkey::Pubkey>,
+    user_lp_token_account: Option<solana_pubkey::Pubkey>,
     nonce: Option<u8>,
     open_time: Option<u64>,
     init_pc_amount: Option<u64>,
     init_coin_amount: Option<u64>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl Initialize2Builder {
@@ -252,67 +241,64 @@ impl Initialize2Builder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
     pub fn spl_associated_token_account(
         &mut self,
-        spl_associated_token_account: solana_program::pubkey::Pubkey,
+        spl_associated_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.spl_associated_token_account = Some(spl_associated_token_account);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn amm_open_orders(
-        &mut self,
-        amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_open_orders(&mut self, amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
-    pub fn lp_mint(&mut self, lp_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn lp_mint(&mut self, lp_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.lp_mint = Some(lp_mint);
         self
     }
     #[inline(always)]
-    pub fn coin_mint(&mut self, coin_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn coin_mint(&mut self, coin_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.coin_mint = Some(coin_mint);
         self
     }
     #[inline(always)]
-    pub fn pc_mint(&mut self, pc_mint: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn pc_mint(&mut self, pc_mint: solana_pubkey::Pubkey) -> &mut Self {
         self.pc_mint = Some(pc_mint);
         self
     }
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: solana_program::pubkey::Pubkey,
+        pool_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -320,64 +306,55 @@ impl Initialize2Builder {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: solana_program::pubkey::Pubkey,
+        pool_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_pc_token_account = Some(pool_pc_token_account);
         self
     }
     #[inline(always)]
-    pub fn pool_withdraw_queue(
-        &mut self,
-        pool_withdraw_queue: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn pool_withdraw_queue(&mut self, pool_withdraw_queue: solana_pubkey::Pubkey) -> &mut Self {
         self.pool_withdraw_queue = Some(pool_withdraw_queue);
         self
     }
     #[inline(always)]
-    pub fn amm_target_orders(
-        &mut self,
-        amm_target_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_target_orders(&mut self, amm_target_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_target_orders = Some(amm_target_orders);
         self
     }
     #[inline(always)]
-    pub fn pool_temp_lp(&mut self, pool_temp_lp: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn pool_temp_lp(&mut self, pool_temp_lp: solana_pubkey::Pubkey) -> &mut Self {
         self.pool_temp_lp = Some(pool_temp_lp);
         self
     }
     #[inline(always)]
-    pub fn serum_program(&mut self, serum_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_program(&mut self, serum_program: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_program = Some(serum_program);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
-    pub fn user_wallet(&mut self, user_wallet: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn user_wallet(&mut self, user_wallet: solana_pubkey::Pubkey) -> &mut Self {
         self.user_wallet = Some(user_wallet);
         self
     }
     #[inline(always)]
-    pub fn user_token_coin(
-        &mut self,
-        user_token_coin: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn user_token_coin(&mut self, user_token_coin: solana_pubkey::Pubkey) -> &mut Self {
         self.user_token_coin = Some(user_token_coin);
         self
     }
     #[inline(always)]
-    pub fn user_token_pc(&mut self, user_token_pc: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn user_token_pc(&mut self, user_token_pc: solana_pubkey::Pubkey) -> &mut Self {
         self.user_token_pc = Some(user_token_pc);
         self
     }
     #[inline(always)]
     pub fn user_lp_token_account(
         &mut self,
-        user_lp_token_account: solana_program::pubkey::Pubkey,
+        user_lp_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.user_lp_token_account = Some(user_lp_token_account);
         self
@@ -404,10 +381,7 @@ impl Initialize2Builder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -415,15 +389,15 @@ impl Initialize2Builder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = Initialize2 {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             spl_associated_token_account: self
@@ -431,8 +405,8 @@ impl Initialize2Builder {
                 .expect("spl_associated_token_account is not set"),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
             amm: self.amm.expect("amm is not set"),
@@ -482,102 +456,102 @@ impl Initialize2Builder {
 
 /// `initialize2` CPI accounts.
 pub struct Initialize2CpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub spl_associated_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub spl_associated_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lp_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lp_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub coin_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub coin_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pc_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pc_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_temp_lp: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_temp_lp: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_wallet: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_wallet: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_token_coin: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_token_coin: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_token_pc: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_token_pc: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize2` CPI instruction.
 pub struct Initialize2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub spl_associated_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub spl_associated_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lp_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lp_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub coin_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub coin_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pc_mint: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pc_mint: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_temp_lp: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_temp_lp: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_wallet: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_wallet: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_token_coin: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_token_coin: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_token_pc: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_token_pc: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: Initialize2InstructionArgs,
 }
 
 impl<'a, 'b> Initialize2Cpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: Initialize2CpiAccounts<'a, 'b>,
         args: Initialize2InstructionArgs,
     ) -> Self {
@@ -608,25 +582,21 @@ impl<'a, 'b> Initialize2Cpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -635,99 +605,92 @@ impl<'a, 'b> Initialize2Cpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(21 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.spl_associated_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.amm.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.amm.key, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.lp_mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.coin_mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.pc_mint.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_withdraw_queue.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_target_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_temp_lp.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.user_wallet.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.user_token_coin.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.user_token_pc.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.user_lp_token_account.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -737,7 +700,7 @@ impl<'a, 'b> Initialize2Cpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -770,9 +733,9 @@ impl<'a, 'b> Initialize2Cpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -808,7 +771,7 @@ pub struct Initialize2CpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(Initialize2CpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -843,7 +806,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -851,7 +814,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn spl_associated_token_account(
         &mut self,
-        spl_associated_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        spl_associated_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_associated_token_account = Some(spl_associated_token_account);
         self
@@ -859,25 +822,25 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -885,39 +848,30 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_open_orders(
         &mut self,
-        amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
-    pub fn lp_mint(
-        &mut self,
-        lp_mint: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn lp_mint(&mut self, lp_mint: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.lp_mint = Some(lp_mint);
         self
     }
     #[inline(always)]
-    pub fn coin_mint(
-        &mut self,
-        coin_mint: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn coin_mint(&mut self, coin_mint: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.coin_mint = Some(coin_mint);
         self
     }
     #[inline(always)]
-    pub fn pc_mint(
-        &mut self,
-        pc_mint: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn pc_mint(&mut self, pc_mint: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.pc_mint = Some(pc_mint);
         self
     }
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -925,7 +879,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -933,7 +887,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_withdraw_queue(
         &mut self,
-        pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_withdraw_queue = Some(pool_withdraw_queue);
         self
@@ -941,7 +895,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_target_orders(
         &mut self,
-        amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_target_orders = Some(amm_target_orders);
         self
@@ -949,7 +903,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_temp_lp(
         &mut self,
-        pool_temp_lp: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_temp_lp: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_temp_lp = Some(pool_temp_lp);
         self
@@ -957,7 +911,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_program(
         &mut self,
-        serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_program = Some(serum_program);
         self
@@ -965,7 +919,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -973,7 +927,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_wallet(
         &mut self,
-        user_wallet: &'b solana_program::account_info::AccountInfo<'a>,
+        user_wallet: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_wallet = Some(user_wallet);
         self
@@ -981,7 +935,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_token_coin(
         &mut self,
-        user_token_coin: &'b solana_program::account_info::AccountInfo<'a>,
+        user_token_coin: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_token_coin = Some(user_token_coin);
         self
@@ -989,7 +943,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_token_pc(
         &mut self,
-        user_token_pc: &'b solana_program::account_info::AccountInfo<'a>,
+        user_token_pc: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_token_pc = Some(user_token_pc);
         self
@@ -997,7 +951,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_lp_token_account(
         &mut self,
-        user_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        user_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_lp_token_account = Some(user_lp_token_account);
         self
@@ -1026,7 +980,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -1042,11 +996,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -1054,7 +1004,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -1062,7 +1012,7 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = Initialize2InstructionArgs {
             nonce: self.instruction.nonce.clone().expect("nonce is not set"),
             open_time: self
@@ -1184,36 +1134,32 @@ impl<'a, 'b> Initialize2CpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct Initialize2CpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    spl_associated_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    lp_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    coin_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pc_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_withdraw_queue: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_target_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_temp_lp: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_wallet: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_token_coin: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_token_pc: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_lp_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    spl_associated_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    lp_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    coin_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pc_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_withdraw_queue: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_target_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_temp_lp: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_wallet: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_token_coin: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_token_pc: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_lp_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
     nonce: Option<u8>,
     open_time: Option<u64>,
     init_pc_amount: Option<u64>,
     init_coin_amount: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/migrate_to_open_book.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/migrate_to_open_book.rs
@@ -11,145 +11,135 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct MigrateToOpenBook {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub amm_open_orders: solana_program::pubkey::Pubkey,
+    pub amm_open_orders: solana_pubkey::Pubkey,
 
-    pub amm_token_coin: solana_program::pubkey::Pubkey,
+    pub amm_token_coin: solana_pubkey::Pubkey,
 
-    pub amm_token_pc: solana_program::pubkey::Pubkey,
+    pub amm_token_pc: solana_pubkey::Pubkey,
 
-    pub amm_target_orders: solana_program::pubkey::Pubkey,
+    pub amm_target_orders: solana_pubkey::Pubkey,
 
-    pub serum_program: solana_program::pubkey::Pubkey,
+    pub serum_program: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub serum_bids: solana_program::pubkey::Pubkey,
+    pub serum_bids: solana_pubkey::Pubkey,
 
-    pub serum_asks: solana_program::pubkey::Pubkey,
+    pub serum_asks: solana_pubkey::Pubkey,
 
-    pub serum_event_queue: solana_program::pubkey::Pubkey,
+    pub serum_event_queue: solana_pubkey::Pubkey,
 
-    pub serum_coin_vault: solana_program::pubkey::Pubkey,
+    pub serum_coin_vault: solana_pubkey::Pubkey,
 
-    pub serum_pc_vault: solana_program::pubkey::Pubkey,
+    pub serum_pc_vault: solana_pubkey::Pubkey,
 
-    pub serum_vault_signer: solana_program::pubkey::Pubkey,
+    pub serum_vault_signer: solana_pubkey::Pubkey,
 
-    pub new_amm_open_orders: solana_program::pubkey::Pubkey,
+    pub new_amm_open_orders: solana_pubkey::Pubkey,
 
-    pub new_serum_program: solana_program::pubkey::Pubkey,
+    pub new_serum_program: solana_pubkey::Pubkey,
 
-    pub new_serum_market: solana_program::pubkey::Pubkey,
+    pub new_serum_market: solana_pubkey::Pubkey,
 
-    pub admin: solana_program::pubkey::Pubkey,
+    pub admin: solana_pubkey::Pubkey,
 }
 
 impl MigrateToOpenBook {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(21 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm, false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.amm, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_token_coin,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_token_pc,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_target_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_bids,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_asks,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_bids, false));
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_asks, false));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_event_queue,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_coin_vault,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_pc_vault,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_vault_signer,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.new_amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.new_serum_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.new_serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.admin, true,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.admin, true));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&MigrateToOpenBookInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -202,28 +192,28 @@ impl Default for MigrateToOpenBookInstructionData {
 ///   20. `[writable, signer]` admin
 #[derive(Clone, Debug, Default)]
 pub struct MigrateToOpenBookBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    amm_token_coin: Option<solana_program::pubkey::Pubkey>,
-    amm_token_pc: Option<solana_program::pubkey::Pubkey>,
-    amm_target_orders: Option<solana_program::pubkey::Pubkey>,
-    serum_program: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    serum_bids: Option<solana_program::pubkey::Pubkey>,
-    serum_asks: Option<solana_program::pubkey::Pubkey>,
-    serum_event_queue: Option<solana_program::pubkey::Pubkey>,
-    serum_coin_vault: Option<solana_program::pubkey::Pubkey>,
-    serum_pc_vault: Option<solana_program::pubkey::Pubkey>,
-    serum_vault_signer: Option<solana_program::pubkey::Pubkey>,
-    new_amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    new_serum_program: Option<solana_program::pubkey::Pubkey>,
-    new_serum_market: Option<solana_program::pubkey::Pubkey>,
-    admin: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    amm_open_orders: Option<solana_pubkey::Pubkey>,
+    amm_token_coin: Option<solana_pubkey::Pubkey>,
+    amm_token_pc: Option<solana_pubkey::Pubkey>,
+    amm_target_orders: Option<solana_pubkey::Pubkey>,
+    serum_program: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    serum_bids: Option<solana_pubkey::Pubkey>,
+    serum_asks: Option<solana_pubkey::Pubkey>,
+    serum_event_queue: Option<solana_pubkey::Pubkey>,
+    serum_coin_vault: Option<solana_pubkey::Pubkey>,
+    serum_pc_vault: Option<solana_pubkey::Pubkey>,
+    serum_vault_signer: Option<solana_pubkey::Pubkey>,
+    new_amm_open_orders: Option<solana_pubkey::Pubkey>,
+    new_serum_program: Option<solana_pubkey::Pubkey>,
+    new_serum_market: Option<solana_pubkey::Pubkey>,
+    admin: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl MigrateToOpenBookBuilder {
@@ -232,142 +222,115 @@ impl MigrateToOpenBookBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn amm_open_orders(
-        &mut self,
-        amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_open_orders(&mut self, amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
-    pub fn amm_token_coin(&mut self, amm_token_coin: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_token_coin(&mut self, amm_token_coin: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_token_coin = Some(amm_token_coin);
         self
     }
     #[inline(always)]
-    pub fn amm_token_pc(&mut self, amm_token_pc: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_token_pc(&mut self, amm_token_pc: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_token_pc = Some(amm_token_pc);
         self
     }
     #[inline(always)]
-    pub fn amm_target_orders(
-        &mut self,
-        amm_target_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_target_orders(&mut self, amm_target_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_target_orders = Some(amm_target_orders);
         self
     }
     #[inline(always)]
-    pub fn serum_program(&mut self, serum_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_program(&mut self, serum_program: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_program = Some(serum_program);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
-    pub fn serum_bids(&mut self, serum_bids: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_bids(&mut self, serum_bids: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_bids = Some(serum_bids);
         self
     }
     #[inline(always)]
-    pub fn serum_asks(&mut self, serum_asks: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_asks(&mut self, serum_asks: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_asks = Some(serum_asks);
         self
     }
     #[inline(always)]
-    pub fn serum_event_queue(
-        &mut self,
-        serum_event_queue: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_event_queue(&mut self, serum_event_queue: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_event_queue = Some(serum_event_queue);
         self
     }
     #[inline(always)]
-    pub fn serum_coin_vault(
-        &mut self,
-        serum_coin_vault: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_coin_vault(&mut self, serum_coin_vault: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_coin_vault = Some(serum_coin_vault);
         self
     }
     #[inline(always)]
-    pub fn serum_pc_vault(&mut self, serum_pc_vault: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_pc_vault(&mut self, serum_pc_vault: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_pc_vault = Some(serum_pc_vault);
         self
     }
     #[inline(always)]
-    pub fn serum_vault_signer(
-        &mut self,
-        serum_vault_signer: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_vault_signer(&mut self, serum_vault_signer: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_vault_signer = Some(serum_vault_signer);
         self
     }
     #[inline(always)]
-    pub fn new_amm_open_orders(
-        &mut self,
-        new_amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn new_amm_open_orders(&mut self, new_amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.new_amm_open_orders = Some(new_amm_open_orders);
         self
     }
     #[inline(always)]
-    pub fn new_serum_program(
-        &mut self,
-        new_serum_program: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn new_serum_program(&mut self, new_serum_program: solana_pubkey::Pubkey) -> &mut Self {
         self.new_serum_program = Some(new_serum_program);
         self
     }
     #[inline(always)]
-    pub fn new_serum_market(
-        &mut self,
-        new_serum_market: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn new_serum_market(&mut self, new_serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.new_serum_market = Some(new_serum_market);
         self
     }
     #[inline(always)]
-    pub fn admin(&mut self, admin: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn admin(&mut self, admin: solana_pubkey::Pubkey) -> &mut Self {
         self.admin = Some(admin);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -375,21 +338,21 @@ impl MigrateToOpenBookBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = MigrateToOpenBook {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
             amm: self.amm.expect("amm is not set"),
@@ -428,100 +391,100 @@ impl MigrateToOpenBookBuilder {
 
 /// `migrate_to_open_book` CPI accounts.
 pub struct MigrateToOpenBookCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_token_coin: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_token_coin: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_token_pc: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_token_pc: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub admin: &'b solana_program::account_info::AccountInfo<'a>,
+    pub admin: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `migrate_to_open_book` CPI instruction.
 pub struct MigrateToOpenBookCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_token_coin: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_token_coin: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_token_pc: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_token_pc: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub admin: &'b solana_program::account_info::AccountInfo<'a>,
+    pub admin: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> MigrateToOpenBookCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: MigrateToOpenBookCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -550,25 +513,21 @@ impl<'a, 'b> MigrateToOpenBookCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -577,99 +536,89 @@ impl<'a, 'b> MigrateToOpenBookCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(21 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.amm.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.amm.key, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_token_coin.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_token_pc.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_target_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_bids.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_asks.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_event_queue.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_coin_vault.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_pc_vault.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_vault_signer.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.new_amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.new_serum_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.new_serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.admin.key,
-            true,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(*self.admin.key, true));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -677,7 +626,7 @@ impl<'a, 'b> MigrateToOpenBookCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&MigrateToOpenBookInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -710,9 +659,9 @@ impl<'a, 'b> MigrateToOpenBookCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -748,7 +697,7 @@ pub struct MigrateToOpenBookCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(MigrateToOpenBookCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -779,7 +728,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -787,25 +736,25 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -813,7 +762,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_open_orders(
         &mut self,
-        amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_open_orders = Some(amm_open_orders);
         self
@@ -821,7 +770,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_token_coin(
         &mut self,
-        amm_token_coin: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_token_coin: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_token_coin = Some(amm_token_coin);
         self
@@ -829,7 +778,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_token_pc(
         &mut self,
-        amm_token_pc: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_token_pc: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_token_pc = Some(amm_token_pc);
         self
@@ -837,7 +786,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_target_orders(
         &mut self,
-        amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_target_orders = Some(amm_target_orders);
         self
@@ -845,7 +794,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_program(
         &mut self,
-        serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_program = Some(serum_program);
         self
@@ -853,7 +802,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -861,7 +810,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_bids(
         &mut self,
-        serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_bids: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_bids = Some(serum_bids);
         self
@@ -869,7 +818,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_asks(
         &mut self,
-        serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_asks: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_asks = Some(serum_asks);
         self
@@ -877,7 +826,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_event_queue(
         &mut self,
-        serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_event_queue = Some(serum_event_queue);
         self
@@ -885,7 +834,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_coin_vault(
         &mut self,
-        serum_coin_vault: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_coin_vault: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_coin_vault = Some(serum_coin_vault);
         self
@@ -893,7 +842,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_pc_vault(
         &mut self,
-        serum_pc_vault: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_pc_vault: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_pc_vault = Some(serum_pc_vault);
         self
@@ -901,7 +850,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_vault_signer(
         &mut self,
-        serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_vault_signer = Some(serum_vault_signer);
         self
@@ -909,7 +858,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn new_amm_open_orders(
         &mut self,
-        new_amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        new_amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_amm_open_orders = Some(new_amm_open_orders);
         self
@@ -917,7 +866,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn new_serum_program(
         &mut self,
-        new_serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+        new_serum_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_serum_program = Some(new_serum_program);
         self
@@ -925,13 +874,13 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn new_serum_market(
         &mut self,
-        new_serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        new_serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_serum_market = Some(new_serum_market);
         self
     }
     #[inline(always)]
-    pub fn admin(&mut self, admin: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn admin(&mut self, admin: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.admin = Some(admin);
         self
     }
@@ -939,7 +888,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -955,11 +904,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -967,7 +912,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -975,7 +920,7 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = MigrateToOpenBookCpi {
             __program: self.instruction.__program,
 
@@ -1078,32 +1023,28 @@ impl<'a, 'b> MigrateToOpenBookCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct MigrateToOpenBookCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_token_coin: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_token_pc: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_target_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_bids: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_asks: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_event_queue: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_coin_vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_pc_vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_vault_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    new_amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    new_serum_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    new_serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    admin: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_token_coin: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_token_pc: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_target_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_bids: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_asks: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_event_queue: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_coin_vault: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_pc_vault: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_vault_signer: Option<&'b solana_account_info::AccountInfo<'a>>,
+    new_amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    new_serum_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    new_serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    admin: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/monitor_step.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/monitor_step.rs
@@ -11,50 +11,47 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct MonitorStep {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 
-    pub clock: solana_program::pubkey::Pubkey,
+    pub clock: solana_pubkey::Pubkey,
 
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub amm_open_orders: solana_program::pubkey::Pubkey,
+    pub amm_open_orders: solana_pubkey::Pubkey,
 
-    pub amm_target_orders: solana_program::pubkey::Pubkey,
+    pub amm_target_orders: solana_pubkey::Pubkey,
 
-    pub pool_coin_token_account: solana_program::pubkey::Pubkey,
+    pub pool_coin_token_account: solana_pubkey::Pubkey,
 
-    pub pool_pc_token_account: solana_program::pubkey::Pubkey,
+    pub pool_pc_token_account: solana_pubkey::Pubkey,
 
-    pub pool_withdraw_queue: solana_program::pubkey::Pubkey,
+    pub pool_withdraw_queue: solana_pubkey::Pubkey,
 
-    pub serum_program: solana_program::pubkey::Pubkey,
+    pub serum_program: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub serum_coin_vault_account: solana_program::pubkey::Pubkey,
+    pub serum_coin_vault_account: solana_pubkey::Pubkey,
 
-    pub serum_pc_vault_account: solana_program::pubkey::Pubkey,
+    pub serum_pc_vault_account: solana_pubkey::Pubkey,
 
-    pub serum_vault_signer: solana_program::pubkey::Pubkey,
+    pub serum_vault_signer: solana_pubkey::Pubkey,
 
-    pub serum_req_q: solana_program::pubkey::Pubkey,
+    pub serum_req_q: solana_pubkey::Pubkey,
 
-    pub serum_event_q: solana_program::pubkey::Pubkey,
+    pub serum_event_q: solana_pubkey::Pubkey,
 
-    pub serum_bids: solana_program::pubkey::Pubkey,
+    pub serum_bids: solana_pubkey::Pubkey,
 
-    pub serum_asks: solana_program::pubkey::Pubkey,
+    pub serum_asks: solana_pubkey::Pubkey,
 }
 
 impl MonitorStep {
-    pub fn instruction(
-        &self,
-        args: MonitorStepInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: MonitorStepInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -62,88 +59,80 @@ impl MonitorStep {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: MonitorStepInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(19 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.clock, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm, false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.amm, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_target_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_withdraw_queue,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_coin_vault_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_pc_vault_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_vault_signer,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_req_q,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_event_q,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_bids,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_asks,
-            false,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_bids, false));
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_asks, false));
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&MonitorStepInstructionData::new()).unwrap();
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -202,29 +191,29 @@ pub struct MonitorStepInstructionArgs {
 ///   18. `[writable]` serum_asks
 #[derive(Clone, Debug, Default)]
 pub struct MonitorStepBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
-    clock: Option<solana_program::pubkey::Pubkey>,
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    amm_target_orders: Option<solana_program::pubkey::Pubkey>,
-    pool_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_withdraw_queue: Option<solana_program::pubkey::Pubkey>,
-    serum_program: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    serum_coin_vault_account: Option<solana_program::pubkey::Pubkey>,
-    serum_pc_vault_account: Option<solana_program::pubkey::Pubkey>,
-    serum_vault_signer: Option<solana_program::pubkey::Pubkey>,
-    serum_req_q: Option<solana_program::pubkey::Pubkey>,
-    serum_event_q: Option<solana_program::pubkey::Pubkey>,
-    serum_bids: Option<solana_program::pubkey::Pubkey>,
-    serum_asks: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
+    clock: Option<solana_pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    amm_open_orders: Option<solana_pubkey::Pubkey>,
+    amm_target_orders: Option<solana_pubkey::Pubkey>,
+    pool_coin_token_account: Option<solana_pubkey::Pubkey>,
+    pool_pc_token_account: Option<solana_pubkey::Pubkey>,
+    pool_withdraw_queue: Option<solana_pubkey::Pubkey>,
+    serum_program: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    serum_coin_vault_account: Option<solana_pubkey::Pubkey>,
+    serum_pc_vault_account: Option<solana_pubkey::Pubkey>,
+    serum_vault_signer: Option<solana_pubkey::Pubkey>,
+    serum_req_q: Option<solana_pubkey::Pubkey>,
+    serum_event_q: Option<solana_pubkey::Pubkey>,
+    serum_bids: Option<solana_pubkey::Pubkey>,
+    serum_asks: Option<solana_pubkey::Pubkey>,
     plan_order_limit: Option<u16>,
     place_order_limit: Option<u16>,
     cancel_order_limit: Option<u16>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl MonitorStepBuilder {
@@ -233,51 +222,45 @@ impl MonitorStepBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
     #[inline(always)]
-    pub fn clock(&mut self, clock: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn clock(&mut self, clock: solana_pubkey::Pubkey) -> &mut Self {
         self.clock = Some(clock);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn amm_open_orders(
-        &mut self,
-        amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_open_orders(&mut self, amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
-    pub fn amm_target_orders(
-        &mut self,
-        amm_target_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_target_orders(&mut self, amm_target_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_target_orders = Some(amm_target_orders);
         self
     }
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: solana_program::pubkey::Pubkey,
+        pool_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -285,33 +268,30 @@ impl MonitorStepBuilder {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: solana_program::pubkey::Pubkey,
+        pool_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_pc_token_account = Some(pool_pc_token_account);
         self
     }
     #[inline(always)]
-    pub fn pool_withdraw_queue(
-        &mut self,
-        pool_withdraw_queue: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn pool_withdraw_queue(&mut self, pool_withdraw_queue: solana_pubkey::Pubkey) -> &mut Self {
         self.pool_withdraw_queue = Some(pool_withdraw_queue);
         self
     }
     #[inline(always)]
-    pub fn serum_program(&mut self, serum_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_program(&mut self, serum_program: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_program = Some(serum_program);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
     pub fn serum_coin_vault_account(
         &mut self,
-        serum_coin_vault_account: solana_program::pubkey::Pubkey,
+        serum_coin_vault_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.serum_coin_vault_account = Some(serum_coin_vault_account);
         self
@@ -319,36 +299,33 @@ impl MonitorStepBuilder {
     #[inline(always)]
     pub fn serum_pc_vault_account(
         &mut self,
-        serum_pc_vault_account: solana_program::pubkey::Pubkey,
+        serum_pc_vault_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.serum_pc_vault_account = Some(serum_pc_vault_account);
         self
     }
     #[inline(always)]
-    pub fn serum_vault_signer(
-        &mut self,
-        serum_vault_signer: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_vault_signer(&mut self, serum_vault_signer: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_vault_signer = Some(serum_vault_signer);
         self
     }
     #[inline(always)]
-    pub fn serum_req_q(&mut self, serum_req_q: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_req_q(&mut self, serum_req_q: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_req_q = Some(serum_req_q);
         self
     }
     #[inline(always)]
-    pub fn serum_event_q(&mut self, serum_event_q: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_event_q(&mut self, serum_event_q: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_event_q = Some(serum_event_q);
         self
     }
     #[inline(always)]
-    pub fn serum_bids(&mut self, serum_bids: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_bids(&mut self, serum_bids: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_bids = Some(serum_bids);
         self
     }
     #[inline(always)]
-    pub fn serum_asks(&mut self, serum_asks: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_asks(&mut self, serum_asks: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_asks = Some(serum_asks);
         self
     }
@@ -369,10 +346,7 @@ impl MonitorStepBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -380,18 +354,18 @@ impl MonitorStepBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = MonitorStep {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
             clock: self.clock.expect("clock is not set"),
@@ -447,94 +421,94 @@ impl MonitorStepBuilder {
 
 /// `monitor_step` CPI accounts.
 pub struct MonitorStepCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub clock: &'b solana_program::account_info::AccountInfo<'a>,
+    pub clock: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_req_q: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_req_q: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_q: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_q: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `monitor_step` CPI instruction.
 pub struct MonitorStepCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub clock: &'b solana_program::account_info::AccountInfo<'a>,
+    pub clock: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_req_q: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_req_q: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_q: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_q: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: MonitorStepInstructionArgs,
 }
 
 impl<'a, 'b> MonitorStepCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: MonitorStepCpiAccounts<'a, 'b>,
         args: MonitorStepInstructionArgs,
     ) -> Self {
@@ -563,25 +537,21 @@ impl<'a, 'b> MonitorStepCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -590,91 +560,84 @@ impl<'a, 'b> MonitorStepCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(19 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.clock.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.amm.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.amm.key, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_target_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_withdraw_queue.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_coin_vault_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_pc_vault_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_vault_signer.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_req_q.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_event_q.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_bids.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_asks.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -684,7 +647,7 @@ impl<'a, 'b> MonitorStepCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -715,9 +678,9 @@ impl<'a, 'b> MonitorStepCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -751,7 +714,7 @@ pub struct MonitorStepCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(MonitorStepCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -783,30 +746,30 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
     #[inline(always)]
-    pub fn clock(&mut self, clock: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn clock(&mut self, clock: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.clock = Some(clock);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -814,7 +777,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_open_orders(
         &mut self,
-        amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_open_orders = Some(amm_open_orders);
         self
@@ -822,7 +785,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_target_orders(
         &mut self,
-        amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_target_orders = Some(amm_target_orders);
         self
@@ -830,7 +793,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -838,7 +801,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -846,7 +809,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_withdraw_queue(
         &mut self,
-        pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_withdraw_queue = Some(pool_withdraw_queue);
         self
@@ -854,7 +817,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_program(
         &mut self,
-        serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_program = Some(serum_program);
         self
@@ -862,7 +825,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -870,7 +833,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_coin_vault_account(
         &mut self,
-        serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_coin_vault_account = Some(serum_coin_vault_account);
         self
@@ -878,7 +841,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_pc_vault_account(
         &mut self,
-        serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_pc_vault_account = Some(serum_pc_vault_account);
         self
@@ -886,7 +849,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_vault_signer(
         &mut self,
-        serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_vault_signer = Some(serum_vault_signer);
         self
@@ -894,7 +857,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_req_q(
         &mut self,
-        serum_req_q: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_req_q: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_req_q = Some(serum_req_q);
         self
@@ -902,7 +865,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_event_q(
         &mut self,
-        serum_event_q: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_event_q: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_event_q = Some(serum_event_q);
         self
@@ -910,7 +873,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_bids(
         &mut self,
-        serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_bids: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_bids = Some(serum_bids);
         self
@@ -918,7 +881,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_asks(
         &mut self,
-        serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_asks: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_asks = Some(serum_asks);
         self
@@ -942,7 +905,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -958,11 +921,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -970,7 +929,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -978,7 +937,7 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = MonitorStepInstructionArgs {
             plan_order_limit: self
                 .instruction
@@ -1089,33 +1048,29 @@ impl<'a, 'b> MonitorStepCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct MonitorStepCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    clock: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_target_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_withdraw_queue: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_coin_vault_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_pc_vault_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_vault_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_req_q: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_event_q: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_bids: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_asks: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
+    clock: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_target_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_withdraw_queue: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_coin_vault_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_pc_vault_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_vault_signer: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_req_q: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_event_q: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_bids: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_asks: Option<&'b solana_account_info::AccountInfo<'a>>,
     plan_order_limit: Option<u16>,
     place_order_limit: Option<u16>,
     cancel_order_limit: Option<u16>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/pre_initialize.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/pre_initialize.rs
@@ -11,40 +11,40 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct PreInitialize {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub system_program: solana_program::pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
 
-    pub rent: solana_program::pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
 
-    pub amm_target_orders: solana_program::pubkey::Pubkey,
+    pub amm_target_orders: solana_pubkey::Pubkey,
 
-    pub pool_withdraw_queue: solana_program::pubkey::Pubkey,
+    pub pool_withdraw_queue: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub lp_mint_address: solana_program::pubkey::Pubkey,
+    pub lp_mint_address: solana_pubkey::Pubkey,
 
-    pub coin_mint_address: solana_program::pubkey::Pubkey,
+    pub coin_mint_address: solana_pubkey::Pubkey,
 
-    pub pc_mint_address: solana_program::pubkey::Pubkey,
+    pub pc_mint_address: solana_pubkey::Pubkey,
 
-    pub pool_coin_token_account: solana_program::pubkey::Pubkey,
+    pub pool_coin_token_account: solana_pubkey::Pubkey,
 
-    pub pool_pc_token_account: solana_program::pubkey::Pubkey,
+    pub pool_pc_token_account: solana_pubkey::Pubkey,
 
-    pub pool_temp_lp_token_account: solana_program::pubkey::Pubkey,
+    pub pool_temp_lp_token_account: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub user_wallet: solana_program::pubkey::Pubkey,
+    pub user_wallet: solana_pubkey::Pubkey,
 }
 
 impl PreInitialize {
     pub fn instruction(
         &self,
         args: PreInitializeInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -52,70 +52,67 @@ impl PreInitialize {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: PreInitializeInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_target_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_withdraw_queue,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.lp_mint_address,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.coin_mint_address,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.pc_mint_address,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_temp_lp_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.user_wallet,
-            true,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.user_wallet, true));
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&PreInitializeInstructionData::new()).unwrap();
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -169,22 +166,22 @@ pub struct PreInitializeInstructionArgs {
 ///   13. `[writable, signer]` user_wallet
 #[derive(Clone, Debug, Default)]
 pub struct PreInitializeBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    rent: Option<solana_program::pubkey::Pubkey>,
-    amm_target_orders: Option<solana_program::pubkey::Pubkey>,
-    pool_withdraw_queue: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    lp_mint_address: Option<solana_program::pubkey::Pubkey>,
-    coin_mint_address: Option<solana_program::pubkey::Pubkey>,
-    pc_mint_address: Option<solana_program::pubkey::Pubkey>,
-    pool_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_temp_lp_token_account: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    user_wallet: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    system_program: Option<solana_pubkey::Pubkey>,
+    rent: Option<solana_pubkey::Pubkey>,
+    amm_target_orders: Option<solana_pubkey::Pubkey>,
+    pool_withdraw_queue: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    lp_mint_address: Option<solana_pubkey::Pubkey>,
+    coin_mint_address: Option<solana_pubkey::Pubkey>,
+    pc_mint_address: Option<solana_pubkey::Pubkey>,
+    pool_coin_token_account: Option<solana_pubkey::Pubkey>,
+    pool_pc_token_account: Option<solana_pubkey::Pubkey>,
+    pool_temp_lp_token_account: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    user_wallet: Option<solana_pubkey::Pubkey>,
     nonce: Option<u8>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl PreInitializeBuilder {
@@ -193,71 +190,56 @@ impl PreInitializeBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn system_program(&mut self, system_program: solana_pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent(&mut self, rent: solana_pubkey::Pubkey) -> &mut Self {
         self.rent = Some(rent);
         self
     }
     #[inline(always)]
-    pub fn amm_target_orders(
-        &mut self,
-        amm_target_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_target_orders(&mut self, amm_target_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_target_orders = Some(amm_target_orders);
         self
     }
     #[inline(always)]
-    pub fn pool_withdraw_queue(
-        &mut self,
-        pool_withdraw_queue: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn pool_withdraw_queue(&mut self, pool_withdraw_queue: solana_pubkey::Pubkey) -> &mut Self {
         self.pool_withdraw_queue = Some(pool_withdraw_queue);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn lp_mint_address(
-        &mut self,
-        lp_mint_address: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn lp_mint_address(&mut self, lp_mint_address: solana_pubkey::Pubkey) -> &mut Self {
         self.lp_mint_address = Some(lp_mint_address);
         self
     }
     #[inline(always)]
-    pub fn coin_mint_address(
-        &mut self,
-        coin_mint_address: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn coin_mint_address(&mut self, coin_mint_address: solana_pubkey::Pubkey) -> &mut Self {
         self.coin_mint_address = Some(coin_mint_address);
         self
     }
     #[inline(always)]
-    pub fn pc_mint_address(
-        &mut self,
-        pc_mint_address: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn pc_mint_address(&mut self, pc_mint_address: solana_pubkey::Pubkey) -> &mut Self {
         self.pc_mint_address = Some(pc_mint_address);
         self
     }
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: solana_program::pubkey::Pubkey,
+        pool_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -265,7 +247,7 @@ impl PreInitializeBuilder {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: solana_program::pubkey::Pubkey,
+        pool_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -273,18 +255,18 @@ impl PreInitializeBuilder {
     #[inline(always)]
     pub fn pool_temp_lp_token_account(
         &mut self,
-        pool_temp_lp_token_account: solana_program::pubkey::Pubkey,
+        pool_temp_lp_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_temp_lp_token_account = Some(pool_temp_lp_token_account);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
-    pub fn user_wallet(&mut self, user_wallet: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn user_wallet(&mut self, user_wallet: solana_pubkey::Pubkey) -> &mut Self {
         self.user_wallet = Some(user_wallet);
         self
     }
@@ -295,10 +277,7 @@ impl PreInitializeBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -306,21 +285,21 @@ impl PreInitializeBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = PreInitialize {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             system_program: self
                 .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
-            rent: self.rent.unwrap_or(solana_program::pubkey!(
+                .unwrap_or(solana_pubkey::pubkey!("11111111111111111111111111111111")),
+            rent: self.rent.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
             amm_target_orders: self
@@ -357,74 +336,74 @@ impl PreInitializeBuilder {
 
 /// `pre_initialize` CPI accounts.
 pub struct PreInitializeCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub coin_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub coin_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pc_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pc_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_temp_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_temp_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_wallet: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_wallet: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `pre_initialize` CPI instruction.
 pub struct PreInitializeCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub coin_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub coin_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pc_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pc_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_temp_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_temp_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_wallet: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_wallet: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: PreInitializeInstructionArgs,
 }
 
 impl<'a, 'b> PreInitializeCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: PreInitializeCpiAccounts<'a, 'b>,
         args: PreInitializeInstructionArgs,
     ) -> Self {
@@ -448,25 +427,21 @@ impl<'a, 'b> PreInitializeCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -475,71 +450,67 @@ impl<'a, 'b> PreInitializeCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_target_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_withdraw_queue.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.lp_mint_address.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.coin_mint_address.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.pc_mint_address.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_temp_lp_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.user_wallet.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -549,7 +520,7 @@ impl<'a, 'b> PreInitializeCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -575,9 +546,9 @@ impl<'a, 'b> PreInitializeCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -606,7 +577,7 @@ pub struct PreInitializeCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(PreInitializeCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -631,7 +602,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -639,20 +610,20 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
     #[inline(always)]
     pub fn amm_target_orders(
         &mut self,
-        amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_target_orders = Some(amm_target_orders);
         self
@@ -660,7 +631,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_withdraw_queue(
         &mut self,
-        pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_withdraw_queue = Some(pool_withdraw_queue);
         self
@@ -668,7 +639,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -676,7 +647,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn lp_mint_address(
         &mut self,
-        lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+        lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.lp_mint_address = Some(lp_mint_address);
         self
@@ -684,7 +655,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn coin_mint_address(
         &mut self,
-        coin_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+        coin_mint_address: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.coin_mint_address = Some(coin_mint_address);
         self
@@ -692,7 +663,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pc_mint_address(
         &mut self,
-        pc_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+        pc_mint_address: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pc_mint_address = Some(pc_mint_address);
         self
@@ -700,7 +671,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -708,7 +679,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -716,7 +687,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_temp_lp_token_account(
         &mut self,
-        pool_temp_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_temp_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_temp_lp_token_account = Some(pool_temp_lp_token_account);
         self
@@ -724,7 +695,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -732,7 +703,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_wallet(
         &mut self,
-        user_wallet: &'b solana_program::account_info::AccountInfo<'a>,
+        user_wallet: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_wallet = Some(user_wallet);
         self
@@ -746,7 +717,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -762,11 +733,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -774,7 +741,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -782,7 +749,7 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = PreInitializeInstructionArgs {
             nonce: self.instruction.nonce.clone().expect("nonce is not set"),
         };
@@ -866,26 +833,22 @@ impl<'a, 'b> PreInitializeCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct PreInitializeCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_target_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_withdraw_queue: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    lp_mint_address: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    coin_mint_address: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pc_mint_address: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_temp_lp_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_wallet: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_target_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_withdraw_queue: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    lp_mint_address: Option<&'b solana_account_info::AccountInfo<'a>>,
+    coin_mint_address: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pc_mint_address: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_temp_lp_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_wallet: Option<&'b solana_account_info::AccountInfo<'a>>,
     nonce: Option<u8>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/set_params.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/set_params.rs
@@ -10,49 +10,46 @@ use crate::generated::types::LastOrderDistance;
 use crate::generated::types::NeedTake;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 /// Accounts.
 #[derive(Debug)]
 pub struct SetParams {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub amm_open_orders: solana_program::pubkey::Pubkey,
+    pub amm_open_orders: solana_pubkey::Pubkey,
 
-    pub amm_target_orders: solana_program::pubkey::Pubkey,
+    pub amm_target_orders: solana_pubkey::Pubkey,
 
-    pub amm_coin_vault: solana_program::pubkey::Pubkey,
+    pub amm_coin_vault: solana_pubkey::Pubkey,
 
-    pub amm_pc_vault: solana_program::pubkey::Pubkey,
+    pub amm_pc_vault: solana_pubkey::Pubkey,
 
-    pub serum_program: solana_program::pubkey::Pubkey,
+    pub serum_program: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub serum_coin_vault: solana_program::pubkey::Pubkey,
+    pub serum_coin_vault: solana_pubkey::Pubkey,
 
-    pub serum_pc_vault: solana_program::pubkey::Pubkey,
+    pub serum_pc_vault: solana_pubkey::Pubkey,
 
-    pub serum_vault_signer: solana_program::pubkey::Pubkey,
+    pub serum_vault_signer: solana_pubkey::Pubkey,
 
-    pub serum_event_queue: solana_program::pubkey::Pubkey,
+    pub serum_event_queue: solana_pubkey::Pubkey,
 
-    pub serum_bids: solana_program::pubkey::Pubkey,
+    pub serum_bids: solana_pubkey::Pubkey,
 
-    pub serum_asks: solana_program::pubkey::Pubkey,
+    pub serum_asks: solana_pubkey::Pubkey,
 
-    pub amm_admin_account: solana_program::pubkey::Pubkey,
+    pub amm_admin_account: solana_pubkey::Pubkey,
 }
 
 impl SetParams {
-    pub fn instruction(
-        &self,
-        args: SetParamsInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: SetParamsInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -60,69 +57,61 @@ impl SetParams {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SetParamsInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(16 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm, false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.amm, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_target_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_coin_vault,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_pc_vault,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_coin_vault,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_pc_vault,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_vault_signer,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_event_queue,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_bids,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_asks,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_bids, false));
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_asks, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_admin_account,
             true,
         ));
@@ -131,7 +120,7 @@ impl SetParams {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -190,29 +179,29 @@ pub struct SetParamsInstructionArgs {
 ///   15. `[signer]` amm_admin_account
 #[derive(Clone, Debug, Default)]
 pub struct SetParamsBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    amm_target_orders: Option<solana_program::pubkey::Pubkey>,
-    amm_coin_vault: Option<solana_program::pubkey::Pubkey>,
-    amm_pc_vault: Option<solana_program::pubkey::Pubkey>,
-    serum_program: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    serum_coin_vault: Option<solana_program::pubkey::Pubkey>,
-    serum_pc_vault: Option<solana_program::pubkey::Pubkey>,
-    serum_vault_signer: Option<solana_program::pubkey::Pubkey>,
-    serum_event_queue: Option<solana_program::pubkey::Pubkey>,
-    serum_bids: Option<solana_program::pubkey::Pubkey>,
-    serum_asks: Option<solana_program::pubkey::Pubkey>,
-    amm_admin_account: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    amm_open_orders: Option<solana_pubkey::Pubkey>,
+    amm_target_orders: Option<solana_pubkey::Pubkey>,
+    amm_coin_vault: Option<solana_pubkey::Pubkey>,
+    amm_pc_vault: Option<solana_pubkey::Pubkey>,
+    serum_program: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    serum_coin_vault: Option<solana_pubkey::Pubkey>,
+    serum_pc_vault: Option<solana_pubkey::Pubkey>,
+    serum_vault_signer: Option<solana_pubkey::Pubkey>,
+    serum_event_queue: Option<solana_pubkey::Pubkey>,
+    serum_bids: Option<solana_pubkey::Pubkey>,
+    serum_asks: Option<solana_pubkey::Pubkey>,
+    amm_admin_account: Option<solana_pubkey::Pubkey>,
     param: Option<u8>,
     value: Option<u64>,
     new_pubkey: Option<Pubkey>,
     fees: Option<Fees>,
     last_order_distance: Option<LastOrderDistance>,
     need_take_amounts: Option<NeedTake>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SetParamsBuilder {
@@ -221,100 +210,82 @@ impl SetParamsBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn amm_open_orders(
-        &mut self,
-        amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_open_orders(&mut self, amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
-    pub fn amm_target_orders(
-        &mut self,
-        amm_target_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_target_orders(&mut self, amm_target_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_target_orders = Some(amm_target_orders);
         self
     }
     #[inline(always)]
-    pub fn amm_coin_vault(&mut self, amm_coin_vault: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_coin_vault(&mut self, amm_coin_vault: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_coin_vault = Some(amm_coin_vault);
         self
     }
     #[inline(always)]
-    pub fn amm_pc_vault(&mut self, amm_pc_vault: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_pc_vault(&mut self, amm_pc_vault: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_pc_vault = Some(amm_pc_vault);
         self
     }
     #[inline(always)]
-    pub fn serum_program(&mut self, serum_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_program(&mut self, serum_program: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_program = Some(serum_program);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
-    pub fn serum_coin_vault(
-        &mut self,
-        serum_coin_vault: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_coin_vault(&mut self, serum_coin_vault: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_coin_vault = Some(serum_coin_vault);
         self
     }
     #[inline(always)]
-    pub fn serum_pc_vault(&mut self, serum_pc_vault: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_pc_vault(&mut self, serum_pc_vault: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_pc_vault = Some(serum_pc_vault);
         self
     }
     #[inline(always)]
-    pub fn serum_vault_signer(
-        &mut self,
-        serum_vault_signer: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_vault_signer(&mut self, serum_vault_signer: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_vault_signer = Some(serum_vault_signer);
         self
     }
     #[inline(always)]
-    pub fn serum_event_queue(
-        &mut self,
-        serum_event_queue: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_event_queue(&mut self, serum_event_queue: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_event_queue = Some(serum_event_queue);
         self
     }
     #[inline(always)]
-    pub fn serum_bids(&mut self, serum_bids: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_bids(&mut self, serum_bids: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_bids = Some(serum_bids);
         self
     }
     #[inline(always)]
-    pub fn serum_asks(&mut self, serum_asks: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_asks(&mut self, serum_asks: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_asks = Some(serum_asks);
         self
     }
     #[inline(always)]
-    pub fn amm_admin_account(
-        &mut self,
-        amm_admin_account: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_admin_account(&mut self, amm_admin_account: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_admin_account = Some(amm_admin_account);
         self
     }
@@ -355,10 +326,7 @@ impl SetParamsBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -366,15 +334,15 @@ impl SetParamsBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SetParams {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             amm: self.amm.expect("amm is not set"),
@@ -416,82 +384,82 @@ impl SetParamsBuilder {
 
 /// `set_params` CPI accounts.
 pub struct SetParamsCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_coin_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_coin_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_pc_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_pc_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_admin_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_admin_account: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `set_params` CPI instruction.
 pub struct SetParamsCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_coin_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_coin_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_pc_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_pc_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_admin_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_admin_account: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SetParamsInstructionArgs,
 }
 
 impl<'a, 'b> SetParamsCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SetParamsCpiAccounts<'a, 'b>,
         args: SetParamsInstructionArgs,
     ) -> Self {
@@ -517,25 +485,21 @@ impl<'a, 'b> SetParamsCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -544,79 +508,72 @@ impl<'a, 'b> SetParamsCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(16 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.amm.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.amm.key, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_target_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_coin_vault.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_pc_vault.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_coin_vault.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_pc_vault.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_vault_signer.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_event_queue.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_bids.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_asks.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_admin_account.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -626,7 +583,7 @@ impl<'a, 'b> SetParamsCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -654,9 +611,9 @@ impl<'a, 'b> SetParamsCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -687,7 +644,7 @@ pub struct SetParamsCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetParamsCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -719,20 +676,20 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -740,7 +697,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_open_orders(
         &mut self,
-        amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_open_orders = Some(amm_open_orders);
         self
@@ -748,7 +705,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_target_orders(
         &mut self,
-        amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_target_orders = Some(amm_target_orders);
         self
@@ -756,7 +713,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_coin_vault(
         &mut self,
-        amm_coin_vault: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_coin_vault: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_coin_vault = Some(amm_coin_vault);
         self
@@ -764,7 +721,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_pc_vault(
         &mut self,
-        amm_pc_vault: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_pc_vault: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_pc_vault = Some(amm_pc_vault);
         self
@@ -772,7 +729,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_program(
         &mut self,
-        serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_program = Some(serum_program);
         self
@@ -780,7 +737,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -788,7 +745,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_coin_vault(
         &mut self,
-        serum_coin_vault: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_coin_vault: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_coin_vault = Some(serum_coin_vault);
         self
@@ -796,7 +753,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_pc_vault(
         &mut self,
-        serum_pc_vault: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_pc_vault: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_pc_vault = Some(serum_pc_vault);
         self
@@ -804,7 +761,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_vault_signer(
         &mut self,
-        serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_vault_signer = Some(serum_vault_signer);
         self
@@ -812,7 +769,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_event_queue(
         &mut self,
-        serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_event_queue = Some(serum_event_queue);
         self
@@ -820,7 +777,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_bids(
         &mut self,
-        serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_bids: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_bids = Some(serum_bids);
         self
@@ -828,7 +785,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_asks(
         &mut self,
-        serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_asks: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_asks = Some(serum_asks);
         self
@@ -836,7 +793,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_admin_account(
         &mut self,
-        amm_admin_account: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_admin_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_admin_account = Some(amm_admin_account);
         self
@@ -880,7 +837,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -896,11 +853,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -908,7 +861,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -916,7 +869,7 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SetParamsInstructionArgs {
             param: self.instruction.param.clone().expect("param is not set"),
             value: self.instruction.value.clone(),
@@ -1009,23 +962,23 @@ impl<'a, 'b> SetParamsCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SetParamsCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_target_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_coin_vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_pc_vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_coin_vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_pc_vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_vault_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_event_queue: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_bids: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_asks: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_admin_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_target_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_coin_vault: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_pc_vault: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_coin_vault: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_pc_vault: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_vault_signer: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_event_queue: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_bids: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_asks: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_admin_account: Option<&'b solana_account_info::AccountInfo<'a>>,
     param: Option<u8>,
     value: Option<u64>,
     new_pubkey: Option<Pubkey>,
@@ -1033,9 +986,5 @@ struct SetParamsCpiBuilderInstruction<'a, 'b> {
     last_order_distance: Option<LastOrderDistance>,
     need_take_amounts: Option<NeedTake>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/simulate_info.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/simulate_info.rs
@@ -13,28 +13,28 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SimulateInfo {
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub amm_open_orders: solana_program::pubkey::Pubkey,
+    pub amm_open_orders: solana_pubkey::Pubkey,
 
-    pub pool_coin_token_account: solana_program::pubkey::Pubkey,
+    pub pool_coin_token_account: solana_pubkey::Pubkey,
 
-    pub pool_pc_token_account: solana_program::pubkey::Pubkey,
+    pub pool_pc_token_account: solana_pubkey::Pubkey,
 
-    pub lp_mint_address: solana_program::pubkey::Pubkey,
+    pub lp_mint_address: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub serum_event_queue: solana_program::pubkey::Pubkey,
+    pub serum_event_queue: solana_pubkey::Pubkey,
 }
 
 impl SimulateInfo {
     pub fn instruction(
         &self,
         args: SimulateInfoInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -42,37 +42,37 @@ impl SimulateInfo {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SimulateInfoInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.pool_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.pool_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.lp_mint_address,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_event_queue,
             false,
         ));
@@ -81,7 +81,7 @@ impl SimulateInfo {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -131,18 +131,18 @@ pub struct SimulateInfoInstructionArgs {
 ///   7. `[]` serum_event_queue
 #[derive(Clone, Debug, Default)]
 pub struct SimulateInfoBuilder {
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    pool_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    lp_mint_address: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    serum_event_queue: Option<solana_program::pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    amm_open_orders: Option<solana_pubkey::Pubkey>,
+    pool_coin_token_account: Option<solana_pubkey::Pubkey>,
+    pool_pc_token_account: Option<solana_pubkey::Pubkey>,
+    lp_mint_address: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    serum_event_queue: Option<solana_pubkey::Pubkey>,
     param: Option<u8>,
     swap_base_in_value: Option<SwapInstructionBaseIn>,
     swap_base_out_value: Option<SwapInstructionBaseOut>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SimulateInfoBuilder {
@@ -150,27 +150,24 @@ impl SimulateInfoBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn amm_open_orders(
-        &mut self,
-        amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_open_orders(&mut self, amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: solana_program::pubkey::Pubkey,
+        pool_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -178,29 +175,23 @@ impl SimulateInfoBuilder {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: solana_program::pubkey::Pubkey,
+        pool_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_pc_token_account = Some(pool_pc_token_account);
         self
     }
     #[inline(always)]
-    pub fn lp_mint_address(
-        &mut self,
-        lp_mint_address: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn lp_mint_address(&mut self, lp_mint_address: solana_pubkey::Pubkey) -> &mut Self {
         self.lp_mint_address = Some(lp_mint_address);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
-    pub fn serum_event_queue(
-        &mut self,
-        serum_event_queue: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_event_queue(&mut self, serum_event_queue: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_event_queue = Some(serum_event_queue);
         self
     }
@@ -226,10 +217,7 @@ impl SimulateInfoBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -237,13 +225,13 @@ impl SimulateInfoBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SimulateInfo {
             amm: self.amm.expect("amm is not set"),
             amm_authority: self.amm_authority.expect("amm_authority is not set"),
@@ -272,50 +260,50 @@ impl SimulateInfoBuilder {
 
 /// `simulate_info` CPI accounts.
 pub struct SimulateInfoCpiAccounts<'a, 'b> {
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `simulate_info` CPI instruction.
 pub struct SimulateInfoCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SimulateInfoInstructionArgs,
 }
 
 impl<'a, 'b> SimulateInfoCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SimulateInfoCpiAccounts<'a, 'b>,
         args: SimulateInfoInstructionArgs,
     ) -> Self {
@@ -333,25 +321,21 @@ impl<'a, 'b> SimulateInfoCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -360,47 +344,43 @@ impl<'a, 'b> SimulateInfoCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.pool_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.pool_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.lp_mint_address.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_event_queue.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -410,7 +390,7 @@ impl<'a, 'b> SimulateInfoCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -430,9 +410,9 @@ impl<'a, 'b> SimulateInfoCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -455,7 +435,7 @@ pub struct SimulateInfoCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SimulateInfoCpiBuilderInstruction {
             __program: program,
             amm: None,
@@ -474,14 +454,14 @@ impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -489,7 +469,7 @@ impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_open_orders(
         &mut self,
-        amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_open_orders = Some(amm_open_orders);
         self
@@ -497,7 +477,7 @@ impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -505,7 +485,7 @@ impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -513,7 +493,7 @@ impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn lp_mint_address(
         &mut self,
-        lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+        lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.lp_mint_address = Some(lp_mint_address);
         self
@@ -521,7 +501,7 @@ impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -529,7 +509,7 @@ impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_event_queue(
         &mut self,
-        serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_event_queue = Some(serum_event_queue);
         self
@@ -558,7 +538,7 @@ impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -574,11 +554,7 @@ impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -586,7 +562,7 @@ impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -594,7 +570,7 @@ impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SimulateInfoInstructionArgs {
             param: self.instruction.param.clone().expect("param is not set"),
             swap_base_in_value: self.instruction.swap_base_in_value.clone(),
@@ -650,22 +626,18 @@ impl<'a, 'b> SimulateInfoCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SimulateInfoCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    lp_mint_address: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_event_queue: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    lp_mint_address: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_event_queue: Option<&'b solana_account_info::AccountInfo<'a>>,
     param: Option<u8>,
     swap_base_in_value: Option<SwapInstructionBaseIn>,
     swap_base_out_value: Option<SwapInstructionBaseOut>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/swap_base_in.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/swap_base_in.rs
@@ -11,48 +11,45 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SwapBaseIn {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub amm_open_orders: solana_program::pubkey::Pubkey,
+    pub amm_open_orders: solana_pubkey::Pubkey,
 
-    pub amm_target_orders: solana_program::pubkey::Pubkey,
+    pub amm_target_orders: solana_pubkey::Pubkey,
 
-    pub pool_coin_token_account: solana_program::pubkey::Pubkey,
+    pub pool_coin_token_account: solana_pubkey::Pubkey,
 
-    pub pool_pc_token_account: solana_program::pubkey::Pubkey,
+    pub pool_pc_token_account: solana_pubkey::Pubkey,
 
-    pub serum_program: solana_program::pubkey::Pubkey,
+    pub serum_program: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub serum_bids: solana_program::pubkey::Pubkey,
+    pub serum_bids: solana_pubkey::Pubkey,
 
-    pub serum_asks: solana_program::pubkey::Pubkey,
+    pub serum_asks: solana_pubkey::Pubkey,
 
-    pub serum_event_queue: solana_program::pubkey::Pubkey,
+    pub serum_event_queue: solana_pubkey::Pubkey,
 
-    pub serum_coin_vault_account: solana_program::pubkey::Pubkey,
+    pub serum_coin_vault_account: solana_pubkey::Pubkey,
 
-    pub serum_pc_vault_account: solana_program::pubkey::Pubkey,
+    pub serum_pc_vault_account: solana_pubkey::Pubkey,
 
-    pub serum_vault_signer: solana_program::pubkey::Pubkey,
+    pub serum_vault_signer: solana_pubkey::Pubkey,
 
-    pub uer_source_token_account: solana_program::pubkey::Pubkey,
+    pub uer_source_token_account: solana_pubkey::Pubkey,
 
-    pub uer_destination_token_account: solana_program::pubkey::Pubkey,
+    pub uer_destination_token_account: solana_pubkey::Pubkey,
 
-    pub user_source_owner: solana_program::pubkey::Pubkey,
+    pub user_source_owner: solana_pubkey::Pubkey,
 }
 
 impl SwapBaseIn {
-    pub fn instruction(
-        &self,
-        args: SwapBaseInInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: SwapBaseInInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -60,77 +57,69 @@ impl SwapBaseIn {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SwapBaseInInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(18 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm, false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.amm, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_target_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_bids,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_asks,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_bids, false));
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_asks, false));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_event_queue,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_coin_vault_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_pc_vault_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_vault_signer,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.uer_source_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.uer_destination_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.user_source_owner,
             true,
         ));
@@ -139,7 +128,7 @@ impl SwapBaseIn {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -196,27 +185,27 @@ pub struct SwapBaseInInstructionArgs {
 ///   17. `[signer]` user_source_owner
 #[derive(Clone, Debug, Default)]
 pub struct SwapBaseInBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    amm_target_orders: Option<solana_program::pubkey::Pubkey>,
-    pool_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    serum_program: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    serum_bids: Option<solana_program::pubkey::Pubkey>,
-    serum_asks: Option<solana_program::pubkey::Pubkey>,
-    serum_event_queue: Option<solana_program::pubkey::Pubkey>,
-    serum_coin_vault_account: Option<solana_program::pubkey::Pubkey>,
-    serum_pc_vault_account: Option<solana_program::pubkey::Pubkey>,
-    serum_vault_signer: Option<solana_program::pubkey::Pubkey>,
-    uer_source_token_account: Option<solana_program::pubkey::Pubkey>,
-    uer_destination_token_account: Option<solana_program::pubkey::Pubkey>,
-    user_source_owner: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    amm_open_orders: Option<solana_pubkey::Pubkey>,
+    amm_target_orders: Option<solana_pubkey::Pubkey>,
+    pool_coin_token_account: Option<solana_pubkey::Pubkey>,
+    pool_pc_token_account: Option<solana_pubkey::Pubkey>,
+    serum_program: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    serum_bids: Option<solana_pubkey::Pubkey>,
+    serum_asks: Option<solana_pubkey::Pubkey>,
+    serum_event_queue: Option<solana_pubkey::Pubkey>,
+    serum_coin_vault_account: Option<solana_pubkey::Pubkey>,
+    serum_pc_vault_account: Option<solana_pubkey::Pubkey>,
+    serum_vault_signer: Option<solana_pubkey::Pubkey>,
+    uer_source_token_account: Option<solana_pubkey::Pubkey>,
+    uer_destination_token_account: Option<solana_pubkey::Pubkey>,
+    user_source_owner: Option<solana_pubkey::Pubkey>,
     amount_in: Option<u64>,
     minimum_amount_out: Option<u64>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SwapBaseInBuilder {
@@ -225,40 +214,34 @@ impl SwapBaseInBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn amm_open_orders(
-        &mut self,
-        amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_open_orders(&mut self, amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
-    pub fn amm_target_orders(
-        &mut self,
-        amm_target_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_target_orders(&mut self, amm_target_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_target_orders = Some(amm_target_orders);
         self
     }
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: solana_program::pubkey::Pubkey,
+        pool_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -266,43 +249,40 @@ impl SwapBaseInBuilder {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: solana_program::pubkey::Pubkey,
+        pool_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_pc_token_account = Some(pool_pc_token_account);
         self
     }
     #[inline(always)]
-    pub fn serum_program(&mut self, serum_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_program(&mut self, serum_program: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_program = Some(serum_program);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
-    pub fn serum_bids(&mut self, serum_bids: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_bids(&mut self, serum_bids: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_bids = Some(serum_bids);
         self
     }
     #[inline(always)]
-    pub fn serum_asks(&mut self, serum_asks: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_asks(&mut self, serum_asks: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_asks = Some(serum_asks);
         self
     }
     #[inline(always)]
-    pub fn serum_event_queue(
-        &mut self,
-        serum_event_queue: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_event_queue(&mut self, serum_event_queue: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_event_queue = Some(serum_event_queue);
         self
     }
     #[inline(always)]
     pub fn serum_coin_vault_account(
         &mut self,
-        serum_coin_vault_account: solana_program::pubkey::Pubkey,
+        serum_coin_vault_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.serum_coin_vault_account = Some(serum_coin_vault_account);
         self
@@ -310,23 +290,20 @@ impl SwapBaseInBuilder {
     #[inline(always)]
     pub fn serum_pc_vault_account(
         &mut self,
-        serum_pc_vault_account: solana_program::pubkey::Pubkey,
+        serum_pc_vault_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.serum_pc_vault_account = Some(serum_pc_vault_account);
         self
     }
     #[inline(always)]
-    pub fn serum_vault_signer(
-        &mut self,
-        serum_vault_signer: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_vault_signer(&mut self, serum_vault_signer: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_vault_signer = Some(serum_vault_signer);
         self
     }
     #[inline(always)]
     pub fn uer_source_token_account(
         &mut self,
-        uer_source_token_account: solana_program::pubkey::Pubkey,
+        uer_source_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.uer_source_token_account = Some(uer_source_token_account);
         self
@@ -334,16 +311,13 @@ impl SwapBaseInBuilder {
     #[inline(always)]
     pub fn uer_destination_token_account(
         &mut self,
-        uer_destination_token_account: solana_program::pubkey::Pubkey,
+        uer_destination_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.uer_destination_token_account = Some(uer_destination_token_account);
         self
     }
     #[inline(always)]
-    pub fn user_source_owner(
-        &mut self,
-        user_source_owner: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn user_source_owner(&mut self, user_source_owner: solana_pubkey::Pubkey) -> &mut Self {
         self.user_source_owner = Some(user_source_owner);
         self
     }
@@ -359,10 +333,7 @@ impl SwapBaseInBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -370,15 +341,15 @@ impl SwapBaseInBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SwapBaseIn {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             amm: self.amm.expect("amm is not set"),
@@ -433,90 +404,90 @@ impl SwapBaseInBuilder {
 
 /// `swap_base_in` CPI accounts.
 pub struct SwapBaseInCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub uer_source_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub uer_source_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub uer_destination_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub uer_destination_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_source_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_source_owner: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `swap_base_in` CPI instruction.
 pub struct SwapBaseInCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub uer_source_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub uer_source_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub uer_destination_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub uer_destination_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_source_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_source_owner: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SwapBaseInInstructionArgs,
 }
 
 impl<'a, 'b> SwapBaseInCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SwapBaseInCpiAccounts<'a, 'b>,
         args: SwapBaseInInstructionArgs,
     ) -> Self {
@@ -544,25 +515,21 @@ impl<'a, 'b> SwapBaseInCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -571,87 +538,80 @@ impl<'a, 'b> SwapBaseInCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(18 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.amm.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.amm.key, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_target_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_bids.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_asks.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_event_queue.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_coin_vault_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_pc_vault_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_vault_signer.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.uer_source_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.uer_destination_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.user_source_owner.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -661,7 +621,7 @@ impl<'a, 'b> SwapBaseInCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -691,9 +651,9 @@ impl<'a, 'b> SwapBaseInCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -726,7 +686,7 @@ pub struct SwapBaseInCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SwapBaseInCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -756,20 +716,20 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -777,7 +737,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_open_orders(
         &mut self,
-        amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_open_orders = Some(amm_open_orders);
         self
@@ -785,7 +745,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_target_orders(
         &mut self,
-        amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_target_orders = Some(amm_target_orders);
         self
@@ -793,7 +753,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -801,7 +761,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -809,7 +769,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_program(
         &mut self,
-        serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_program = Some(serum_program);
         self
@@ -817,7 +777,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -825,7 +785,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_bids(
         &mut self,
-        serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_bids: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_bids = Some(serum_bids);
         self
@@ -833,7 +793,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_asks(
         &mut self,
-        serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_asks: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_asks = Some(serum_asks);
         self
@@ -841,7 +801,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_event_queue(
         &mut self,
-        serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_event_queue = Some(serum_event_queue);
         self
@@ -849,7 +809,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_coin_vault_account(
         &mut self,
-        serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_coin_vault_account = Some(serum_coin_vault_account);
         self
@@ -857,7 +817,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_pc_vault_account(
         &mut self,
-        serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_pc_vault_account = Some(serum_pc_vault_account);
         self
@@ -865,7 +825,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_vault_signer(
         &mut self,
-        serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_vault_signer = Some(serum_vault_signer);
         self
@@ -873,7 +833,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn uer_source_token_account(
         &mut self,
-        uer_source_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        uer_source_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.uer_source_token_account = Some(uer_source_token_account);
         self
@@ -881,7 +841,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn uer_destination_token_account(
         &mut self,
-        uer_destination_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        uer_destination_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.uer_destination_token_account = Some(uer_destination_token_account);
         self
@@ -889,7 +849,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_source_owner(
         &mut self,
-        user_source_owner: &'b solana_program::account_info::AccountInfo<'a>,
+        user_source_owner: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_source_owner = Some(user_source_owner);
         self
@@ -908,7 +868,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -924,11 +884,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -936,7 +892,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -944,7 +900,7 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SwapBaseInInstructionArgs {
             amount_in: self
                 .instruction
@@ -1051,31 +1007,27 @@ impl<'a, 'b> SwapBaseInCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SwapBaseInCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_target_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_bids: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_asks: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_event_queue: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_coin_vault_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_pc_vault_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_vault_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    uer_source_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    uer_destination_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_source_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_target_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_bids: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_asks: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_event_queue: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_coin_vault_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_pc_vault_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_vault_signer: Option<&'b solana_account_info::AccountInfo<'a>>,
+    uer_source_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    uer_destination_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_source_owner: Option<&'b solana_account_info::AccountInfo<'a>>,
     amount_in: Option<u64>,
     minimum_amount_out: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/swap_base_out.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/swap_base_out.rs
@@ -11,48 +11,45 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct SwapBaseOut {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub amm_open_orders: solana_program::pubkey::Pubkey,
+    pub amm_open_orders: solana_pubkey::Pubkey,
 
-    pub amm_target_orders: solana_program::pubkey::Pubkey,
+    pub amm_target_orders: solana_pubkey::Pubkey,
 
-    pub pool_coin_token_account: solana_program::pubkey::Pubkey,
+    pub pool_coin_token_account: solana_pubkey::Pubkey,
 
-    pub pool_pc_token_account: solana_program::pubkey::Pubkey,
+    pub pool_pc_token_account: solana_pubkey::Pubkey,
 
-    pub serum_program: solana_program::pubkey::Pubkey,
+    pub serum_program: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub serum_bids: solana_program::pubkey::Pubkey,
+    pub serum_bids: solana_pubkey::Pubkey,
 
-    pub serum_asks: solana_program::pubkey::Pubkey,
+    pub serum_asks: solana_pubkey::Pubkey,
 
-    pub serum_event_queue: solana_program::pubkey::Pubkey,
+    pub serum_event_queue: solana_pubkey::Pubkey,
 
-    pub serum_coin_vault_account: solana_program::pubkey::Pubkey,
+    pub serum_coin_vault_account: solana_pubkey::Pubkey,
 
-    pub serum_pc_vault_account: solana_program::pubkey::Pubkey,
+    pub serum_pc_vault_account: solana_pubkey::Pubkey,
 
-    pub serum_vault_signer: solana_program::pubkey::Pubkey,
+    pub serum_vault_signer: solana_pubkey::Pubkey,
 
-    pub uer_source_token_account: solana_program::pubkey::Pubkey,
+    pub uer_source_token_account: solana_pubkey::Pubkey,
 
-    pub uer_destination_token_account: solana_program::pubkey::Pubkey,
+    pub uer_destination_token_account: solana_pubkey::Pubkey,
 
-    pub user_source_owner: solana_program::pubkey::Pubkey,
+    pub user_source_owner: solana_pubkey::Pubkey,
 }
 
 impl SwapBaseOut {
-    pub fn instruction(
-        &self,
-        args: SwapBaseOutInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: SwapBaseOutInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -60,77 +57,69 @@ impl SwapBaseOut {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: SwapBaseOutInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(18 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm, false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.amm, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_target_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_bids,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_asks,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_bids, false));
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_asks, false));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_event_queue,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_coin_vault_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_pc_vault_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_vault_signer,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.uer_source_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.uer_destination_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.user_source_owner,
             true,
         ));
@@ -139,7 +128,7 @@ impl SwapBaseOut {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -198,27 +187,27 @@ pub struct SwapBaseOutInstructionArgs {
 ///   17. `[signer]` user_source_owner
 #[derive(Clone, Debug, Default)]
 pub struct SwapBaseOutBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    amm_target_orders: Option<solana_program::pubkey::Pubkey>,
-    pool_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    serum_program: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    serum_bids: Option<solana_program::pubkey::Pubkey>,
-    serum_asks: Option<solana_program::pubkey::Pubkey>,
-    serum_event_queue: Option<solana_program::pubkey::Pubkey>,
-    serum_coin_vault_account: Option<solana_program::pubkey::Pubkey>,
-    serum_pc_vault_account: Option<solana_program::pubkey::Pubkey>,
-    serum_vault_signer: Option<solana_program::pubkey::Pubkey>,
-    uer_source_token_account: Option<solana_program::pubkey::Pubkey>,
-    uer_destination_token_account: Option<solana_program::pubkey::Pubkey>,
-    user_source_owner: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    amm_open_orders: Option<solana_pubkey::Pubkey>,
+    amm_target_orders: Option<solana_pubkey::Pubkey>,
+    pool_coin_token_account: Option<solana_pubkey::Pubkey>,
+    pool_pc_token_account: Option<solana_pubkey::Pubkey>,
+    serum_program: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    serum_bids: Option<solana_pubkey::Pubkey>,
+    serum_asks: Option<solana_pubkey::Pubkey>,
+    serum_event_queue: Option<solana_pubkey::Pubkey>,
+    serum_coin_vault_account: Option<solana_pubkey::Pubkey>,
+    serum_pc_vault_account: Option<solana_pubkey::Pubkey>,
+    serum_vault_signer: Option<solana_pubkey::Pubkey>,
+    uer_source_token_account: Option<solana_pubkey::Pubkey>,
+    uer_destination_token_account: Option<solana_pubkey::Pubkey>,
+    user_source_owner: Option<solana_pubkey::Pubkey>,
     max_amount_in: Option<u64>,
     amount_out: Option<u64>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl SwapBaseOutBuilder {
@@ -227,40 +216,34 @@ impl SwapBaseOutBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn amm_open_orders(
-        &mut self,
-        amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_open_orders(&mut self, amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
-    pub fn amm_target_orders(
-        &mut self,
-        amm_target_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_target_orders(&mut self, amm_target_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_target_orders = Some(amm_target_orders);
         self
     }
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: solana_program::pubkey::Pubkey,
+        pool_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -268,43 +251,40 @@ impl SwapBaseOutBuilder {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: solana_program::pubkey::Pubkey,
+        pool_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_pc_token_account = Some(pool_pc_token_account);
         self
     }
     #[inline(always)]
-    pub fn serum_program(&mut self, serum_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_program(&mut self, serum_program: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_program = Some(serum_program);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
-    pub fn serum_bids(&mut self, serum_bids: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_bids(&mut self, serum_bids: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_bids = Some(serum_bids);
         self
     }
     #[inline(always)]
-    pub fn serum_asks(&mut self, serum_asks: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_asks(&mut self, serum_asks: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_asks = Some(serum_asks);
         self
     }
     #[inline(always)]
-    pub fn serum_event_queue(
-        &mut self,
-        serum_event_queue: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_event_queue(&mut self, serum_event_queue: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_event_queue = Some(serum_event_queue);
         self
     }
     #[inline(always)]
     pub fn serum_coin_vault_account(
         &mut self,
-        serum_coin_vault_account: solana_program::pubkey::Pubkey,
+        serum_coin_vault_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.serum_coin_vault_account = Some(serum_coin_vault_account);
         self
@@ -312,23 +292,20 @@ impl SwapBaseOutBuilder {
     #[inline(always)]
     pub fn serum_pc_vault_account(
         &mut self,
-        serum_pc_vault_account: solana_program::pubkey::Pubkey,
+        serum_pc_vault_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.serum_pc_vault_account = Some(serum_pc_vault_account);
         self
     }
     #[inline(always)]
-    pub fn serum_vault_signer(
-        &mut self,
-        serum_vault_signer: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_vault_signer(&mut self, serum_vault_signer: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_vault_signer = Some(serum_vault_signer);
         self
     }
     #[inline(always)]
     pub fn uer_source_token_account(
         &mut self,
-        uer_source_token_account: solana_program::pubkey::Pubkey,
+        uer_source_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.uer_source_token_account = Some(uer_source_token_account);
         self
@@ -336,16 +313,13 @@ impl SwapBaseOutBuilder {
     #[inline(always)]
     pub fn uer_destination_token_account(
         &mut self,
-        uer_destination_token_account: solana_program::pubkey::Pubkey,
+        uer_destination_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.uer_destination_token_account = Some(uer_destination_token_account);
         self
     }
     #[inline(always)]
-    pub fn user_source_owner(
-        &mut self,
-        user_source_owner: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn user_source_owner(&mut self, user_source_owner: solana_pubkey::Pubkey) -> &mut Self {
         self.user_source_owner = Some(user_source_owner);
         self
     }
@@ -361,10 +335,7 @@ impl SwapBaseOutBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -372,15 +343,15 @@ impl SwapBaseOutBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = SwapBaseOut {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             amm: self.amm.expect("amm is not set"),
@@ -435,90 +406,90 @@ impl SwapBaseOutBuilder {
 
 /// `swap_base_out` CPI accounts.
 pub struct SwapBaseOutCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub uer_source_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub uer_source_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub uer_destination_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub uer_destination_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_source_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_source_owner: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `swap_base_out` CPI instruction.
 pub struct SwapBaseOutCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub uer_source_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub uer_source_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub uer_destination_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub uer_destination_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_source_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_source_owner: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SwapBaseOutInstructionArgs,
 }
 
 impl<'a, 'b> SwapBaseOutCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: SwapBaseOutCpiAccounts<'a, 'b>,
         args: SwapBaseOutInstructionArgs,
     ) -> Self {
@@ -546,25 +517,21 @@ impl<'a, 'b> SwapBaseOutCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -573,87 +540,80 @@ impl<'a, 'b> SwapBaseOutCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(18 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.amm.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.amm.key, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_target_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_bids.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_asks.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_event_queue.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_coin_vault_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_pc_vault_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_vault_signer.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.uer_source_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.uer_destination_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.user_source_owner.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -663,7 +623,7 @@ impl<'a, 'b> SwapBaseOutCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -693,9 +653,9 @@ impl<'a, 'b> SwapBaseOutCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -728,7 +688,7 @@ pub struct SwapBaseOutCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SwapBaseOutCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -758,20 +718,20 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -779,7 +739,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_open_orders(
         &mut self,
-        amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_open_orders = Some(amm_open_orders);
         self
@@ -787,7 +747,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_target_orders(
         &mut self,
-        amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_target_orders = Some(amm_target_orders);
         self
@@ -795,7 +755,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -803,7 +763,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -811,7 +771,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_program(
         &mut self,
-        serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_program = Some(serum_program);
         self
@@ -819,7 +779,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -827,7 +787,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_bids(
         &mut self,
-        serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_bids: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_bids = Some(serum_bids);
         self
@@ -835,7 +795,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_asks(
         &mut self,
-        serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_asks: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_asks = Some(serum_asks);
         self
@@ -843,7 +803,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_event_queue(
         &mut self,
-        serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_event_queue = Some(serum_event_queue);
         self
@@ -851,7 +811,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_coin_vault_account(
         &mut self,
-        serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_coin_vault_account = Some(serum_coin_vault_account);
         self
@@ -859,7 +819,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_pc_vault_account(
         &mut self,
-        serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_pc_vault_account = Some(serum_pc_vault_account);
         self
@@ -867,7 +827,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_vault_signer(
         &mut self,
-        serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_vault_signer = Some(serum_vault_signer);
         self
@@ -875,7 +835,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn uer_source_token_account(
         &mut self,
-        uer_source_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        uer_source_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.uer_source_token_account = Some(uer_source_token_account);
         self
@@ -883,7 +843,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn uer_destination_token_account(
         &mut self,
-        uer_destination_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        uer_destination_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.uer_destination_token_account = Some(uer_destination_token_account);
         self
@@ -891,7 +851,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_source_owner(
         &mut self,
-        user_source_owner: &'b solana_program::account_info::AccountInfo<'a>,
+        user_source_owner: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_source_owner = Some(user_source_owner);
         self
@@ -910,7 +870,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -926,11 +886,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -938,7 +894,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -946,7 +902,7 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = SwapBaseOutInstructionArgs {
             max_amount_in: self
                 .instruction
@@ -1053,31 +1009,27 @@ impl<'a, 'b> SwapBaseOutCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct SwapBaseOutCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_target_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_bids: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_asks: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_event_queue: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_coin_vault_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_pc_vault_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_vault_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    uer_source_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    uer_destination_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_source_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_target_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_bids: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_asks: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_event_queue: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_coin_vault_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_pc_vault_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_vault_signer: Option<&'b solana_account_info::AccountInfo<'a>>,
+    uer_source_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    uer_destination_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_source_owner: Option<&'b solana_account_info::AccountInfo<'a>>,
     max_amount_in: Option<u64>,
     amount_out: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/update_config_account.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/update_config_account.rs
@@ -7,21 +7,21 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 /// Accounts.
 #[derive(Debug)]
 pub struct UpdateConfigAccount {
-    pub admin: solana_program::pubkey::Pubkey,
+    pub admin: solana_pubkey::Pubkey,
 
-    pub amm_config: solana_program::pubkey::Pubkey,
+    pub amm_config: solana_pubkey::Pubkey,
 }
 
 impl UpdateConfigAccount {
     pub fn instruction(
         &self,
         args: UpdateConfigAccountInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -29,22 +29,19 @@ impl UpdateConfigAccount {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: UpdateConfigAccountInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.admin, true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm_config,
-            false,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.amm_config, false));
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&UpdateConfigAccountInstructionData::new()).unwrap();
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -87,11 +84,11 @@ pub struct UpdateConfigAccountInstructionArgs {
 ///   1. `[writable]` amm_config
 #[derive(Clone, Debug, Default)]
 pub struct UpdateConfigAccountBuilder {
-    admin: Option<solana_program::pubkey::Pubkey>,
-    amm_config: Option<solana_program::pubkey::Pubkey>,
+    admin: Option<solana_pubkey::Pubkey>,
+    amm_config: Option<solana_pubkey::Pubkey>,
     param: Option<u8>,
     owner: Option<Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl UpdateConfigAccountBuilder {
@@ -99,12 +96,12 @@ impl UpdateConfigAccountBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn admin(&mut self, admin: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn admin(&mut self, admin: solana_pubkey::Pubkey) -> &mut Self {
         self.admin = Some(admin);
         self
     }
     #[inline(always)]
-    pub fn amm_config(&mut self, amm_config: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_config(&mut self, amm_config: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_config = Some(amm_config);
         self
     }
@@ -120,10 +117,7 @@ impl UpdateConfigAccountBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -131,13 +125,13 @@ impl UpdateConfigAccountBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = UpdateConfigAccount {
             admin: self.admin.expect("admin is not set"),
             amm_config: self.amm_config.expect("amm_config is not set"),
@@ -153,26 +147,26 @@ impl UpdateConfigAccountBuilder {
 
 /// `update_config_account` CPI accounts.
 pub struct UpdateConfigAccountCpiAccounts<'a, 'b> {
-    pub admin: &'b solana_program::account_info::AccountInfo<'a>,
+    pub admin: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_config: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `update_config_account` CPI instruction.
 pub struct UpdateConfigAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub admin: &'b solana_program::account_info::AccountInfo<'a>,
+    pub admin: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_config: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: UpdateConfigAccountInstructionArgs,
 }
 
 impl<'a, 'b> UpdateConfigAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: UpdateConfigAccountCpiAccounts<'a, 'b>,
         args: UpdateConfigAccountInstructionArgs,
     ) -> Self {
@@ -184,25 +178,21 @@ impl<'a, 'b> UpdateConfigAccountCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -211,23 +201,19 @@ impl<'a, 'b> UpdateConfigAccountCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.admin.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_config.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -237,7 +223,7 @@ impl<'a, 'b> UpdateConfigAccountCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -251,9 +237,9 @@ impl<'a, 'b> UpdateConfigAccountCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -270,7 +256,7 @@ pub struct UpdateConfigAccountCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> UpdateConfigAccountCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateConfigAccountCpiBuilderInstruction {
             __program: program,
             admin: None,
@@ -282,14 +268,14 @@ impl<'a, 'b> UpdateConfigAccountCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn admin(&mut self, admin: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn admin(&mut self, admin: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.admin = Some(admin);
         self
     }
     #[inline(always)]
     pub fn amm_config(
         &mut self,
-        amm_config: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_config = Some(amm_config);
         self
@@ -308,7 +294,7 @@ impl<'a, 'b> UpdateConfigAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -324,11 +310,7 @@ impl<'a, 'b> UpdateConfigAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -336,7 +318,7 @@ impl<'a, 'b> UpdateConfigAccountCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -344,7 +326,7 @@ impl<'a, 'b> UpdateConfigAccountCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = UpdateConfigAccountInstructionArgs {
             param: self.instruction.param.clone().expect("param is not set"),
             owner: self.instruction.owner.clone().expect("owner is not set"),
@@ -366,15 +348,11 @@ impl<'a, 'b> UpdateConfigAccountCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct UpdateConfigAccountCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    admin: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    admin: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_config: Option<&'b solana_account_info::AccountInfo<'a>>,
     param: Option<u8>,
     owner: Option<Pubkey>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/withdraw.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/withdraw.rs
@@ -11,56 +11,53 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct Withdraw {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub amm_open_orders: solana_program::pubkey::Pubkey,
+    pub amm_open_orders: solana_pubkey::Pubkey,
 
-    pub amm_target_orders: solana_program::pubkey::Pubkey,
+    pub amm_target_orders: solana_pubkey::Pubkey,
 
-    pub lp_mint_address: solana_program::pubkey::Pubkey,
+    pub lp_mint_address: solana_pubkey::Pubkey,
 
-    pub pool_coin_token_account: solana_program::pubkey::Pubkey,
+    pub pool_coin_token_account: solana_pubkey::Pubkey,
 
-    pub pool_pc_token_account: solana_program::pubkey::Pubkey,
+    pub pool_pc_token_account: solana_pubkey::Pubkey,
 
-    pub pool_withdraw_queue: solana_program::pubkey::Pubkey,
+    pub pool_withdraw_queue: solana_pubkey::Pubkey,
 
-    pub pool_temp_lp_token_account: solana_program::pubkey::Pubkey,
+    pub pool_temp_lp_token_account: solana_pubkey::Pubkey,
 
-    pub serum_program: solana_program::pubkey::Pubkey,
+    pub serum_program: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub serum_coin_vault_account: solana_program::pubkey::Pubkey,
+    pub serum_coin_vault_account: solana_pubkey::Pubkey,
 
-    pub serum_pc_vault_account: solana_program::pubkey::Pubkey,
+    pub serum_pc_vault_account: solana_pubkey::Pubkey,
 
-    pub serum_vault_signer: solana_program::pubkey::Pubkey,
+    pub serum_vault_signer: solana_pubkey::Pubkey,
 
-    pub user_lp_token_account: solana_program::pubkey::Pubkey,
+    pub user_lp_token_account: solana_pubkey::Pubkey,
 
-    pub uer_coin_token_account: solana_program::pubkey::Pubkey,
+    pub uer_coin_token_account: solana_pubkey::Pubkey,
 
-    pub uer_pc_token_account: solana_program::pubkey::Pubkey,
+    pub uer_pc_token_account: solana_pubkey::Pubkey,
 
-    pub user_owner: solana_program::pubkey::Pubkey,
+    pub user_owner: solana_pubkey::Pubkey,
 
-    pub serum_event_q: solana_program::pubkey::Pubkey,
+    pub serum_event_q: solana_pubkey::Pubkey,
 
-    pub serum_bids: solana_program::pubkey::Pubkey,
+    pub serum_bids: solana_pubkey::Pubkey,
 
-    pub serum_asks: solana_program::pubkey::Pubkey,
+    pub serum_asks: solana_pubkey::Pubkey,
 }
 
 impl Withdraw {
-    pub fn instruction(
-        &self,
-        args: WithdrawInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: WithdrawInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -68,102 +65,94 @@ impl Withdraw {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: WithdrawInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(22 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm, false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.amm, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_target_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.lp_mint_address,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_withdraw_queue,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_temp_lp_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_coin_vault_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_pc_vault_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_vault_signer,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.user_lp_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.uer_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.uer_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.user_owner,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_event_q,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_bids,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.serum_asks,
-            false,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_bids, false));
+        accounts.push(solana_instruction::AccountMeta::new(self.serum_asks, false));
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&WithdrawInstructionData::new()).unwrap();
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -223,30 +212,30 @@ pub struct WithdrawInstructionArgs {
 ///   21. `[writable]` serum_asks
 #[derive(Clone, Debug, Default)]
 pub struct WithdrawBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    amm_target_orders: Option<solana_program::pubkey::Pubkey>,
-    lp_mint_address: Option<solana_program::pubkey::Pubkey>,
-    pool_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_withdraw_queue: Option<solana_program::pubkey::Pubkey>,
-    pool_temp_lp_token_account: Option<solana_program::pubkey::Pubkey>,
-    serum_program: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    serum_coin_vault_account: Option<solana_program::pubkey::Pubkey>,
-    serum_pc_vault_account: Option<solana_program::pubkey::Pubkey>,
-    serum_vault_signer: Option<solana_program::pubkey::Pubkey>,
-    user_lp_token_account: Option<solana_program::pubkey::Pubkey>,
-    uer_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    uer_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    user_owner: Option<solana_program::pubkey::Pubkey>,
-    serum_event_q: Option<solana_program::pubkey::Pubkey>,
-    serum_bids: Option<solana_program::pubkey::Pubkey>,
-    serum_asks: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    amm_open_orders: Option<solana_pubkey::Pubkey>,
+    amm_target_orders: Option<solana_pubkey::Pubkey>,
+    lp_mint_address: Option<solana_pubkey::Pubkey>,
+    pool_coin_token_account: Option<solana_pubkey::Pubkey>,
+    pool_pc_token_account: Option<solana_pubkey::Pubkey>,
+    pool_withdraw_queue: Option<solana_pubkey::Pubkey>,
+    pool_temp_lp_token_account: Option<solana_pubkey::Pubkey>,
+    serum_program: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    serum_coin_vault_account: Option<solana_pubkey::Pubkey>,
+    serum_pc_vault_account: Option<solana_pubkey::Pubkey>,
+    serum_vault_signer: Option<solana_pubkey::Pubkey>,
+    user_lp_token_account: Option<solana_pubkey::Pubkey>,
+    uer_coin_token_account: Option<solana_pubkey::Pubkey>,
+    uer_pc_token_account: Option<solana_pubkey::Pubkey>,
+    user_owner: Option<solana_pubkey::Pubkey>,
+    serum_event_q: Option<solana_pubkey::Pubkey>,
+    serum_bids: Option<solana_pubkey::Pubkey>,
+    serum_asks: Option<solana_pubkey::Pubkey>,
     amount: Option<u64>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl WithdrawBuilder {
@@ -255,48 +244,39 @@ impl WithdrawBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn amm_open_orders(
-        &mut self,
-        amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_open_orders(&mut self, amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
-    pub fn amm_target_orders(
-        &mut self,
-        amm_target_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_target_orders(&mut self, amm_target_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_target_orders = Some(amm_target_orders);
         self
     }
     #[inline(always)]
-    pub fn lp_mint_address(
-        &mut self,
-        lp_mint_address: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn lp_mint_address(&mut self, lp_mint_address: solana_pubkey::Pubkey) -> &mut Self {
         self.lp_mint_address = Some(lp_mint_address);
         self
     }
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: solana_program::pubkey::Pubkey,
+        pool_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -304,41 +284,38 @@ impl WithdrawBuilder {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: solana_program::pubkey::Pubkey,
+        pool_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_pc_token_account = Some(pool_pc_token_account);
         self
     }
     #[inline(always)]
-    pub fn pool_withdraw_queue(
-        &mut self,
-        pool_withdraw_queue: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn pool_withdraw_queue(&mut self, pool_withdraw_queue: solana_pubkey::Pubkey) -> &mut Self {
         self.pool_withdraw_queue = Some(pool_withdraw_queue);
         self
     }
     #[inline(always)]
     pub fn pool_temp_lp_token_account(
         &mut self,
-        pool_temp_lp_token_account: solana_program::pubkey::Pubkey,
+        pool_temp_lp_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_temp_lp_token_account = Some(pool_temp_lp_token_account);
         self
     }
     #[inline(always)]
-    pub fn serum_program(&mut self, serum_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_program(&mut self, serum_program: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_program = Some(serum_program);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
     pub fn serum_coin_vault_account(
         &mut self,
-        serum_coin_vault_account: solana_program::pubkey::Pubkey,
+        serum_coin_vault_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.serum_coin_vault_account = Some(serum_coin_vault_account);
         self
@@ -346,23 +323,20 @@ impl WithdrawBuilder {
     #[inline(always)]
     pub fn serum_pc_vault_account(
         &mut self,
-        serum_pc_vault_account: solana_program::pubkey::Pubkey,
+        serum_pc_vault_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.serum_pc_vault_account = Some(serum_pc_vault_account);
         self
     }
     #[inline(always)]
-    pub fn serum_vault_signer(
-        &mut self,
-        serum_vault_signer: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_vault_signer(&mut self, serum_vault_signer: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_vault_signer = Some(serum_vault_signer);
         self
     }
     #[inline(always)]
     pub fn user_lp_token_account(
         &mut self,
-        user_lp_token_account: solana_program::pubkey::Pubkey,
+        user_lp_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.user_lp_token_account = Some(user_lp_token_account);
         self
@@ -370,7 +344,7 @@ impl WithdrawBuilder {
     #[inline(always)]
     pub fn uer_coin_token_account(
         &mut self,
-        uer_coin_token_account: solana_program::pubkey::Pubkey,
+        uer_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.uer_coin_token_account = Some(uer_coin_token_account);
         self
@@ -378,28 +352,28 @@ impl WithdrawBuilder {
     #[inline(always)]
     pub fn uer_pc_token_account(
         &mut self,
-        uer_pc_token_account: solana_program::pubkey::Pubkey,
+        uer_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.uer_pc_token_account = Some(uer_pc_token_account);
         self
     }
     #[inline(always)]
-    pub fn user_owner(&mut self, user_owner: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn user_owner(&mut self, user_owner: solana_pubkey::Pubkey) -> &mut Self {
         self.user_owner = Some(user_owner);
         self
     }
     #[inline(always)]
-    pub fn serum_event_q(&mut self, serum_event_q: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_event_q(&mut self, serum_event_q: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_event_q = Some(serum_event_q);
         self
     }
     #[inline(always)]
-    pub fn serum_bids(&mut self, serum_bids: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_bids(&mut self, serum_bids: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_bids = Some(serum_bids);
         self
     }
     #[inline(always)]
-    pub fn serum_asks(&mut self, serum_asks: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_asks(&mut self, serum_asks: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_asks = Some(serum_asks);
         self
     }
@@ -410,10 +384,7 @@ impl WithdrawBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -421,15 +392,15 @@ impl WithdrawBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = Withdraw {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             amm: self.amm.expect("amm is not set"),
@@ -486,106 +457,106 @@ impl WithdrawBuilder {
 
 /// `withdraw` CPI accounts.
 pub struct WithdrawCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_temp_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_temp_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub uer_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub uer_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub uer_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub uer_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_q: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_q: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `withdraw` CPI instruction.
 pub struct WithdrawCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+    pub lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_temp_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_temp_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub uer_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub uer_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub uer_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub uer_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub user_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub user_owner: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_q: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_q: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_bids: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_asks: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: WithdrawInstructionArgs,
 }
 
 impl<'a, 'b> WithdrawCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: WithdrawCpiAccounts<'a, 'b>,
         args: WithdrawInstructionArgs,
     ) -> Self {
@@ -617,25 +588,21 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -644,103 +611,96 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(22 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.amm.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.amm.key, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_target_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.lp_mint_address.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_withdraw_queue.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_temp_lp_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_coin_vault_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_pc_vault_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_vault_signer.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.user_lp_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.uer_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.uer_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.user_owner.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_event_q.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_bids.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_asks.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -750,7 +710,7 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -784,9 +744,9 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -823,7 +783,7 @@ pub struct WithdrawCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(WithdrawCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -856,20 +816,20 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -877,7 +837,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_open_orders(
         &mut self,
-        amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_open_orders = Some(amm_open_orders);
         self
@@ -885,7 +845,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_target_orders(
         &mut self,
-        amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_target_orders = Some(amm_target_orders);
         self
@@ -893,7 +853,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn lp_mint_address(
         &mut self,
-        lp_mint_address: &'b solana_program::account_info::AccountInfo<'a>,
+        lp_mint_address: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.lp_mint_address = Some(lp_mint_address);
         self
@@ -901,7 +861,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -909,7 +869,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -917,7 +877,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_withdraw_queue(
         &mut self,
-        pool_withdraw_queue: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_withdraw_queue: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_withdraw_queue = Some(pool_withdraw_queue);
         self
@@ -925,7 +885,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_temp_lp_token_account(
         &mut self,
-        pool_temp_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_temp_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_temp_lp_token_account = Some(pool_temp_lp_token_account);
         self
@@ -933,7 +893,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_program(
         &mut self,
-        serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_program = Some(serum_program);
         self
@@ -941,7 +901,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -949,7 +909,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_coin_vault_account(
         &mut self,
-        serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_coin_vault_account = Some(serum_coin_vault_account);
         self
@@ -957,7 +917,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_pc_vault_account(
         &mut self,
-        serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_pc_vault_account = Some(serum_pc_vault_account);
         self
@@ -965,7 +925,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_vault_signer(
         &mut self,
-        serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_vault_signer = Some(serum_vault_signer);
         self
@@ -973,7 +933,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_lp_token_account(
         &mut self,
-        user_lp_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        user_lp_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_lp_token_account = Some(user_lp_token_account);
         self
@@ -981,7 +941,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn uer_coin_token_account(
         &mut self,
-        uer_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        uer_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.uer_coin_token_account = Some(uer_coin_token_account);
         self
@@ -989,7 +949,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn uer_pc_token_account(
         &mut self,
-        uer_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        uer_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.uer_pc_token_account = Some(uer_pc_token_account);
         self
@@ -997,7 +957,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn user_owner(
         &mut self,
-        user_owner: &'b solana_program::account_info::AccountInfo<'a>,
+        user_owner: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.user_owner = Some(user_owner);
         self
@@ -1005,7 +965,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_event_q(
         &mut self,
-        serum_event_q: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_event_q: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_event_q = Some(serum_event_q);
         self
@@ -1013,7 +973,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_bids(
         &mut self,
-        serum_bids: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_bids: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_bids = Some(serum_bids);
         self
@@ -1021,7 +981,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_asks(
         &mut self,
-        serum_asks: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_asks: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_asks = Some(serum_asks);
         self
@@ -1035,7 +995,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -1051,11 +1011,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -1063,7 +1019,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -1071,7 +1027,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = WithdrawInstructionArgs {
             amount: self.instruction.amount.clone().expect("amount is not set"),
         };
@@ -1186,34 +1142,30 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct WithdrawCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_target_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    lp_mint_address: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_withdraw_queue: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_temp_lp_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_coin_vault_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_pc_vault_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_vault_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_lp_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    uer_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    uer_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    user_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_event_q: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_bids: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_asks: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_target_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    lp_mint_address: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_withdraw_queue: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_temp_lp_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_coin_vault_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_pc_vault_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_vault_signer: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_lp_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    uer_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    uer_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    user_owner: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_event_q: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_bids: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_asks: Option<&'b solana_account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/withdraw_pnl.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/withdraw_pnl.rs
@@ -11,123 +11,121 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct WithdrawPnl {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_config: solana_program::pubkey::Pubkey,
+    pub amm_config: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub amm_open_orders: solana_program::pubkey::Pubkey,
+    pub amm_open_orders: solana_pubkey::Pubkey,
 
-    pub pool_coin_token_account: solana_program::pubkey::Pubkey,
+    pub pool_coin_token_account: solana_pubkey::Pubkey,
 
-    pub pool_pc_token_account: solana_program::pubkey::Pubkey,
+    pub pool_pc_token_account: solana_pubkey::Pubkey,
 
-    pub coin_pnl_token_account: solana_program::pubkey::Pubkey,
+    pub coin_pnl_token_account: solana_pubkey::Pubkey,
 
-    pub pc_pnl_token_account: solana_program::pubkey::Pubkey,
+    pub pc_pnl_token_account: solana_pubkey::Pubkey,
 
-    pub pnl_owner_account: solana_program::pubkey::Pubkey,
+    pub pnl_owner_account: solana_pubkey::Pubkey,
 
-    pub amm_target_orders: solana_program::pubkey::Pubkey,
+    pub amm_target_orders: solana_pubkey::Pubkey,
 
-    pub serum_program: solana_program::pubkey::Pubkey,
+    pub serum_program: solana_pubkey::Pubkey,
 
-    pub serum_market: solana_program::pubkey::Pubkey,
+    pub serum_market: solana_pubkey::Pubkey,
 
-    pub serum_event_queue: solana_program::pubkey::Pubkey,
+    pub serum_event_queue: solana_pubkey::Pubkey,
 
-    pub serum_coin_vault_account: solana_program::pubkey::Pubkey,
+    pub serum_coin_vault_account: solana_pubkey::Pubkey,
 
-    pub serum_pc_vault_account: solana_program::pubkey::Pubkey,
+    pub serum_pc_vault_account: solana_pubkey::Pubkey,
 
-    pub serum_vault_signer: solana_program::pubkey::Pubkey,
+    pub serum_vault_signer: solana_pubkey::Pubkey,
 }
 
 impl WithdrawPnl {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(17 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.amm, false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.amm, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_open_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_coin_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pool_pc_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.coin_pnl_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.pc_pnl_token_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.pnl_owner_account,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.amm_target_orders,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_market,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_event_queue,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_coin_vault_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.serum_pc_vault_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.serum_vault_signer,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&WithdrawPnlInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -176,24 +174,24 @@ impl Default for WithdrawPnlInstructionData {
 ///   16. `[]` serum_vault_signer
 #[derive(Clone, Debug, Default)]
 pub struct WithdrawPnlBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_config: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    amm_open_orders: Option<solana_program::pubkey::Pubkey>,
-    pool_coin_token_account: Option<solana_program::pubkey::Pubkey>,
-    pool_pc_token_account: Option<solana_program::pubkey::Pubkey>,
-    coin_pnl_token_account: Option<solana_program::pubkey::Pubkey>,
-    pc_pnl_token_account: Option<solana_program::pubkey::Pubkey>,
-    pnl_owner_account: Option<solana_program::pubkey::Pubkey>,
-    amm_target_orders: Option<solana_program::pubkey::Pubkey>,
-    serum_program: Option<solana_program::pubkey::Pubkey>,
-    serum_market: Option<solana_program::pubkey::Pubkey>,
-    serum_event_queue: Option<solana_program::pubkey::Pubkey>,
-    serum_coin_vault_account: Option<solana_program::pubkey::Pubkey>,
-    serum_pc_vault_account: Option<solana_program::pubkey::Pubkey>,
-    serum_vault_signer: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_config: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    amm_open_orders: Option<solana_pubkey::Pubkey>,
+    pool_coin_token_account: Option<solana_pubkey::Pubkey>,
+    pool_pc_token_account: Option<solana_pubkey::Pubkey>,
+    coin_pnl_token_account: Option<solana_pubkey::Pubkey>,
+    pc_pnl_token_account: Option<solana_pubkey::Pubkey>,
+    pnl_owner_account: Option<solana_pubkey::Pubkey>,
+    amm_target_orders: Option<solana_pubkey::Pubkey>,
+    serum_program: Option<solana_pubkey::Pubkey>,
+    serum_market: Option<solana_pubkey::Pubkey>,
+    serum_event_queue: Option<solana_pubkey::Pubkey>,
+    serum_coin_vault_account: Option<solana_pubkey::Pubkey>,
+    serum_pc_vault_account: Option<solana_pubkey::Pubkey>,
+    serum_vault_signer: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl WithdrawPnlBuilder {
@@ -202,37 +200,34 @@ impl WithdrawPnlBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_config(&mut self, amm_config: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_config(&mut self, amm_config: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_config = Some(amm_config);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn amm_open_orders(
-        &mut self,
-        amm_open_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_open_orders(&mut self, amm_open_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_open_orders = Some(amm_open_orders);
         self
     }
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: solana_program::pubkey::Pubkey,
+        pool_coin_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -240,7 +235,7 @@ impl WithdrawPnlBuilder {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: solana_program::pubkey::Pubkey,
+        pool_pc_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -248,7 +243,7 @@ impl WithdrawPnlBuilder {
     #[inline(always)]
     pub fn coin_pnl_token_account(
         &mut self,
-        coin_pnl_token_account: solana_program::pubkey::Pubkey,
+        coin_pnl_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.coin_pnl_token_account = Some(coin_pnl_token_account);
         self
@@ -256,49 +251,40 @@ impl WithdrawPnlBuilder {
     #[inline(always)]
     pub fn pc_pnl_token_account(
         &mut self,
-        pc_pnl_token_account: solana_program::pubkey::Pubkey,
+        pc_pnl_token_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.pc_pnl_token_account = Some(pc_pnl_token_account);
         self
     }
     #[inline(always)]
-    pub fn pnl_owner_account(
-        &mut self,
-        pnl_owner_account: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn pnl_owner_account(&mut self, pnl_owner_account: solana_pubkey::Pubkey) -> &mut Self {
         self.pnl_owner_account = Some(pnl_owner_account);
         self
     }
     #[inline(always)]
-    pub fn amm_target_orders(
-        &mut self,
-        amm_target_orders: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_target_orders(&mut self, amm_target_orders: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_target_orders = Some(amm_target_orders);
         self
     }
     #[inline(always)]
-    pub fn serum_program(&mut self, serum_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_program(&mut self, serum_program: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_program = Some(serum_program);
         self
     }
     #[inline(always)]
-    pub fn serum_market(&mut self, serum_market: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn serum_market(&mut self, serum_market: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_market = Some(serum_market);
         self
     }
     #[inline(always)]
-    pub fn serum_event_queue(
-        &mut self,
-        serum_event_queue: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_event_queue(&mut self, serum_event_queue: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_event_queue = Some(serum_event_queue);
         self
     }
     #[inline(always)]
     pub fn serum_coin_vault_account(
         &mut self,
-        serum_coin_vault_account: solana_program::pubkey::Pubkey,
+        serum_coin_vault_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.serum_coin_vault_account = Some(serum_coin_vault_account);
         self
@@ -306,25 +292,19 @@ impl WithdrawPnlBuilder {
     #[inline(always)]
     pub fn serum_pc_vault_account(
         &mut self,
-        serum_pc_vault_account: solana_program::pubkey::Pubkey,
+        serum_pc_vault_account: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.serum_pc_vault_account = Some(serum_pc_vault_account);
         self
     }
     #[inline(always)]
-    pub fn serum_vault_signer(
-        &mut self,
-        serum_vault_signer: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn serum_vault_signer(&mut self, serum_vault_signer: solana_pubkey::Pubkey) -> &mut Self {
         self.serum_vault_signer = Some(serum_vault_signer);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -332,15 +312,15 @@ impl WithdrawPnlBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = WithdrawPnl {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             amm: self.amm.expect("amm is not set"),
@@ -387,84 +367,84 @@ impl WithdrawPnlBuilder {
 
 /// `withdraw_pnl` CPI accounts.
 pub struct WithdrawPnlCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub coin_pnl_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub coin_pnl_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pc_pnl_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pc_pnl_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pnl_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pnl_owner_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `withdraw_pnl` CPI instruction.
 pub struct WithdrawPnlCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_config: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_config: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub coin_pnl_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub coin_pnl_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pc_pnl_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pc_pnl_token_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub pnl_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub pnl_owner_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_market: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> WithdrawPnlCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: WithdrawPnlCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -489,25 +469,21 @@ impl<'a, 'b> WithdrawPnlCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -516,83 +492,76 @@ impl<'a, 'b> WithdrawPnlCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(17 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.amm.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(*self.amm.key, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_open_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_coin_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pool_pc_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.coin_pnl_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.pc_pnl_token_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.pnl_owner_account.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.amm_target_orders.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_market.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_event_queue.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_coin_vault_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.serum_pc_vault_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.serum_vault_signer.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -600,7 +569,7 @@ impl<'a, 'b> WithdrawPnlCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&WithdrawPnlInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -629,9 +598,9 @@ impl<'a, 'b> WithdrawPnlCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -663,7 +632,7 @@ pub struct WithdrawPnlCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(WithdrawPnlCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -690,20 +659,20 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_config(
         &mut self,
-        amm_config: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_config: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_config = Some(amm_config);
         self
@@ -711,7 +680,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
@@ -719,7 +688,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_open_orders(
         &mut self,
-        amm_open_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_open_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_open_orders = Some(amm_open_orders);
         self
@@ -727,7 +696,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_coin_token_account(
         &mut self,
-        pool_coin_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_coin_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_coin_token_account = Some(pool_coin_token_account);
         self
@@ -735,7 +704,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pool_pc_token_account(
         &mut self,
-        pool_pc_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pool_pc_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pool_pc_token_account = Some(pool_pc_token_account);
         self
@@ -743,7 +712,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn coin_pnl_token_account(
         &mut self,
-        coin_pnl_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        coin_pnl_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.coin_pnl_token_account = Some(coin_pnl_token_account);
         self
@@ -751,7 +720,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pc_pnl_token_account(
         &mut self,
-        pc_pnl_token_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pc_pnl_token_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pc_pnl_token_account = Some(pc_pnl_token_account);
         self
@@ -759,7 +728,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn pnl_owner_account(
         &mut self,
-        pnl_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+        pnl_owner_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pnl_owner_account = Some(pnl_owner_account);
         self
@@ -767,7 +736,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_target_orders(
         &mut self,
-        amm_target_orders: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_target_orders: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_target_orders = Some(amm_target_orders);
         self
@@ -775,7 +744,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_program(
         &mut self,
-        serum_program: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_program = Some(serum_program);
         self
@@ -783,7 +752,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_market(
         &mut self,
-        serum_market: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_market: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_market = Some(serum_market);
         self
@@ -791,7 +760,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_event_queue(
         &mut self,
-        serum_event_queue: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_event_queue: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_event_queue = Some(serum_event_queue);
         self
@@ -799,7 +768,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_coin_vault_account(
         &mut self,
-        serum_coin_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_coin_vault_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_coin_vault_account = Some(serum_coin_vault_account);
         self
@@ -807,7 +776,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_pc_vault_account(
         &mut self,
-        serum_pc_vault_account: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_pc_vault_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_pc_vault_account = Some(serum_pc_vault_account);
         self
@@ -815,7 +784,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn serum_vault_signer(
         &mut self,
-        serum_vault_signer: &'b solana_program::account_info::AccountInfo<'a>,
+        serum_vault_signer: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.serum_vault_signer = Some(serum_vault_signer);
         self
@@ -824,7 +793,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -840,11 +809,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -852,7 +817,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -860,7 +825,7 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = WithdrawPnlCpi {
             __program: self.instruction.__program,
 
@@ -952,28 +917,24 @@ impl<'a, 'b> WithdrawPnlCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct WithdrawPnlCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_open_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_coin_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pool_pc_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    coin_pnl_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pc_pnl_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    pnl_owner_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_target_orders: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_market: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_event_queue: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_coin_vault_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_pc_vault_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    serum_vault_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_config: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_open_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_coin_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pool_pc_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    coin_pnl_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pc_pnl_token_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    pnl_owner_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_target_orders: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_market: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_event_queue: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_coin_vault_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_pc_vault_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    serum_vault_signer: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/withdraw_srm.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/instructions/withdraw_srm.rs
@@ -11,24 +11,21 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct WithdrawSrm {
-    pub token_program: solana_program::pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
 
-    pub amm: solana_program::pubkey::Pubkey,
+    pub amm: solana_pubkey::Pubkey,
 
-    pub amm_owner_account: solana_program::pubkey::Pubkey,
+    pub amm_owner_account: solana_pubkey::Pubkey,
 
-    pub amm_authority: solana_program::pubkey::Pubkey,
+    pub amm_authority: solana_pubkey::Pubkey,
 
-    pub srm_token: solana_program::pubkey::Pubkey,
+    pub srm_token: solana_pubkey::Pubkey,
 
-    pub dest_srm_token: solana_program::pubkey::Pubkey,
+    pub dest_srm_token: solana_pubkey::Pubkey,
 }
 
 impl WithdrawSrm {
-    pub fn instruction(
-        &self,
-        args: WithdrawSrmInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: WithdrawSrmInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -36,29 +33,26 @@ impl WithdrawSrm {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: WithdrawSrmInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.token_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_owner_account,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.amm_authority,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.srm_token,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.srm_token, false));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.dest_srm_token,
             false,
         ));
@@ -67,7 +61,7 @@ impl WithdrawSrm {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -111,14 +105,14 @@ pub struct WithdrawSrmInstructionArgs {
 ///   5. `[writable]` dest_srm_token
 #[derive(Clone, Debug, Default)]
 pub struct WithdrawSrmBuilder {
-    token_program: Option<solana_program::pubkey::Pubkey>,
-    amm: Option<solana_program::pubkey::Pubkey>,
-    amm_owner_account: Option<solana_program::pubkey::Pubkey>,
-    amm_authority: Option<solana_program::pubkey::Pubkey>,
-    srm_token: Option<solana_program::pubkey::Pubkey>,
-    dest_srm_token: Option<solana_program::pubkey::Pubkey>,
+    token_program: Option<solana_pubkey::Pubkey>,
+    amm: Option<solana_pubkey::Pubkey>,
+    amm_owner_account: Option<solana_pubkey::Pubkey>,
+    amm_authority: Option<solana_pubkey::Pubkey>,
+    srm_token: Option<solana_pubkey::Pubkey>,
+    dest_srm_token: Option<solana_pubkey::Pubkey>,
     amount: Option<u64>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl WithdrawSrmBuilder {
@@ -127,35 +121,32 @@ impl WithdrawSrmBuilder {
     }
     /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
-    pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn token_program(&mut self, token_program: solana_pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm(&mut self, amm: solana_pubkey::Pubkey) -> &mut Self {
         self.amm = Some(amm);
         self
     }
     #[inline(always)]
-    pub fn amm_owner_account(
-        &mut self,
-        amm_owner_account: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn amm_owner_account(&mut self, amm_owner_account: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_owner_account = Some(amm_owner_account);
         self
     }
     #[inline(always)]
-    pub fn amm_authority(&mut self, amm_authority: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn amm_authority(&mut self, amm_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn srm_token(&mut self, srm_token: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn srm_token(&mut self, srm_token: solana_pubkey::Pubkey) -> &mut Self {
         self.srm_token = Some(srm_token);
         self
     }
     #[inline(always)]
-    pub fn dest_srm_token(&mut self, dest_srm_token: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn dest_srm_token(&mut self, dest_srm_token: solana_pubkey::Pubkey) -> &mut Self {
         self.dest_srm_token = Some(dest_srm_token);
         self
     }
@@ -166,10 +157,7 @@ impl WithdrawSrmBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -177,15 +165,15 @@ impl WithdrawSrmBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = WithdrawSrm {
-            token_program: self.token_program.unwrap_or(solana_program::pubkey!(
+            token_program: self.token_program.unwrap_or(solana_pubkey::pubkey!(
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
             )),
             amm: self.amm.expect("amm is not set"),
@@ -206,42 +194,42 @@ impl WithdrawSrmBuilder {
 
 /// `withdraw_srm` CPI accounts.
 pub struct WithdrawSrmCpiAccounts<'a, 'b> {
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_owner_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub srm_token: &'b solana_program::account_info::AccountInfo<'a>,
+    pub srm_token: &'b solana_account_info::AccountInfo<'a>,
 
-    pub dest_srm_token: &'b solana_program::account_info::AccountInfo<'a>,
+    pub dest_srm_token: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `withdraw_srm` CPI instruction.
 pub struct WithdrawSrmCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_owner_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub amm_authority: &'b solana_account_info::AccountInfo<'a>,
 
-    pub srm_token: &'b solana_program::account_info::AccountInfo<'a>,
+    pub srm_token: &'b solana_account_info::AccountInfo<'a>,
 
-    pub dest_srm_token: &'b solana_program::account_info::AccountInfo<'a>,
+    pub dest_srm_token: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: WithdrawSrmInstructionArgs,
 }
 
 impl<'a, 'b> WithdrawSrmCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: WithdrawSrmCpiAccounts<'a, 'b>,
         args: WithdrawSrmInstructionArgs,
     ) -> Self {
@@ -257,25 +245,21 @@ impl<'a, 'b> WithdrawSrmCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -284,39 +268,35 @@ impl<'a, 'b> WithdrawSrmCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.token_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_owner_account.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.amm_authority.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.srm_token.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.dest_srm_token.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -326,7 +306,7 @@ impl<'a, 'b> WithdrawSrmCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::RAYDIUM_AMM_ID,
             accounts,
             data,
@@ -344,9 +324,9 @@ impl<'a, 'b> WithdrawSrmCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -367,7 +347,7 @@ pub struct WithdrawSrmCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> WithdrawSrmCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(WithdrawSrmCpiBuilderInstruction {
             __program: program,
             token_program: None,
@@ -384,20 +364,20 @@ impl<'a, 'b> WithdrawSrmCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'b solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
     }
     #[inline(always)]
-    pub fn amm(&mut self, amm: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn amm(&mut self, amm: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.amm = Some(amm);
         self
     }
     #[inline(always)]
     pub fn amm_owner_account(
         &mut self,
-        amm_owner_account: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_owner_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_owner_account = Some(amm_owner_account);
         self
@@ -405,23 +385,20 @@ impl<'a, 'b> WithdrawSrmCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn amm_authority(
         &mut self,
-        amm_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        amm_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.amm_authority = Some(amm_authority);
         self
     }
     #[inline(always)]
-    pub fn srm_token(
-        &mut self,
-        srm_token: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn srm_token(&mut self, srm_token: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.srm_token = Some(srm_token);
         self
     }
     #[inline(always)]
     pub fn dest_srm_token(
         &mut self,
-        dest_srm_token: &'b solana_program::account_info::AccountInfo<'a>,
+        dest_srm_token: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.dest_srm_token = Some(dest_srm_token);
         self
@@ -435,7 +412,7 @@ impl<'a, 'b> WithdrawSrmCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -451,11 +428,7 @@ impl<'a, 'b> WithdrawSrmCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -463,7 +436,7 @@ impl<'a, 'b> WithdrawSrmCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -471,7 +444,7 @@ impl<'a, 'b> WithdrawSrmCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = WithdrawSrmInstructionArgs {
             amount: self.instruction.amount.clone().expect("amount is not set"),
         };
@@ -512,18 +485,14 @@ impl<'a, 'b> WithdrawSrmCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct WithdrawSrmCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_owner_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    amm_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    srm_token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    dest_srm_token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    token_program: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_owner_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    amm_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
+    srm_token: Option<&'b solana_account_info::AccountInfo<'a>>,
+    dest_srm_token: Option<&'b solana_account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/programs.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/programs.rs
@@ -5,7 +5,7 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
-use solana_program::{pubkey, pubkey::Pubkey};
+use solana_pubkey::{pubkey, Pubkey};
 
 /// `raydium_amm` program ID.
 pub const RAYDIUM_AMM_ID: Pubkey = pubkey!("675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8");

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/shared.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/shared.rs
@@ -8,8 +8,8 @@
 #[cfg(feature = "fetch")]
 #[derive(Debug, Clone)]
 pub struct DecodedAccount<T> {
-    pub address: solana_program::pubkey::Pubkey,
-    pub account: solana_sdk::account::Account,
+    pub address: solana_pubkey::Pubkey,
+    pub account: solana_account::Account,
     pub data: T,
 }
 
@@ -17,5 +17,5 @@ pub struct DecodedAccount<T> {
 #[derive(Debug, Clone)]
 pub enum MaybeAccount<T> {
     Exists(DecodedAccount<T>),
-    NotFound(solana_program::pubkey::Pubkey),
+    NotFound(solana_pubkey::Pubkey),
 }

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/types/withdraw_dest_token.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/generated_sdk/types/withdraw_dest_token.rs
@@ -7,7 +7,7 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/lib.rs
+++ b/packages/renderers-vixen-parser/e2e/raydium-amm-v4-parser/src/lib.rs
@@ -3,7 +3,7 @@ mod generated_sdk;
 pub use generated::*;
 pub use generated_parser::*;
 use generated_sdk as generated;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 pub const ID: Pubkey = RAYDIUM_AMM_ID;
 

--- a/packages/renderers-vixen-parser/e2e/system-parser/Cargo.lock
+++ b/packages/renderers-vixen-parser/e2e/system-parser/Cargo.lock
@@ -45,18 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,12 +162,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -198,29 +180,6 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-
-[[package]]
-name = "blake3"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -315,33 +274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "bv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8834bb1d8ee5dc048ee3124f2c7c1afcc6bc9aed03f11e9dfd8c69470a5db340"
-dependencies = [
- "feature-probe",
- "serde",
-]
-
-[[package]]
-name = "bytemuck"
-version = "1.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,32 +303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "console_log"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89f72f65e8501878b8a004d5a1afb780987e2ce2b4532c562e367a72c57499f"
-dependencies = [
- "log",
- "web-sys",
-]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,12 +319,6 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -439,9 +339,9 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
- "rand_core 0.6.4",
+ "rand_core",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -460,22 +360,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -505,12 +395,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "feature-probe"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "fiat-crypto"
@@ -602,17 +486,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -854,71 +727,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "libsecp256k1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
-dependencies = [
- "arrayref",
- "base64 0.12.3",
- "digest 0.9.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
-dependencies = [
- "libsecp256k1-core",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -955,15 +767,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,16 +799,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,15 +807,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1048,12 +832,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "parking_lot"
@@ -1256,36 +1034,13 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1295,16 +1050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1314,15 +1060,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1419,15 +1156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,36 +1168,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest 0.10.7",
- "keccak",
+ "digest",
 ]
 
 [[package]]
@@ -1504,46 +1209,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-account"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f949fe4edaeaea78c844023bfc1c898e0b1f5a100f8a8d2d0f85d0a7b090258"
-dependencies = [
- "solana-account-info",
- "solana-clock",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
 name = "solana-account-info"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c17d606a298a205fae325489fbed88ee6dc4463c111672172327e741c8905d"
+checksum = "c8f5152a288ef1912300fc6efa6c2d1f9bb55d9398eb6c72326360b8063987da"
 dependencies = [
- "bincode",
- "serde",
  "solana-program-error",
  "solana-program-memory",
  "solana-pubkey",
-]
-
-[[package]]
-name = "solana-address-lookup-table-interface"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1673f67efe870b64a65cb39e6194be5b26527691ce5922909939961a6e6b395"
-dependencies = [
- "bincode",
- "bytemuck",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-slot-hashes",
 ]
 
 [[package]]
@@ -1553,63 +1226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52e52720efe60465b052b9e7445a01c17550666beec855cce66f44766697bc2"
 dependencies = [
  "parking_lot",
-]
-
-[[package]]
-name = "solana-big-mod-exp"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db7f2bbac3e62cfd139065d15bcda9e2428883ba61fc8d27ccb251081e7567"
-dependencies = [
- "num-bigint",
- "num-traits",
- "solana-define-syscall",
-]
-
-[[package]]
-name = "solana-bincode"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a3787b8cf9c9fe3dd360800e8b70982b9e5a8af9e11c354b6665dd4a003adc"
-dependencies = [
- "bincode",
- "serde",
- "solana-instruction",
-]
-
-[[package]]
-name = "solana-blake3-hasher"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0801e25a1b31a14494fc80882a036be0ffd290efc4c2d640bfcca120a4672"
-dependencies = [
- "blake3",
- "solana-define-syscall",
- "solana-hash",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-borsh"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718333bcd0a1a7aed6655aa66bef8d7fb047944922b2d3a18f49cbc13e73d004"
-dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.7",
-]
-
-[[package]]
-name = "solana-clock"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c2177a1b9fe8326004f1151a5acd124420b737811080b1035df31349e4d892"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
 ]
 
 [[package]]
@@ -1642,96 +1258,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf784bb2cb3e02cac9801813c30187344228d2ae952534902108f6150573a33d"
 
 [[package]]
-name = "solana-epoch-rewards"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b575d3dd323b9ea10bb6fe89bf6bf93e249b215ba8ed7f68f1a3633f384db7"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-hash",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-epoch-schedule"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce071fbddecc55d727b1d7ed16a629afe4f6e4c217bc8d00af3b785f6f67ed"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-example-mocks"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84461d56cbb8bb8d539347151e0525b53910102e4bced875d49d5139708e39d3"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-address-lookup-table-interface",
- "solana-clock",
- "solana-hash",
- "solana-instruction",
- "solana-keccak-hasher",
- "solana-message",
- "solana-nonce",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-feature-gate-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9c7fbf3e58b64a667c5f35e90af580538a95daea7001ff7806c0662d301bdf"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-fee-calculator"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89bc408da0fb3812bc3008189d148b4d3e08252c79ad810b245482a3f70cd8d"
-dependencies = [
- "log",
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "solana-hash"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf7bcb14392900fe02e4e34e90234fbf0c673d4e327888410ba99fa2ba0f4e99"
 dependencies = [
- "borsh 1.5.7",
  "bs58",
- "bytemuck",
- "bytemuck_derive",
  "js-sys",
- "serde",
- "serde_derive",
  "solana-atomic-u64",
  "solana-sanitize",
  "wasm-bindgen",
@@ -1743,124 +1276,11 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce496a475e5062ba5de97215ab39d9c358f9c9df4bb7f3a45a1f1a8bd9065ed"
 dependencies = [
- "bincode",
- "borsh 1.5.7",
  "getrandom 0.2.16",
  "js-sys",
  "num-traits",
- "serde",
- "serde_derive",
  "solana-define-syscall",
  "solana-pubkey",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-instructions-sysvar"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427f2d0d6dc0bb49f16cef5e7f975180d2e80aab9bdd3b2af68e2d029ec63f43"
-dependencies = [
- "bitflags",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-serialize-utils",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-keccak-hasher"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7aeb957fbd42a451b99235df4942d96db7ef678e8d5061ef34c9b34cae12f79"
-dependencies = [
- "sha3",
- "solana-define-syscall",
- "solana-hash",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-last-restart-slot"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6360ac2fdc72e7463565cd256eedcf10d7ef0c28a1249d261ec168c1b55cdd"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-loader-v2-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ab08006dad78ae7cd30df8eea0539e207d08d91eaefb3e1d49a446e1c49654"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-loader-v3-interface"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4be76cfa9afd84ca2f35ebc09f0da0f0092935ccdac0595d98447f259538c2"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-loader-v4-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706a777242f1f39a83e2a96a2a6cb034cb41169c6ecbee2cf09cb873d9659e7e"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-message"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6bf99c4570173710107a1f233f3bee226feea5fc817308707d4f7cb100a72d"
-dependencies = [
- "bincode",
- "blake3",
- "lazy_static",
- "serde",
- "serde_derive",
- "solana-bincode",
- "solana-hash",
- "solana-instruction",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-short-vec",
- "solana-system-interface",
- "solana-transaction-error",
  "wasm-bindgen",
 ]
 
@@ -1874,110 +1294,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-native-token"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307fb2f78060995979e9b4f68f833623565ed4e55d3725f100454ce78a99a1a3"
-
-[[package]]
-name = "solana-nonce"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703e22eb185537e06204a5bd9d509b948f0066f2d1d814a6f475dafb3ddf1325"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-fee-calculator",
- "solana-hash",
- "solana-pubkey",
- "solana-sha256-hasher",
-]
-
-[[package]]
-name = "solana-program"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "586469467e93ceb79048f8d8e3a619bf61d05396ee7de95cb40280301a589d05"
-dependencies = [
- "bincode",
- "blake3",
- "borsh 0.10.4",
- "borsh 1.5.7",
- "bs58",
- "bytemuck",
- "console_error_panic_hook",
- "console_log",
- "getrandom 0.2.16",
- "lazy_static",
- "log",
- "memoffset",
- "num-bigint",
- "num-derive",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-account-info",
- "solana-address-lookup-table-interface",
- "solana-atomic-u64",
- "solana-big-mod-exp",
- "solana-bincode",
- "solana-blake3-hasher",
- "solana-borsh",
- "solana-clock",
- "solana-cpi",
- "solana-decode-error",
- "solana-define-syscall",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-example-mocks",
- "solana-feature-gate-interface",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-keccak-hasher",
- "solana-last-restart-slot",
- "solana-loader-v2-interface",
- "solana-loader-v3-interface",
- "solana-loader-v4-interface",
- "solana-message",
- "solana-msg",
- "solana-native-token",
- "solana-nonce",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-secp256k1-recover",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-sha256-hasher",
- "solana-short-vec",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stable-layout",
- "solana-stake-interface",
- "solana-system-interface",
- "solana-sysvar",
- "solana-sysvar-id",
- "solana-vote-interface",
- "thiserror 2.0.12",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "solana-program-entrypoint"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473ffe73c68d93e9f2aa726ad2985fe52760052709aaab188100a42c618060ec"
+checksum = "32ce041b1a0ed275290a5008ee1a4a6c48f5054c8a3d78d313c08958a06aedbd"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -1991,10 +1311,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8ae2c1a8d0d4ae865882d5770a7ebca92bab9c685e43f0461682c6c05a35bfa"
 dependencies = [
- "borsh 1.5.7",
  "num-traits",
- "serde",
- "serde_derive",
  "solana-decode-error",
  "solana-instruction",
  "solana-msg",
@@ -2003,27 +1320,11 @@ dependencies = [
 
 [[package]]
 name = "solana-program-memory"
-version = "2.2.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0268f6c89825fb634a34bd0c3b8fdaeaecfc3728be1d622a8ee6dd577b60d4"
+checksum = "3a5426090c6f3fd6cfdc10685322fede9ca8e5af43cd6a59e98bfe4e91671712"
 dependencies = [
- "num-traits",
  "solana-define-syscall",
-]
-
-[[package]]
-name = "solana-program-option"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc677a2e9bc616eda6dbdab834d463372b92848b2bfe4a1ed4e4b4adba3397d0"
-
-[[package]]
-name = "solana-program-pack"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319f0ef15e6e12dc37c597faccb7d62525a509fec5f6975ecb9419efddeb277b"
-dependencies = [
- "solana-program-error",
 ]
 
 [[package]]
@@ -2035,15 +1336,11 @@ dependencies = [
  "borsh 0.10.4",
  "borsh 1.5.7",
  "bs58",
- "bytemuck",
- "bytemuck_derive",
  "curve25519-dalek",
  "five8_const",
  "getrandom 0.2.16",
  "js-sys",
  "num-traits",
- "serde",
- "serde_derive",
  "solana-atomic-u64",
  "solana-decode-error",
  "solana-define-syscall",
@@ -2053,75 +1350,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-rent"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1aea8fdea9de98ca6e8c2da5827707fb3842833521b528a713810ca685d2480"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
 name = "solana-sanitize"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
-
-[[package]]
-name = "solana-sdk-ids"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5d8b9cc68d5c88b062a33e23a6466722467dde0035152d8fb1afbcdf350a5f"
-dependencies = [
- "solana-pubkey",
-]
-
-[[package]]
-name = "solana-sdk-macro"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86280da8b99d03560f6ab5aca9de2e38805681df34e0bb8f238e69b29433b9df"
-dependencies = [
- "bs58",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "solana-secp256k1-recover"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa3120b6cdaa270f39444f5093a90a7b03d296d362878f7a6991d6de3bbe496"
-dependencies = [
- "libsecp256k1",
- "solana-define-syscall",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-serde-varint"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc07d00200d82e6def2f7f7a45738e3406b17fe54a18adcf0defa16a97ccadb"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "solana-serialize-utils"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817a284b63197d2b27afdba829c5ab34231da4a9b4e763466a003c40ca4f535e"
-dependencies = [
- "solana-instruction",
- "solana-pubkey",
- "solana-sanitize",
-]
 
 [[package]]
 name = "solana-sha256-hasher"
@@ -2129,44 +1361,9 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0037386961c0d633421f53560ad7c80675c0447cba4d1bb66d60974dd486c7ea"
 dependencies = [
- "sha2 0.10.9",
+ "sha2",
  "solana-define-syscall",
  "solana-hash",
-]
-
-[[package]]
-name = "solana-short-vec"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c54c66f19b9766a56fa0057d060de8378676cb64987533fa088861858fc5a69"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "solana-slot-hashes"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8691982114513763e88d04094c9caa0376b867a29577939011331134c301ce"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-hash",
- "solana-sdk-ids",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-slot-history"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ccc1b2067ca22754d5283afb2b0126d61eae734fc616d23871b0943b0d935e"
-dependencies = [
- "bv",
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sysvar-id",
 ]
 
 [[package]]
@@ -2177,124 +1374,6 @@ checksum = "9f14f7d02af8f2bc1b5efeeae71bc1c2b7f0f65cd75bcc7d8180f2c762a57f54"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
-]
-
-[[package]]
-name = "solana-stake-interface"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5269e89fde216b4d7e1d1739cf5303f8398a1ff372a81232abbee80e554a838c"
-dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.7",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-system-interface",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-system-interface"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7c18cb1a91c6be5f5a8ac9276a1d7c737e39a21beba9ea710ab4b9c63bc90"
-dependencies = [
- "js-sys",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-decode-error",
- "solana-instruction",
- "solana-pubkey",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-sysvar"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6b44740d7f0c9f375d045c165bc0aab4a90658f92d6835aeb0649afaeaff9a"
-dependencies = [
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "lazy_static",
- "serde",
- "serde_derive",
- "solana-account-info",
- "solana-clock",
- "solana-define-syscall",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-last-restart-slot",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stake-interface",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-sysvar-id"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5762b273d3325b047cfda250787f8d796d781746860d5d0a746ee29f3e8812c1"
-dependencies = [
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-transaction-error"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a9dc8fdb61c6088baab34fc3a8b8473a03a7a5fd404ed8dd502fa79b67cb1"
-dependencies = [
- "solana-instruction",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-vote-interface"
-version = "2.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f039b0788337bedc6c5450d2f237718f938defb5ce0e0ad8ef507e78dcd370"
-dependencies = [
- "bincode",
- "num-derive",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-decode-error",
- "solana-hash",
- "solana-instruction",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-short-vec",
- "solana-system-interface",
 ]
 
 [[package]]
@@ -2369,16 +1448,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2386,17 +1456,6 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2480,15 +1539,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.9.0",
  "toml_datetime",
@@ -2504,7 +1563,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "flate2",
  "h2",
@@ -2552,7 +1611,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -2653,12 +1712,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2728,16 +1781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2824,9 +1867,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -2860,7 +1903,7 @@ version = "0.3.0"
 source = "git+https://github.com/rpcpool/yellowstone-vixen?branch=main#05ba40b34045f19ef81bfaf1d1ea6865590acb0c"
 dependencies = [
  "bs58",
- "thiserror 1.0.69",
+ "thiserror",
  "yellowstone-grpc-proto",
  "yellowstone-vixen-proto",
 ]
@@ -2882,10 +1925,17 @@ dependencies = [
  "num-traits",
  "prost",
  "prost-build",
- "solana-program",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey",
  "strum",
  "strum_macros",
- "thiserror 1.0.69",
+ "thiserror",
  "tonic",
  "tracing",
  "yellowstone-vixen-core",

--- a/packages/renderers-vixen-parser/e2e/system-parser/Cargo.toml
+++ b/packages/renderers-vixen-parser/e2e/system-parser/Cargo.toml
@@ -9,7 +9,14 @@ edition = "2021"
 [dependencies]
 prost = "0.13.1"
 tonic = { version = "0.12.1", features = ["gzip", "zstd"] }
-solana-program = "^2.1.6"
+solana-account-info = "2.2.1"
+solana-cpi = "2.2.1"
+solana-decode-error = "2.2.1"
+solana-pubkey = { version = "2.2.1", features = ["curve25519", "borsh"] }
+solana-instruction = "2.2.1"
+solana-msg = "2.2.1"
+solana-program-entrypoint = "2.2.1"
+solana-program-error = "2.2.1"
 borsh = "^0.10"
 yellowstone-vixen-core = { git = "https://github.com/rpcpool/yellowstone-vixen", branch = "main",features = ["proto"] }
 num-derive = "0.4"

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_parser/accounts_parser.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_parser/accounts_parser.rs
@@ -79,7 +79,7 @@ impl yellowstone_vixen_core::Parser for AccountParser {
         let inner = acct
             .account
             .as_ref()
-            .ok_or(solana_program::program_error::ProgramError::InvalidArgument)?;
+            .ok_or(solana_program_error::ProgramError::InvalidArgument)?;
         SystemProgramState::try_unpack(&inner.data)
     }
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/accounts/nonce.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/accounts/nonce.rs
@@ -9,7 +9,7 @@ use crate::generated::types::NonceState;
 use crate::generated::types::NonceVersion;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -39,12 +39,10 @@ impl Nonce {
     }
 }
 
-impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Nonce {
+impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for Nonce {
     type Error = std::io::Error;
 
-    fn try_from(
-        account_info: &solana_program::account_info::AccountInfo<'a>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)
     }
@@ -53,7 +51,7 @@ impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Nonce {
 #[cfg(feature = "fetch")]
 pub fn fetch_nonce(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::DecodedAccount<Nonce>, std::io::Error> {
     let accounts = fetch_all_nonce(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -62,7 +60,7 @@ pub fn fetch_nonce(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_nonce(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::DecodedAccount<Nonce>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
@@ -87,7 +85,7 @@ pub fn fetch_all_nonce(
 #[cfg(feature = "fetch")]
 pub fn fetch_maybe_nonce(
     rpc: &solana_client::rpc_client::RpcClient,
-    address: &solana_program::pubkey::Pubkey,
+    address: &solana_pubkey::Pubkey,
 ) -> Result<crate::shared::MaybeAccount<Nonce>, std::io::Error> {
     let accounts = fetch_all_maybe_nonce(rpc, &[*address])?;
     Ok(accounts[0].clone())
@@ -96,7 +94,7 @@ pub fn fetch_maybe_nonce(
 #[cfg(feature = "fetch")]
 pub fn fetch_all_maybe_nonce(
     rpc: &solana_client::rpc_client::RpcClient,
-    addresses: &[solana_program::pubkey::Pubkey],
+    addresses: &[solana_pubkey::Pubkey],
 ) -> Result<Vec<crate::shared::MaybeAccount<Nonce>>, std::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/errors/system.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/errors/system.rs
@@ -39,13 +39,13 @@ pub enum SystemError {
     NonceUnexpectedBlockhashValue = 0x8,
 }
 
-impl solana_program::program_error::PrintProgramError for SystemError {
+impl solana_program_error::PrintProgramError for SystemError {
     fn print<E>(&self) {
-        solana_program::msg!(&self.to_string());
+        solana_msg::msg!(&self.to_string());
     }
 }
 
-impl<T> solana_program::decode_error::DecodeError<T> for SystemError {
+impl<T> solana_decode_error::DecodeError<T> for SystemError {
     fn type_of() -> &'static str {
         "SystemError"
     }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/advance_nonce_account.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/advance_nonce_account.rs
@@ -11,40 +11,40 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct AdvanceNonceAccount {
-    pub nonce_account: solana_program::pubkey::Pubkey,
+    pub nonce_account: solana_pubkey::Pubkey,
 
-    pub recent_blockhashes_sysvar: solana_program::pubkey::Pubkey,
+    pub recent_blockhashes_sysvar: solana_pubkey::Pubkey,
 
-    pub nonce_authority: solana_program::pubkey::Pubkey,
+    pub nonce_authority: solana_pubkey::Pubkey,
 }
 
 impl AdvanceNonceAccount {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.nonce_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.recent_blockhashes_sysvar,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.nonce_authority,
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&AdvanceNonceAccountInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -79,10 +79,10 @@ impl Default for AdvanceNonceAccountInstructionData {
 ///   2. `[signer]` nonce_authority
 #[derive(Clone, Debug, Default)]
 pub struct AdvanceNonceAccountBuilder {
-    nonce_account: Option<solana_program::pubkey::Pubkey>,
-    recent_blockhashes_sysvar: Option<solana_program::pubkey::Pubkey>,
-    nonce_authority: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    nonce_account: Option<solana_pubkey::Pubkey>,
+    recent_blockhashes_sysvar: Option<solana_pubkey::Pubkey>,
+    nonce_authority: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl AdvanceNonceAccountBuilder {
@@ -90,7 +90,7 @@ impl AdvanceNonceAccountBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn nonce_account(&mut self, nonce_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn nonce_account(&mut self, nonce_account: solana_pubkey::Pubkey) -> &mut Self {
         self.nonce_account = Some(nonce_account);
         self
     }
@@ -98,25 +98,19 @@ impl AdvanceNonceAccountBuilder {
     #[inline(always)]
     pub fn recent_blockhashes_sysvar(
         &mut self,
-        recent_blockhashes_sysvar: solana_program::pubkey::Pubkey,
+        recent_blockhashes_sysvar: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.recent_blockhashes_sysvar = Some(recent_blockhashes_sysvar);
         self
     }
     #[inline(always)]
-    pub fn nonce_authority(
-        &mut self,
-        nonce_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn nonce_authority(&mut self, nonce_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.nonce_authority = Some(nonce_authority);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -124,17 +118,17 @@ impl AdvanceNonceAccountBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = AdvanceNonceAccount {
             nonce_account: self.nonce_account.expect("nonce_account is not set"),
             recent_blockhashes_sysvar: self.recent_blockhashes_sysvar.unwrap_or(
-                solana_program::pubkey!("SysvarRecentB1ockHashes11111111111111111111"),
+                solana_pubkey::pubkey!("SysvarRecentB1ockHashes11111111111111111111"),
             ),
             nonce_authority: self.nonce_authority.expect("nonce_authority is not set"),
         };
@@ -145,28 +139,28 @@ impl AdvanceNonceAccountBuilder {
 
 /// `advance_nonce_account` CPI accounts.
 pub struct AdvanceNonceAccountCpiAccounts<'a, 'b> {
-    pub nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub recent_blockhashes_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+    pub recent_blockhashes_sysvar: &'b solana_account_info::AccountInfo<'a>,
 
-    pub nonce_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `advance_nonce_account` CPI instruction.
 pub struct AdvanceNonceAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub recent_blockhashes_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+    pub recent_blockhashes_sysvar: &'b solana_account_info::AccountInfo<'a>,
 
-    pub nonce_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> AdvanceNonceAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: AdvanceNonceAccountCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -177,25 +171,21 @@ impl<'a, 'b> AdvanceNonceAccountCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -204,27 +194,23 @@ impl<'a, 'b> AdvanceNonceAccountCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.nonce_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.recent_blockhashes_sysvar.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.nonce_authority.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -232,7 +218,7 @@ impl<'a, 'b> AdvanceNonceAccountCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&AdvanceNonceAccountInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -247,9 +233,9 @@ impl<'a, 'b> AdvanceNonceAccountCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -267,7 +253,7 @@ pub struct AdvanceNonceAccountCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> AdvanceNonceAccountCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(AdvanceNonceAccountCpiBuilderInstruction {
             __program: program,
             nonce_account: None,
@@ -280,7 +266,7 @@ impl<'a, 'b> AdvanceNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn nonce_account(
         &mut self,
-        nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+        nonce_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.nonce_account = Some(nonce_account);
         self
@@ -288,7 +274,7 @@ impl<'a, 'b> AdvanceNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn recent_blockhashes_sysvar(
         &mut self,
-        recent_blockhashes_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+        recent_blockhashes_sysvar: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.recent_blockhashes_sysvar = Some(recent_blockhashes_sysvar);
         self
@@ -296,7 +282,7 @@ impl<'a, 'b> AdvanceNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn nonce_authority(
         &mut self,
-        nonce_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        nonce_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.nonce_authority = Some(nonce_authority);
         self
@@ -305,7 +291,7 @@ impl<'a, 'b> AdvanceNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -321,11 +307,7 @@ impl<'a, 'b> AdvanceNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -333,7 +315,7 @@ impl<'a, 'b> AdvanceNonceAccountCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -341,7 +323,7 @@ impl<'a, 'b> AdvanceNonceAccountCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = AdvanceNonceAccountCpi {
             __program: self.instruction.__program,
 
@@ -369,14 +351,10 @@ impl<'a, 'b> AdvanceNonceAccountCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct AdvanceNonceAccountCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    nonce_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    recent_blockhashes_sysvar: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    nonce_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    nonce_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    recent_blockhashes_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
+    nonce_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/allocate.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/allocate.rs
@@ -11,14 +11,11 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct Allocate {
-    pub new_account: solana_program::pubkey::Pubkey,
+    pub new_account: solana_pubkey::Pubkey,
 }
 
 impl Allocate {
-    pub fn instruction(
-        &self,
-        args: AllocateInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: AllocateInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -26,19 +23,16 @@ impl Allocate {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: AllocateInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.new_account,
-            true,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.new_account, true));
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&AllocateInstructionData::new()).unwrap();
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -77,9 +71,9 @@ pub struct AllocateInstructionArgs {
 ///   0. `[writable, signer]` new_account
 #[derive(Clone, Debug, Default)]
 pub struct AllocateBuilder {
-    new_account: Option<solana_program::pubkey::Pubkey>,
+    new_account: Option<solana_pubkey::Pubkey>,
     space: Option<u64>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl AllocateBuilder {
@@ -87,7 +81,7 @@ impl AllocateBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn new_account(&mut self, new_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn new_account(&mut self, new_account: solana_pubkey::Pubkey) -> &mut Self {
         self.new_account = Some(new_account);
         self
     }
@@ -98,10 +92,7 @@ impl AllocateBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -109,13 +100,13 @@ impl AllocateBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = Allocate {
             new_account: self.new_account.expect("new_account is not set"),
         };
@@ -129,22 +120,22 @@ impl AllocateBuilder {
 
 /// `allocate` CPI accounts.
 pub struct AllocateCpiAccounts<'a, 'b> {
-    pub new_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_account: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `allocate` CPI instruction.
 pub struct AllocateCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_account: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: AllocateInstructionArgs,
 }
 
 impl<'a, 'b> AllocateCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: AllocateCpiAccounts<'a, 'b>,
         args: AllocateInstructionArgs,
     ) -> Self {
@@ -155,25 +146,21 @@ impl<'a, 'b> AllocateCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -182,19 +169,15 @@ impl<'a, 'b> AllocateCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.new_account.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -204,7 +187,7 @@ impl<'a, 'b> AllocateCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -217,9 +200,9 @@ impl<'a, 'b> AllocateCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -235,7 +218,7 @@ pub struct AllocateCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> AllocateCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(AllocateCpiBuilderInstruction {
             __program: program,
             new_account: None,
@@ -247,7 +230,7 @@ impl<'a, 'b> AllocateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn new_account(
         &mut self,
-        new_account: &'b solana_program::account_info::AccountInfo<'a>,
+        new_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_account = Some(new_account);
         self
@@ -261,7 +244,7 @@ impl<'a, 'b> AllocateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -277,11 +260,7 @@ impl<'a, 'b> AllocateCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -289,7 +268,7 @@ impl<'a, 'b> AllocateCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -297,7 +276,7 @@ impl<'a, 'b> AllocateCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = AllocateInstructionArgs {
             space: self.instruction.space.clone().expect("space is not set"),
         };
@@ -319,13 +298,9 @@ impl<'a, 'b> AllocateCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct AllocateCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    new_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    new_account: Option<&'b solana_account_info::AccountInfo<'a>>,
     space: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/allocate_with_seed.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/allocate_with_seed.rs
@@ -7,21 +7,21 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 /// Accounts.
 #[derive(Debug)]
 pub struct AllocateWithSeed {
-    pub new_account: solana_program::pubkey::Pubkey,
+    pub new_account: solana_pubkey::Pubkey,
 
-    pub base_account: solana_program::pubkey::Pubkey,
+    pub base_account: solana_pubkey::Pubkey,
 }
 
 impl AllocateWithSeed {
     pub fn instruction(
         &self,
         args: AllocateWithSeedInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -29,14 +29,14 @@ impl AllocateWithSeed {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: AllocateWithSeedInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.new_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.base_account,
             true,
         ));
@@ -45,7 +45,7 @@ impl AllocateWithSeed {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -88,13 +88,13 @@ pub struct AllocateWithSeedInstructionArgs {
 ///   1. `[signer]` base_account
 #[derive(Clone, Debug, Default)]
 pub struct AllocateWithSeedBuilder {
-    new_account: Option<solana_program::pubkey::Pubkey>,
-    base_account: Option<solana_program::pubkey::Pubkey>,
+    new_account: Option<solana_pubkey::Pubkey>,
+    base_account: Option<solana_pubkey::Pubkey>,
     base: Option<Pubkey>,
     seed: Option<String>,
     space: Option<u64>,
     program_address: Option<Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl AllocateWithSeedBuilder {
@@ -102,12 +102,12 @@ impl AllocateWithSeedBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn new_account(&mut self, new_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn new_account(&mut self, new_account: solana_pubkey::Pubkey) -> &mut Self {
         self.new_account = Some(new_account);
         self
     }
     #[inline(always)]
-    pub fn base_account(&mut self, base_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn base_account(&mut self, base_account: solana_pubkey::Pubkey) -> &mut Self {
         self.base_account = Some(base_account);
         self
     }
@@ -133,10 +133,7 @@ impl AllocateWithSeedBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -144,13 +141,13 @@ impl AllocateWithSeedBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = AllocateWithSeed {
             new_account: self.new_account.expect("new_account is not set"),
             base_account: self.base_account.expect("base_account is not set"),
@@ -171,26 +168,26 @@ impl AllocateWithSeedBuilder {
 
 /// `allocate_with_seed` CPI accounts.
 pub struct AllocateWithSeedCpiAccounts<'a, 'b> {
-    pub new_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub base_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub base_account: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `allocate_with_seed` CPI instruction.
 pub struct AllocateWithSeedCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub base_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub base_account: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: AllocateWithSeedInstructionArgs,
 }
 
 impl<'a, 'b> AllocateWithSeedCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: AllocateWithSeedCpiAccounts<'a, 'b>,
         args: AllocateWithSeedInstructionArgs,
     ) -> Self {
@@ -202,25 +199,21 @@ impl<'a, 'b> AllocateWithSeedCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -229,23 +222,19 @@ impl<'a, 'b> AllocateWithSeedCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.new_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.base_account.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -255,7 +244,7 @@ impl<'a, 'b> AllocateWithSeedCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -269,9 +258,9 @@ impl<'a, 'b> AllocateWithSeedCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -288,7 +277,7 @@ pub struct AllocateWithSeedCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> AllocateWithSeedCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(AllocateWithSeedCpiBuilderInstruction {
             __program: program,
             new_account: None,
@@ -304,7 +293,7 @@ impl<'a, 'b> AllocateWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn new_account(
         &mut self,
-        new_account: &'b solana_program::account_info::AccountInfo<'a>,
+        new_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_account = Some(new_account);
         self
@@ -312,7 +301,7 @@ impl<'a, 'b> AllocateWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn base_account(
         &mut self,
-        base_account: &'b solana_program::account_info::AccountInfo<'a>,
+        base_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.base_account = Some(base_account);
         self
@@ -341,7 +330,7 @@ impl<'a, 'b> AllocateWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -357,11 +346,7 @@ impl<'a, 'b> AllocateWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -369,7 +354,7 @@ impl<'a, 'b> AllocateWithSeedCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -377,7 +362,7 @@ impl<'a, 'b> AllocateWithSeedCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = AllocateWithSeedInstructionArgs {
             base: self.instruction.base.clone().expect("base is not set"),
             seed: self.instruction.seed.clone().expect("seed is not set"),
@@ -411,17 +396,13 @@ impl<'a, 'b> AllocateWithSeedCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct AllocateWithSeedCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    new_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    base_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    new_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    base_account: Option<&'b solana_account_info::AccountInfo<'a>>,
     base: Option<Pubkey>,
     seed: Option<String>,
     space: Option<u64>,
     program_address: Option<Pubkey>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/assign.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/assign.rs
@@ -7,19 +7,16 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 /// Accounts.
 #[derive(Debug)]
 pub struct Assign {
-    pub account: solana_program::pubkey::Pubkey,
+    pub account: solana_pubkey::Pubkey,
 }
 
 impl Assign {
-    pub fn instruction(
-        &self,
-        args: AssignInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: AssignInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -27,19 +24,16 @@ impl Assign {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: AssignInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.account,
-            true,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.account, true));
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&AssignInstructionData::new()).unwrap();
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -78,9 +72,9 @@ pub struct AssignInstructionArgs {
 ///   0. `[writable, signer]` account
 #[derive(Clone, Debug, Default)]
 pub struct AssignBuilder {
-    account: Option<solana_program::pubkey::Pubkey>,
+    account: Option<solana_pubkey::Pubkey>,
     program_address: Option<Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl AssignBuilder {
@@ -88,7 +82,7 @@ impl AssignBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn account(&mut self, account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn account(&mut self, account: solana_pubkey::Pubkey) -> &mut Self {
         self.account = Some(account);
         self
     }
@@ -99,10 +93,7 @@ impl AssignBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -110,13 +101,13 @@ impl AssignBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = Assign {
             account: self.account.expect("account is not set"),
         };
@@ -133,22 +124,22 @@ impl AssignBuilder {
 
 /// `assign` CPI accounts.
 pub struct AssignCpiAccounts<'a, 'b> {
-    pub account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub account: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `assign` CPI instruction.
 pub struct AssignCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub account: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: AssignInstructionArgs,
 }
 
 impl<'a, 'b> AssignCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: AssignCpiAccounts<'a, 'b>,
         args: AssignInstructionArgs,
     ) -> Self {
@@ -159,25 +150,21 @@ impl<'a, 'b> AssignCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -186,19 +173,15 @@ impl<'a, 'b> AssignCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.account.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -208,7 +191,7 @@ impl<'a, 'b> AssignCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -221,9 +204,9 @@ impl<'a, 'b> AssignCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -239,7 +222,7 @@ pub struct AssignCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> AssignCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(AssignCpiBuilderInstruction {
             __program: program,
             account: None,
@@ -249,10 +232,7 @@ impl<'a, 'b> AssignCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn account(
-        &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn account(&mut self, account: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.account = Some(account);
         self
     }
@@ -265,7 +245,7 @@ impl<'a, 'b> AssignCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -281,11 +261,7 @@ impl<'a, 'b> AssignCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -293,7 +269,7 @@ impl<'a, 'b> AssignCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -301,7 +277,7 @@ impl<'a, 'b> AssignCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = AssignInstructionArgs {
             program_address: self
                 .instruction
@@ -324,13 +300,9 @@ impl<'a, 'b> AssignCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct AssignCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    account: Option<&'b solana_account_info::AccountInfo<'a>>,
     program_address: Option<Pubkey>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/assign_with_seed.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/assign_with_seed.rs
@@ -7,21 +7,21 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 /// Accounts.
 #[derive(Debug)]
 pub struct AssignWithSeed {
-    pub account: solana_program::pubkey::Pubkey,
+    pub account: solana_pubkey::Pubkey,
 
-    pub base_account: solana_program::pubkey::Pubkey,
+    pub base_account: solana_pubkey::Pubkey,
 }
 
 impl AssignWithSeed {
     pub fn instruction(
         &self,
         args: AssignWithSeedInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -29,14 +29,11 @@ impl AssignWithSeed {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: AssignWithSeedInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.account,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.account, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.base_account,
             true,
         ));
@@ -45,7 +42,7 @@ impl AssignWithSeed {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -89,12 +86,12 @@ pub struct AssignWithSeedInstructionArgs {
 ///   1. `[signer]` base_account
 #[derive(Clone, Debug, Default)]
 pub struct AssignWithSeedBuilder {
-    account: Option<solana_program::pubkey::Pubkey>,
-    base_account: Option<solana_program::pubkey::Pubkey>,
+    account: Option<solana_pubkey::Pubkey>,
+    base_account: Option<solana_pubkey::Pubkey>,
     base: Option<Pubkey>,
     seed: Option<String>,
     program_address: Option<Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl AssignWithSeedBuilder {
@@ -102,12 +99,12 @@ impl AssignWithSeedBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn account(&mut self, account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn account(&mut self, account: solana_pubkey::Pubkey) -> &mut Self {
         self.account = Some(account);
         self
     }
     #[inline(always)]
-    pub fn base_account(&mut self, base_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn base_account(&mut self, base_account: solana_pubkey::Pubkey) -> &mut Self {
         self.base_account = Some(base_account);
         self
     }
@@ -128,10 +125,7 @@ impl AssignWithSeedBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -139,13 +133,13 @@ impl AssignWithSeedBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = AssignWithSeed {
             account: self.account.expect("account is not set"),
             base_account: self.base_account.expect("base_account is not set"),
@@ -165,26 +159,26 @@ impl AssignWithSeedBuilder {
 
 /// `assign_with_seed` CPI accounts.
 pub struct AssignWithSeedCpiAccounts<'a, 'b> {
-    pub account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub base_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub base_account: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `assign_with_seed` CPI instruction.
 pub struct AssignWithSeedCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub base_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub base_account: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: AssignWithSeedInstructionArgs,
 }
 
 impl<'a, 'b> AssignWithSeedCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: AssignWithSeedCpiAccounts<'a, 'b>,
         args: AssignWithSeedInstructionArgs,
     ) -> Self {
@@ -196,25 +190,21 @@ impl<'a, 'b> AssignWithSeedCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -223,23 +213,19 @@ impl<'a, 'b> AssignWithSeedCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.base_account.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -249,7 +235,7 @@ impl<'a, 'b> AssignWithSeedCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -263,9 +249,9 @@ impl<'a, 'b> AssignWithSeedCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -282,7 +268,7 @@ pub struct AssignWithSeedCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> AssignWithSeedCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(AssignWithSeedCpiBuilderInstruction {
             __program: program,
             account: None,
@@ -295,17 +281,14 @@ impl<'a, 'b> AssignWithSeedCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn account(
-        &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn account(&mut self, account: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.account = Some(account);
         self
     }
     #[inline(always)]
     pub fn base_account(
         &mut self,
-        base_account: &'b solana_program::account_info::AccountInfo<'a>,
+        base_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.base_account = Some(base_account);
         self
@@ -329,7 +312,7 @@ impl<'a, 'b> AssignWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -345,11 +328,7 @@ impl<'a, 'b> AssignWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -357,7 +336,7 @@ impl<'a, 'b> AssignWithSeedCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -365,7 +344,7 @@ impl<'a, 'b> AssignWithSeedCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = AssignWithSeedInstructionArgs {
             base: self.instruction.base.clone().expect("base is not set"),
             seed: self.instruction.seed.clone().expect("seed is not set"),
@@ -395,16 +374,12 @@ impl<'a, 'b> AssignWithSeedCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct AssignWithSeedCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    base_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    base_account: Option<&'b solana_account_info::AccountInfo<'a>>,
     base: Option<Pubkey>,
     seed: Option<String>,
     program_address: Option<Pubkey>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/authorize_nonce_account.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/authorize_nonce_account.rs
@@ -7,21 +7,21 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 /// Accounts.
 #[derive(Debug)]
 pub struct AuthorizeNonceAccount {
-    pub nonce_account: solana_program::pubkey::Pubkey,
+    pub nonce_account: solana_pubkey::Pubkey,
 
-    pub nonce_authority: solana_program::pubkey::Pubkey,
+    pub nonce_authority: solana_pubkey::Pubkey,
 }
 
 impl AuthorizeNonceAccount {
     pub fn instruction(
         &self,
         args: AuthorizeNonceAccountInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -29,14 +29,14 @@ impl AuthorizeNonceAccount {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: AuthorizeNonceAccountInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.nonce_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.nonce_authority,
             true,
         ));
@@ -45,7 +45,7 @@ impl AuthorizeNonceAccount {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -85,10 +85,10 @@ pub struct AuthorizeNonceAccountInstructionArgs {
 ///   1. `[signer]` nonce_authority
 #[derive(Clone, Debug, Default)]
 pub struct AuthorizeNonceAccountBuilder {
-    nonce_account: Option<solana_program::pubkey::Pubkey>,
-    nonce_authority: Option<solana_program::pubkey::Pubkey>,
+    nonce_account: Option<solana_pubkey::Pubkey>,
+    nonce_authority: Option<solana_pubkey::Pubkey>,
     new_nonce_authority: Option<Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl AuthorizeNonceAccountBuilder {
@@ -96,15 +96,12 @@ impl AuthorizeNonceAccountBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn nonce_account(&mut self, nonce_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn nonce_account(&mut self, nonce_account: solana_pubkey::Pubkey) -> &mut Self {
         self.nonce_account = Some(nonce_account);
         self
     }
     #[inline(always)]
-    pub fn nonce_authority(
-        &mut self,
-        nonce_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn nonce_authority(&mut self, nonce_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.nonce_authority = Some(nonce_authority);
         self
     }
@@ -115,10 +112,7 @@ impl AuthorizeNonceAccountBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -126,13 +120,13 @@ impl AuthorizeNonceAccountBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = AuthorizeNonceAccount {
             nonce_account: self.nonce_account.expect("nonce_account is not set"),
             nonce_authority: self.nonce_authority.expect("nonce_authority is not set"),
@@ -150,26 +144,26 @@ impl AuthorizeNonceAccountBuilder {
 
 /// `authorize_nonce_account` CPI accounts.
 pub struct AuthorizeNonceAccountCpiAccounts<'a, 'b> {
-    pub nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub nonce_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `authorize_nonce_account` CPI instruction.
 pub struct AuthorizeNonceAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub nonce_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_authority: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: AuthorizeNonceAccountInstructionArgs,
 }
 
 impl<'a, 'b> AuthorizeNonceAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: AuthorizeNonceAccountCpiAccounts<'a, 'b>,
         args: AuthorizeNonceAccountInstructionArgs,
     ) -> Self {
@@ -181,25 +175,21 @@ impl<'a, 'b> AuthorizeNonceAccountCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -208,23 +198,19 @@ impl<'a, 'b> AuthorizeNonceAccountCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.nonce_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.nonce_authority.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -234,7 +220,7 @@ impl<'a, 'b> AuthorizeNonceAccountCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -248,9 +234,9 @@ impl<'a, 'b> AuthorizeNonceAccountCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -267,7 +253,7 @@ pub struct AuthorizeNonceAccountCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> AuthorizeNonceAccountCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(AuthorizeNonceAccountCpiBuilderInstruction {
             __program: program,
             nonce_account: None,
@@ -280,7 +266,7 @@ impl<'a, 'b> AuthorizeNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn nonce_account(
         &mut self,
-        nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+        nonce_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.nonce_account = Some(nonce_account);
         self
@@ -288,7 +274,7 @@ impl<'a, 'b> AuthorizeNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn nonce_authority(
         &mut self,
-        nonce_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        nonce_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.nonce_authority = Some(nonce_authority);
         self
@@ -302,7 +288,7 @@ impl<'a, 'b> AuthorizeNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -318,11 +304,7 @@ impl<'a, 'b> AuthorizeNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -330,7 +312,7 @@ impl<'a, 'b> AuthorizeNonceAccountCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -338,7 +320,7 @@ impl<'a, 'b> AuthorizeNonceAccountCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = AuthorizeNonceAccountInstructionArgs {
             new_nonce_authority: self
                 .instruction
@@ -369,14 +351,10 @@ impl<'a, 'b> AuthorizeNonceAccountCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct AuthorizeNonceAccountCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    nonce_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    nonce_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    nonce_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    nonce_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     new_nonce_authority: Option<Pubkey>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/create_account.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/create_account.rs
@@ -7,21 +7,21 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 /// Accounts.
 #[derive(Debug)]
 pub struct CreateAccount {
-    pub payer: solana_program::pubkey::Pubkey,
+    pub payer: solana_pubkey::Pubkey,
 
-    pub new_account: solana_program::pubkey::Pubkey,
+    pub new_account: solana_pubkey::Pubkey,
 }
 
 impl CreateAccount {
     pub fn instruction(
         &self,
         args: CreateAccountInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -29,22 +29,17 @@ impl CreateAccount {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: CreateAccountInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.payer, true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.new_account,
-            true,
-        ));
+        accounts.push(solana_instruction::AccountMeta::new(self.payer, true));
+        accounts.push(solana_instruction::AccountMeta::new(self.new_account, true));
         accounts.extend_from_slice(remaining_accounts);
         let mut data = borsh::to_vec(&CreateAccountInstructionData::new()).unwrap();
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -86,12 +81,12 @@ pub struct CreateAccountInstructionArgs {
 ///   1. `[writable, signer]` new_account
 #[derive(Clone, Debug, Default)]
 pub struct CreateAccountBuilder {
-    payer: Option<solana_program::pubkey::Pubkey>,
-    new_account: Option<solana_program::pubkey::Pubkey>,
+    payer: Option<solana_pubkey::Pubkey>,
+    new_account: Option<solana_pubkey::Pubkey>,
     lamports: Option<u64>,
     space: Option<u64>,
     program_address: Option<Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl CreateAccountBuilder {
@@ -99,12 +94,12 @@ impl CreateAccountBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn payer(&mut self, payer: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn payer(&mut self, payer: solana_pubkey::Pubkey) -> &mut Self {
         self.payer = Some(payer);
         self
     }
     #[inline(always)]
-    pub fn new_account(&mut self, new_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn new_account(&mut self, new_account: solana_pubkey::Pubkey) -> &mut Self {
         self.new_account = Some(new_account);
         self
     }
@@ -125,10 +120,7 @@ impl CreateAccountBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -136,13 +128,13 @@ impl CreateAccountBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = CreateAccount {
             payer: self.payer.expect("payer is not set"),
             new_account: self.new_account.expect("new_account is not set"),
@@ -162,26 +154,26 @@ impl CreateAccountBuilder {
 
 /// `create_account` CPI accounts.
 pub struct CreateAccountCpiAccounts<'a, 'b> {
-    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_account: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `create_account` CPI instruction.
 pub struct CreateAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_account: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CreateAccountInstructionArgs,
 }
 
 impl<'a, 'b> CreateAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: CreateAccountCpiAccounts<'a, 'b>,
         args: CreateAccountInstructionArgs,
     ) -> Self {
@@ -193,25 +185,21 @@ impl<'a, 'b> CreateAccountCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -220,23 +208,16 @@ impl<'a, 'b> CreateAccountCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.payer.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(*self.payer.key, true));
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.new_account.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -246,7 +227,7 @@ impl<'a, 'b> CreateAccountCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -260,9 +241,9 @@ impl<'a, 'b> CreateAccountCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -279,7 +260,7 @@ pub struct CreateAccountCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> CreateAccountCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateAccountCpiBuilderInstruction {
             __program: program,
             payer: None,
@@ -292,14 +273,14 @@ impl<'a, 'b> CreateAccountCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
     #[inline(always)]
     pub fn new_account(
         &mut self,
-        new_account: &'b solana_program::account_info::AccountInfo<'a>,
+        new_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_account = Some(new_account);
         self
@@ -323,7 +304,7 @@ impl<'a, 'b> CreateAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -339,11 +320,7 @@ impl<'a, 'b> CreateAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -351,7 +328,7 @@ impl<'a, 'b> CreateAccountCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -359,7 +336,7 @@ impl<'a, 'b> CreateAccountCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = CreateAccountInstructionArgs {
             lamports: self
                 .instruction
@@ -393,16 +370,12 @@ impl<'a, 'b> CreateAccountCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct CreateAccountCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    new_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    payer: Option<&'b solana_account_info::AccountInfo<'a>>,
+    new_account: Option<&'b solana_account_info::AccountInfo<'a>>,
     lamports: Option<u64>,
     space: Option<u64>,
     program_address: Option<Pubkey>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/create_account_with_seed.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/create_account_with_seed.rs
@@ -7,23 +7,23 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 /// Accounts.
 #[derive(Debug)]
 pub struct CreateAccountWithSeed {
-    pub payer: solana_program::pubkey::Pubkey,
+    pub payer: solana_pubkey::Pubkey,
 
-    pub new_account: solana_program::pubkey::Pubkey,
+    pub new_account: solana_pubkey::Pubkey,
 
-    pub base_account: solana_program::pubkey::Pubkey,
+    pub base_account: solana_pubkey::Pubkey,
 }
 
 impl CreateAccountWithSeed {
     pub fn instruction(
         &self,
         args: CreateAccountWithSeedInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -31,17 +31,15 @@ impl CreateAccountWithSeed {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: CreateAccountWithSeedInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.payer, true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.payer, true));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.new_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.base_account,
             true,
         ));
@@ -50,7 +48,7 @@ impl CreateAccountWithSeed {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -95,15 +93,15 @@ pub struct CreateAccountWithSeedInstructionArgs {
 ///   2. `[signer]` base_account
 #[derive(Clone, Debug, Default)]
 pub struct CreateAccountWithSeedBuilder {
-    payer: Option<solana_program::pubkey::Pubkey>,
-    new_account: Option<solana_program::pubkey::Pubkey>,
-    base_account: Option<solana_program::pubkey::Pubkey>,
+    payer: Option<solana_pubkey::Pubkey>,
+    new_account: Option<solana_pubkey::Pubkey>,
+    base_account: Option<solana_pubkey::Pubkey>,
     base: Option<Pubkey>,
     seed: Option<String>,
     amount: Option<u64>,
     space: Option<u64>,
     program_address: Option<Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl CreateAccountWithSeedBuilder {
@@ -111,17 +109,17 @@ impl CreateAccountWithSeedBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn payer(&mut self, payer: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn payer(&mut self, payer: solana_pubkey::Pubkey) -> &mut Self {
         self.payer = Some(payer);
         self
     }
     #[inline(always)]
-    pub fn new_account(&mut self, new_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn new_account(&mut self, new_account: solana_pubkey::Pubkey) -> &mut Self {
         self.new_account = Some(new_account);
         self
     }
     #[inline(always)]
-    pub fn base_account(&mut self, base_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn base_account(&mut self, base_account: solana_pubkey::Pubkey) -> &mut Self {
         self.base_account = Some(base_account);
         self
     }
@@ -152,10 +150,7 @@ impl CreateAccountWithSeedBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -163,13 +158,13 @@ impl CreateAccountWithSeedBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = CreateAccountWithSeed {
             payer: self.payer.expect("payer is not set"),
             new_account: self.new_account.expect("new_account is not set"),
@@ -192,30 +187,30 @@ impl CreateAccountWithSeedBuilder {
 
 /// `create_account_with_seed` CPI accounts.
 pub struct CreateAccountWithSeedCpiAccounts<'a, 'b> {
-    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub base_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub base_account: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `create_account_with_seed` CPI instruction.
 pub struct CreateAccountWithSeedCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_account_info::AccountInfo<'a>,
 
-    pub new_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub new_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub base_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub base_account: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CreateAccountWithSeedInstructionArgs,
 }
 
 impl<'a, 'b> CreateAccountWithSeedCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: CreateAccountWithSeedCpiAccounts<'a, 'b>,
         args: CreateAccountWithSeedInstructionArgs,
     ) -> Self {
@@ -228,25 +223,21 @@ impl<'a, 'b> CreateAccountWithSeedCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -255,27 +246,20 @@ impl<'a, 'b> CreateAccountWithSeedCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.payer.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(*self.payer.key, true));
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.new_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.base_account.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -285,7 +269,7 @@ impl<'a, 'b> CreateAccountWithSeedCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -300,9 +284,9 @@ impl<'a, 'b> CreateAccountWithSeedCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -320,7 +304,7 @@ pub struct CreateAccountWithSeedCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> CreateAccountWithSeedCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateAccountWithSeedCpiBuilderInstruction {
             __program: program,
             payer: None,
@@ -336,14 +320,14 @@ impl<'a, 'b> CreateAccountWithSeedCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
     #[inline(always)]
     pub fn new_account(
         &mut self,
-        new_account: &'b solana_program::account_info::AccountInfo<'a>,
+        new_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_account = Some(new_account);
         self
@@ -351,7 +335,7 @@ impl<'a, 'b> CreateAccountWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn base_account(
         &mut self,
-        base_account: &'b solana_program::account_info::AccountInfo<'a>,
+        base_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.base_account = Some(base_account);
         self
@@ -385,7 +369,7 @@ impl<'a, 'b> CreateAccountWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -401,11 +385,7 @@ impl<'a, 'b> CreateAccountWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -413,7 +393,7 @@ impl<'a, 'b> CreateAccountWithSeedCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -421,7 +401,7 @@ impl<'a, 'b> CreateAccountWithSeedCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = CreateAccountWithSeedInstructionArgs {
             base: self.instruction.base.clone().expect("base is not set"),
             seed: self.instruction.seed.clone().expect("seed is not set"),
@@ -458,19 +438,15 @@ impl<'a, 'b> CreateAccountWithSeedCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct CreateAccountWithSeedCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    new_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    base_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    payer: Option<&'b solana_account_info::AccountInfo<'a>>,
+    new_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    base_account: Option<&'b solana_account_info::AccountInfo<'a>>,
     base: Option<Pubkey>,
     seed: Option<String>,
     amount: Option<u64>,
     space: Option<u64>,
     program_address: Option<Pubkey>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/initialize_nonce_account.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/initialize_nonce_account.rs
@@ -7,23 +7,23 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializeNonceAccount {
-    pub nonce_account: solana_program::pubkey::Pubkey,
+    pub nonce_account: solana_pubkey::Pubkey,
 
-    pub recent_blockhashes_sysvar: solana_program::pubkey::Pubkey,
+    pub recent_blockhashes_sysvar: solana_pubkey::Pubkey,
 
-    pub rent_sysvar: solana_program::pubkey::Pubkey,
+    pub rent_sysvar: solana_pubkey::Pubkey,
 }
 
 impl InitializeNonceAccount {
     pub fn instruction(
         &self,
         args: InitializeNonceAccountInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -31,18 +31,18 @@ impl InitializeNonceAccount {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: InitializeNonceAccountInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.nonce_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.recent_blockhashes_sysvar,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent_sysvar,
             false,
         ));
@@ -51,7 +51,7 @@ impl InitializeNonceAccount {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -92,11 +92,11 @@ pub struct InitializeNonceAccountInstructionArgs {
 ///   2. `[optional]` rent_sysvar (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Clone, Debug, Default)]
 pub struct InitializeNonceAccountBuilder {
-    nonce_account: Option<solana_program::pubkey::Pubkey>,
-    recent_blockhashes_sysvar: Option<solana_program::pubkey::Pubkey>,
-    rent_sysvar: Option<solana_program::pubkey::Pubkey>,
+    nonce_account: Option<solana_pubkey::Pubkey>,
+    recent_blockhashes_sysvar: Option<solana_pubkey::Pubkey>,
+    rent_sysvar: Option<solana_pubkey::Pubkey>,
     nonce_authority: Option<Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl InitializeNonceAccountBuilder {
@@ -104,7 +104,7 @@ impl InitializeNonceAccountBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn nonce_account(&mut self, nonce_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn nonce_account(&mut self, nonce_account: solana_pubkey::Pubkey) -> &mut Self {
         self.nonce_account = Some(nonce_account);
         self
     }
@@ -112,14 +112,14 @@ impl InitializeNonceAccountBuilder {
     #[inline(always)]
     pub fn recent_blockhashes_sysvar(
         &mut self,
-        recent_blockhashes_sysvar: solana_program::pubkey::Pubkey,
+        recent_blockhashes_sysvar: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.recent_blockhashes_sysvar = Some(recent_blockhashes_sysvar);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent_sysvar(&mut self, rent_sysvar: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent_sysvar(&mut self, rent_sysvar: solana_pubkey::Pubkey) -> &mut Self {
         self.rent_sysvar = Some(rent_sysvar);
         self
     }
@@ -130,10 +130,7 @@ impl InitializeNonceAccountBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -141,19 +138,19 @@ impl InitializeNonceAccountBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = InitializeNonceAccount {
             nonce_account: self.nonce_account.expect("nonce_account is not set"),
             recent_blockhashes_sysvar: self.recent_blockhashes_sysvar.unwrap_or(
-                solana_program::pubkey!("SysvarRecentB1ockHashes11111111111111111111"),
+                solana_pubkey::pubkey!("SysvarRecentB1ockHashes11111111111111111111"),
             ),
-            rent_sysvar: self.rent_sysvar.unwrap_or(solana_program::pubkey!(
+            rent_sysvar: self.rent_sysvar.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
         };
@@ -170,30 +167,30 @@ impl InitializeNonceAccountBuilder {
 
 /// `initialize_nonce_account` CPI accounts.
 pub struct InitializeNonceAccountCpiAccounts<'a, 'b> {
-    pub nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub recent_blockhashes_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+    pub recent_blockhashes_sysvar: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent_sysvar: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `initialize_nonce_account` CPI instruction.
 pub struct InitializeNonceAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub recent_blockhashes_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+    pub recent_blockhashes_sysvar: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent_sysvar: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: InitializeNonceAccountInstructionArgs,
 }
 
 impl<'a, 'b> InitializeNonceAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: InitializeNonceAccountCpiAccounts<'a, 'b>,
         args: InitializeNonceAccountInstructionArgs,
     ) -> Self {
@@ -206,25 +203,21 @@ impl<'a, 'b> InitializeNonceAccountCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -233,27 +226,23 @@ impl<'a, 'b> InitializeNonceAccountCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.nonce_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.recent_blockhashes_sysvar.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent_sysvar.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -263,7 +252,7 @@ impl<'a, 'b> InitializeNonceAccountCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -278,9 +267,9 @@ impl<'a, 'b> InitializeNonceAccountCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -298,7 +287,7 @@ pub struct InitializeNonceAccountCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> InitializeNonceAccountCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializeNonceAccountCpiBuilderInstruction {
             __program: program,
             nonce_account: None,
@@ -312,7 +301,7 @@ impl<'a, 'b> InitializeNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn nonce_account(
         &mut self,
-        nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+        nonce_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.nonce_account = Some(nonce_account);
         self
@@ -320,7 +309,7 @@ impl<'a, 'b> InitializeNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn recent_blockhashes_sysvar(
         &mut self,
-        recent_blockhashes_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+        recent_blockhashes_sysvar: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.recent_blockhashes_sysvar = Some(recent_blockhashes_sysvar);
         self
@@ -328,7 +317,7 @@ impl<'a, 'b> InitializeNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn rent_sysvar(
         &mut self,
-        rent_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+        rent_sysvar: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.rent_sysvar = Some(rent_sysvar);
         self
@@ -342,7 +331,7 @@ impl<'a, 'b> InitializeNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -358,11 +347,7 @@ impl<'a, 'b> InitializeNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -370,7 +355,7 @@ impl<'a, 'b> InitializeNonceAccountCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -378,7 +363,7 @@ impl<'a, 'b> InitializeNonceAccountCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = InitializeNonceAccountInstructionArgs {
             nonce_authority: self
                 .instruction
@@ -414,15 +399,11 @@ impl<'a, 'b> InitializeNonceAccountCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct InitializeNonceAccountCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    nonce_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    recent_blockhashes_sysvar: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent_sysvar: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    nonce_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    recent_blockhashes_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
     nonce_authority: Option<Pubkey>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/transfer_sol.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/transfer_sol.rs
@@ -11,16 +11,13 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct TransferSol {
-    pub source: solana_program::pubkey::Pubkey,
+    pub source: solana_pubkey::Pubkey,
 
-    pub destination: solana_program::pubkey::Pubkey,
+    pub destination: solana_pubkey::Pubkey,
 }
 
 impl TransferSol {
-    pub fn instruction(
-        &self,
-        args: TransferSolInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self, args: TransferSolInstructionArgs) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -28,14 +25,11 @@ impl TransferSol {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: TransferSolInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.source,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(self.source, true));
+        accounts.push(solana_instruction::AccountMeta::new(
             self.destination,
             false,
         ));
@@ -44,7 +38,7 @@ impl TransferSol {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -84,10 +78,10 @@ pub struct TransferSolInstructionArgs {
 ///   1. `[writable]` destination
 #[derive(Clone, Debug, Default)]
 pub struct TransferSolBuilder {
-    source: Option<solana_program::pubkey::Pubkey>,
-    destination: Option<solana_program::pubkey::Pubkey>,
+    source: Option<solana_pubkey::Pubkey>,
+    destination: Option<solana_pubkey::Pubkey>,
     amount: Option<u64>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl TransferSolBuilder {
@@ -95,12 +89,12 @@ impl TransferSolBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn source(&mut self, source: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn source(&mut self, source: solana_pubkey::Pubkey) -> &mut Self {
         self.source = Some(source);
         self
     }
     #[inline(always)]
-    pub fn destination(&mut self, destination: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn destination(&mut self, destination: solana_pubkey::Pubkey) -> &mut Self {
         self.destination = Some(destination);
         self
     }
@@ -111,10 +105,7 @@ impl TransferSolBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -122,13 +113,13 @@ impl TransferSolBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = TransferSol {
             source: self.source.expect("source is not set"),
             destination: self.destination.expect("destination is not set"),
@@ -143,26 +134,26 @@ impl TransferSolBuilder {
 
 /// `transfer_sol` CPI accounts.
 pub struct TransferSolCpiAccounts<'a, 'b> {
-    pub source: &'b solana_program::account_info::AccountInfo<'a>,
+    pub source: &'b solana_account_info::AccountInfo<'a>,
 
-    pub destination: &'b solana_program::account_info::AccountInfo<'a>,
+    pub destination: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `transfer_sol` CPI instruction.
 pub struct TransferSolCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub source: &'b solana_program::account_info::AccountInfo<'a>,
+    pub source: &'b solana_account_info::AccountInfo<'a>,
 
-    pub destination: &'b solana_program::account_info::AccountInfo<'a>,
+    pub destination: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: TransferSolInstructionArgs,
 }
 
 impl<'a, 'b> TransferSolCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: TransferSolCpiAccounts<'a, 'b>,
         args: TransferSolInstructionArgs,
     ) -> Self {
@@ -174,25 +165,21 @@ impl<'a, 'b> TransferSolCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -201,23 +188,16 @@ impl<'a, 'b> TransferSolCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.source.key,
-            true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(*self.source.key, true));
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.destination.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -227,7 +207,7 @@ impl<'a, 'b> TransferSolCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -241,9 +221,9 @@ impl<'a, 'b> TransferSolCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -260,7 +240,7 @@ pub struct TransferSolCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> TransferSolCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(TransferSolCpiBuilderInstruction {
             __program: program,
             source: None,
@@ -271,17 +251,14 @@ impl<'a, 'b> TransferSolCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn source(
-        &mut self,
-        source: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn source(&mut self, source: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.source = Some(source);
         self
     }
     #[inline(always)]
     pub fn destination(
         &mut self,
-        destination: &'b solana_program::account_info::AccountInfo<'a>,
+        destination: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.destination = Some(destination);
         self
@@ -295,7 +272,7 @@ impl<'a, 'b> TransferSolCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -311,11 +288,7 @@ impl<'a, 'b> TransferSolCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -323,7 +296,7 @@ impl<'a, 'b> TransferSolCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -331,7 +304,7 @@ impl<'a, 'b> TransferSolCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = TransferSolInstructionArgs {
             amount: self.instruction.amount.clone().expect("amount is not set"),
         };
@@ -355,14 +328,10 @@ impl<'a, 'b> TransferSolCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct TransferSolCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    source: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    destination: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    source: Option<&'b solana_account_info::AccountInfo<'a>>,
+    destination: Option<&'b solana_account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/transfer_sol_with_seed.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/transfer_sol_with_seed.rs
@@ -7,23 +7,23 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 /// Accounts.
 #[derive(Debug)]
 pub struct TransferSolWithSeed {
-    pub source: solana_program::pubkey::Pubkey,
+    pub source: solana_pubkey::Pubkey,
 
-    pub base_account: solana_program::pubkey::Pubkey,
+    pub base_account: solana_pubkey::Pubkey,
 
-    pub destination: solana_program::pubkey::Pubkey,
+    pub destination: solana_pubkey::Pubkey,
 }
 
 impl TransferSolWithSeed {
     pub fn instruction(
         &self,
         args: TransferSolWithSeedInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -31,18 +31,15 @@ impl TransferSolWithSeed {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: TransferSolWithSeedInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
-            self.source,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new(self.source, false));
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.base_account,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.destination,
             false,
         ));
@@ -51,7 +48,7 @@ impl TransferSolWithSeed {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -96,13 +93,13 @@ pub struct TransferSolWithSeedInstructionArgs {
 ///   2. `[writable]` destination
 #[derive(Clone, Debug, Default)]
 pub struct TransferSolWithSeedBuilder {
-    source: Option<solana_program::pubkey::Pubkey>,
-    base_account: Option<solana_program::pubkey::Pubkey>,
-    destination: Option<solana_program::pubkey::Pubkey>,
+    source: Option<solana_pubkey::Pubkey>,
+    base_account: Option<solana_pubkey::Pubkey>,
+    destination: Option<solana_pubkey::Pubkey>,
     amount: Option<u64>,
     from_seed: Option<String>,
     from_owner: Option<Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl TransferSolWithSeedBuilder {
@@ -110,17 +107,17 @@ impl TransferSolWithSeedBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn source(&mut self, source: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn source(&mut self, source: solana_pubkey::Pubkey) -> &mut Self {
         self.source = Some(source);
         self
     }
     #[inline(always)]
-    pub fn base_account(&mut self, base_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn base_account(&mut self, base_account: solana_pubkey::Pubkey) -> &mut Self {
         self.base_account = Some(base_account);
         self
     }
     #[inline(always)]
-    pub fn destination(&mut self, destination: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn destination(&mut self, destination: solana_pubkey::Pubkey) -> &mut Self {
         self.destination = Some(destination);
         self
     }
@@ -141,10 +138,7 @@ impl TransferSolWithSeedBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -152,13 +146,13 @@ impl TransferSolWithSeedBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = TransferSolWithSeed {
             source: self.source.expect("source is not set"),
             base_account: self.base_account.expect("base_account is not set"),
@@ -176,30 +170,30 @@ impl TransferSolWithSeedBuilder {
 
 /// `transfer_sol_with_seed` CPI accounts.
 pub struct TransferSolWithSeedCpiAccounts<'a, 'b> {
-    pub source: &'b solana_program::account_info::AccountInfo<'a>,
+    pub source: &'b solana_account_info::AccountInfo<'a>,
 
-    pub base_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub base_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub destination: &'b solana_program::account_info::AccountInfo<'a>,
+    pub destination: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `transfer_sol_with_seed` CPI instruction.
 pub struct TransferSolWithSeedCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub source: &'b solana_program::account_info::AccountInfo<'a>,
+    pub source: &'b solana_account_info::AccountInfo<'a>,
 
-    pub base_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub base_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub destination: &'b solana_program::account_info::AccountInfo<'a>,
+    pub destination: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: TransferSolWithSeedInstructionArgs,
 }
 
 impl<'a, 'b> TransferSolWithSeedCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: TransferSolWithSeedCpiAccounts<'a, 'b>,
         args: TransferSolWithSeedInstructionArgs,
     ) -> Self {
@@ -212,25 +206,21 @@ impl<'a, 'b> TransferSolWithSeedCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -239,27 +229,23 @@ impl<'a, 'b> TransferSolWithSeedCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.source.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.base_account.key,
             true,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.destination.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -269,7 +255,7 @@ impl<'a, 'b> TransferSolWithSeedCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -284,9 +270,9 @@ impl<'a, 'b> TransferSolWithSeedCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -304,7 +290,7 @@ pub struct TransferSolWithSeedCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> TransferSolWithSeedCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(TransferSolWithSeedCpiBuilderInstruction {
             __program: program,
             source: None,
@@ -318,17 +304,14 @@ impl<'a, 'b> TransferSolWithSeedCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn source(
-        &mut self,
-        source: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
+    pub fn source(&mut self, source: &'b solana_account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.source = Some(source);
         self
     }
     #[inline(always)]
     pub fn base_account(
         &mut self,
-        base_account: &'b solana_program::account_info::AccountInfo<'a>,
+        base_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.base_account = Some(base_account);
         self
@@ -336,7 +319,7 @@ impl<'a, 'b> TransferSolWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn destination(
         &mut self,
-        destination: &'b solana_program::account_info::AccountInfo<'a>,
+        destination: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.destination = Some(destination);
         self
@@ -360,7 +343,7 @@ impl<'a, 'b> TransferSolWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -376,11 +359,7 @@ impl<'a, 'b> TransferSolWithSeedCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -388,7 +367,7 @@ impl<'a, 'b> TransferSolWithSeedCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -396,7 +375,7 @@ impl<'a, 'b> TransferSolWithSeedCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = TransferSolWithSeedInstructionArgs {
             amount: self.instruction.amount.clone().expect("amount is not set"),
             from_seed: self
@@ -435,17 +414,13 @@ impl<'a, 'b> TransferSolWithSeedCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct TransferSolWithSeedCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    source: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    base_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    destination: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    source: Option<&'b solana_account_info::AccountInfo<'a>>,
+    base_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    destination: Option<&'b solana_account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     from_seed: Option<String>,
     from_owner: Option<Pubkey>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/upgrade_nonce_account.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/upgrade_nonce_account.rs
@@ -11,28 +11,28 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct UpgradeNonceAccount {
-    pub nonce_account: solana_program::pubkey::Pubkey,
+    pub nonce_account: solana_pubkey::Pubkey,
 }
 
 impl UpgradeNonceAccount {
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(&[])
     }
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.nonce_account,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
         let data = borsh::to_vec(&UpgradeNonceAccountInstructionData::new()).unwrap();
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -67,8 +67,8 @@ impl Default for UpgradeNonceAccountInstructionData {
 ///   0. `[writable]` nonce_account
 #[derive(Clone, Debug, Default)]
 pub struct UpgradeNonceAccountBuilder {
-    nonce_account: Option<solana_program::pubkey::Pubkey>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    nonce_account: Option<solana_pubkey::Pubkey>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl UpgradeNonceAccountBuilder {
@@ -76,16 +76,13 @@ impl UpgradeNonceAccountBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn nonce_account(&mut self, nonce_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn nonce_account(&mut self, nonce_account: solana_pubkey::Pubkey) -> &mut Self {
         self.nonce_account = Some(nonce_account);
         self
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -93,13 +90,13 @@ impl UpgradeNonceAccountBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = UpgradeNonceAccount {
             nonce_account: self.nonce_account.expect("nonce_account is not set"),
         };
@@ -110,20 +107,20 @@ impl UpgradeNonceAccountBuilder {
 
 /// `upgrade_nonce_account` CPI accounts.
 pub struct UpgradeNonceAccountCpiAccounts<'a, 'b> {
-    pub nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_account: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `upgrade_nonce_account` CPI instruction.
 pub struct UpgradeNonceAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_account: &'b solana_account_info::AccountInfo<'a>,
 }
 
 impl<'a, 'b> UpgradeNonceAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: UpgradeNonceAccountCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
@@ -132,25 +129,21 @@ impl<'a, 'b> UpgradeNonceAccountCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -159,19 +152,15 @@ impl<'a, 'b> UpgradeNonceAccountCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.nonce_account.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -179,7 +168,7 @@ impl<'a, 'b> UpgradeNonceAccountCpi<'a, 'b> {
         });
         let data = borsh::to_vec(&UpgradeNonceAccountInstructionData::new()).unwrap();
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -192,9 +181,9 @@ impl<'a, 'b> UpgradeNonceAccountCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -210,7 +199,7 @@ pub struct UpgradeNonceAccountCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> UpgradeNonceAccountCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpgradeNonceAccountCpiBuilderInstruction {
             __program: program,
             nonce_account: None,
@@ -221,7 +210,7 @@ impl<'a, 'b> UpgradeNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn nonce_account(
         &mut self,
-        nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+        nonce_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.nonce_account = Some(nonce_account);
         self
@@ -230,7 +219,7 @@ impl<'a, 'b> UpgradeNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -246,11 +235,7 @@ impl<'a, 'b> UpgradeNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -258,7 +243,7 @@ impl<'a, 'b> UpgradeNonceAccountCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -266,7 +251,7 @@ impl<'a, 'b> UpgradeNonceAccountCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let instruction = UpgradeNonceAccountCpi {
             __program: self.instruction.__program,
 
@@ -284,12 +269,8 @@ impl<'a, 'b> UpgradeNonceAccountCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct UpgradeNonceAccountCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    nonce_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    nonce_account: Option<&'b solana_account_info::AccountInfo<'a>>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/withdraw_nonce_account.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/instructions/withdraw_nonce_account.rs
@@ -11,22 +11,22 @@ use borsh::BorshSerialize;
 /// Accounts.
 #[derive(Debug)]
 pub struct WithdrawNonceAccount {
-    pub nonce_account: solana_program::pubkey::Pubkey,
+    pub nonce_account: solana_pubkey::Pubkey,
 
-    pub recipient_account: solana_program::pubkey::Pubkey,
+    pub recipient_account: solana_pubkey::Pubkey,
 
-    pub recent_blockhashes_sysvar: solana_program::pubkey::Pubkey,
+    pub recent_blockhashes_sysvar: solana_pubkey::Pubkey,
 
-    pub rent_sysvar: solana_program::pubkey::Pubkey,
+    pub rent_sysvar: solana_pubkey::Pubkey,
 
-    pub nonce_authority: solana_program::pubkey::Pubkey,
+    pub nonce_authority: solana_pubkey::Pubkey,
 }
 
 impl WithdrawNonceAccount {
     pub fn instruction(
         &self,
         args: WithdrawNonceAccountInstructionArgs,
-    ) -> solana_program::instruction::Instruction {
+    ) -> solana_instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -34,26 +34,26 @@ impl WithdrawNonceAccount {
     pub fn instruction_with_remaining_accounts(
         &self,
         args: WithdrawNonceAccountInstructionArgs,
-        remaining_accounts: &[solana_program::instruction::AccountMeta],
-    ) -> solana_program::instruction::Instruction {
+        remaining_accounts: &[solana_instruction::AccountMeta],
+    ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.nonce_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             self.recipient_account,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.recent_blockhashes_sysvar,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.rent_sysvar,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             self.nonce_authority,
             true,
         ));
@@ -62,7 +62,7 @@ impl WithdrawNonceAccount {
         let mut args = borsh::to_vec(&args).unwrap();
         data.append(&mut args);
 
-        solana_program::instruction::Instruction {
+        solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -105,13 +105,13 @@ pub struct WithdrawNonceAccountInstructionArgs {
 ///   4. `[signer]` nonce_authority
 #[derive(Clone, Debug, Default)]
 pub struct WithdrawNonceAccountBuilder {
-    nonce_account: Option<solana_program::pubkey::Pubkey>,
-    recipient_account: Option<solana_program::pubkey::Pubkey>,
-    recent_blockhashes_sysvar: Option<solana_program::pubkey::Pubkey>,
-    rent_sysvar: Option<solana_program::pubkey::Pubkey>,
-    nonce_authority: Option<solana_program::pubkey::Pubkey>,
+    nonce_account: Option<solana_pubkey::Pubkey>,
+    recipient_account: Option<solana_pubkey::Pubkey>,
+    recent_blockhashes_sysvar: Option<solana_pubkey::Pubkey>,
+    rent_sysvar: Option<solana_pubkey::Pubkey>,
+    nonce_authority: Option<solana_pubkey::Pubkey>,
     withdraw_amount: Option<u64>,
-    __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
+    __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
 impl WithdrawNonceAccountBuilder {
@@ -119,15 +119,12 @@ impl WithdrawNonceAccountBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn nonce_account(&mut self, nonce_account: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn nonce_account(&mut self, nonce_account: solana_pubkey::Pubkey) -> &mut Self {
         self.nonce_account = Some(nonce_account);
         self
     }
     #[inline(always)]
-    pub fn recipient_account(
-        &mut self,
-        recipient_account: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn recipient_account(&mut self, recipient_account: solana_pubkey::Pubkey) -> &mut Self {
         self.recipient_account = Some(recipient_account);
         self
     }
@@ -135,22 +132,19 @@ impl WithdrawNonceAccountBuilder {
     #[inline(always)]
     pub fn recent_blockhashes_sysvar(
         &mut self,
-        recent_blockhashes_sysvar: solana_program::pubkey::Pubkey,
+        recent_blockhashes_sysvar: solana_pubkey::Pubkey,
     ) -> &mut Self {
         self.recent_blockhashes_sysvar = Some(recent_blockhashes_sysvar);
         self
     }
     /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     #[inline(always)]
-    pub fn rent_sysvar(&mut self, rent_sysvar: solana_program::pubkey::Pubkey) -> &mut Self {
+    pub fn rent_sysvar(&mut self, rent_sysvar: solana_pubkey::Pubkey) -> &mut Self {
         self.rent_sysvar = Some(rent_sysvar);
         self
     }
     #[inline(always)]
-    pub fn nonce_authority(
-        &mut self,
-        nonce_authority: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
+    pub fn nonce_authority(&mut self, nonce_authority: solana_pubkey::Pubkey) -> &mut Self {
         self.nonce_authority = Some(nonce_authority);
         self
     }
@@ -161,10 +155,7 @@ impl WithdrawNonceAccountBuilder {
     }
     /// Add an additional account to the instruction.
     #[inline(always)]
-    pub fn add_remaining_account(
-        &mut self,
-        account: solana_program::instruction::AccountMeta,
-    ) -> &mut Self {
+    pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
         self.__remaining_accounts.push(account);
         self
     }
@@ -172,22 +163,22 @@ impl WithdrawNonceAccountBuilder {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[solana_program::instruction::AccountMeta],
+        accounts: &[solana_instruction::AccountMeta],
     ) -> &mut Self {
         self.__remaining_accounts.extend_from_slice(accounts);
         self
     }
     #[allow(clippy::clone_on_copy)]
-    pub fn instruction(&self) -> solana_program::instruction::Instruction {
+    pub fn instruction(&self) -> solana_instruction::Instruction {
         let accounts = WithdrawNonceAccount {
             nonce_account: self.nonce_account.expect("nonce_account is not set"),
             recipient_account: self
                 .recipient_account
                 .expect("recipient_account is not set"),
             recent_blockhashes_sysvar: self.recent_blockhashes_sysvar.unwrap_or(
-                solana_program::pubkey!("SysvarRecentB1ockHashes11111111111111111111"),
+                solana_pubkey::pubkey!("SysvarRecentB1ockHashes11111111111111111111"),
             ),
-            rent_sysvar: self.rent_sysvar.unwrap_or(solana_program::pubkey!(
+            rent_sysvar: self.rent_sysvar.unwrap_or(solana_pubkey::pubkey!(
                 "SysvarRent111111111111111111111111111111111"
             )),
             nonce_authority: self.nonce_authority.expect("nonce_authority is not set"),
@@ -205,38 +196,38 @@ impl WithdrawNonceAccountBuilder {
 
 /// `withdraw_nonce_account` CPI accounts.
 pub struct WithdrawNonceAccountCpiAccounts<'a, 'b> {
-    pub nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub recipient_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub recipient_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub recent_blockhashes_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+    pub recent_blockhashes_sysvar: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent_sysvar: &'b solana_account_info::AccountInfo<'a>,
 
-    pub nonce_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_authority: &'b solana_account_info::AccountInfo<'a>,
 }
 
 /// `withdraw_nonce_account` CPI instruction.
 pub struct WithdrawNonceAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_account_info::AccountInfo<'a>,
 
-    pub nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub recipient_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub recipient_account: &'b solana_account_info::AccountInfo<'a>,
 
-    pub recent_blockhashes_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+    pub recent_blockhashes_sysvar: &'b solana_account_info::AccountInfo<'a>,
 
-    pub rent_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+    pub rent_sysvar: &'b solana_account_info::AccountInfo<'a>,
 
-    pub nonce_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub nonce_authority: &'b solana_account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: WithdrawNonceAccountInstructionArgs,
 }
 
 impl<'a, 'b> WithdrawNonceAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'b solana_program::account_info::AccountInfo<'a>,
+        program: &'b solana_account_info::AccountInfo<'a>,
         accounts: WithdrawNonceAccountCpiAccounts<'a, 'b>,
         args: WithdrawNonceAccountInstructionArgs,
     ) -> Self {
@@ -251,25 +242,21 @@ impl<'a, 'b> WithdrawNonceAccountCpi<'a, 'b> {
         }
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], &[])
     }
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
     #[inline(always)]
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(signers_seeds, &[])
     }
     #[allow(clippy::arithmetic_side_effects)]
@@ -278,35 +265,31 @@ impl<'a, 'b> WithdrawNonceAccountCpi<'a, 'b> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
-    ) -> solana_program::entrypoint::ProgramResult {
+        remaining_accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
+    ) -> solana_program_entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.nonce_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_instruction::AccountMeta::new(
             *self.recipient_account.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.recent_blockhashes_sysvar.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.rent_sysvar.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_instruction::AccountMeta::new_readonly(
             *self.nonce_authority.key,
             true,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
-            accounts.push(solana_program::instruction::AccountMeta {
+            accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
                 is_signer: remaining_account.1,
                 is_writable: remaining_account.2,
@@ -316,7 +299,7 @@ impl<'a, 'b> WithdrawNonceAccountCpi<'a, 'b> {
         let mut args = borsh::to_vec(&self.__args).unwrap();
         data.append(&mut args);
 
-        let instruction = solana_program::instruction::Instruction {
+        let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
             accounts,
             data,
@@ -333,9 +316,9 @@ impl<'a, 'b> WithdrawNonceAccountCpi<'a, 'b> {
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
 
         if signers_seeds.is_empty() {
-            solana_program::program::invoke(&instruction, &account_infos)
+            solana_cpi::invoke(&instruction, &account_infos)
         } else {
-            solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds)
+            solana_cpi::invoke_signed(&instruction, &account_infos, signers_seeds)
         }
     }
 }
@@ -355,7 +338,7 @@ pub struct WithdrawNonceAccountCpiBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> WithdrawNonceAccountCpiBuilder<'a, 'b> {
-    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
+    pub fn new(program: &'b solana_account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(WithdrawNonceAccountCpiBuilderInstruction {
             __program: program,
             nonce_account: None,
@@ -371,7 +354,7 @@ impl<'a, 'b> WithdrawNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn nonce_account(
         &mut self,
-        nonce_account: &'b solana_program::account_info::AccountInfo<'a>,
+        nonce_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.nonce_account = Some(nonce_account);
         self
@@ -379,7 +362,7 @@ impl<'a, 'b> WithdrawNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn recipient_account(
         &mut self,
-        recipient_account: &'b solana_program::account_info::AccountInfo<'a>,
+        recipient_account: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.recipient_account = Some(recipient_account);
         self
@@ -387,7 +370,7 @@ impl<'a, 'b> WithdrawNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn recent_blockhashes_sysvar(
         &mut self,
-        recent_blockhashes_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+        recent_blockhashes_sysvar: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.recent_blockhashes_sysvar = Some(recent_blockhashes_sysvar);
         self
@@ -395,7 +378,7 @@ impl<'a, 'b> WithdrawNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn rent_sysvar(
         &mut self,
-        rent_sysvar: &'b solana_program::account_info::AccountInfo<'a>,
+        rent_sysvar: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.rent_sysvar = Some(rent_sysvar);
         self
@@ -403,7 +386,7 @@ impl<'a, 'b> WithdrawNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn nonce_authority(
         &mut self,
-        nonce_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        nonce_authority: &'b solana_account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.nonce_authority = Some(nonce_authority);
         self
@@ -417,7 +400,7 @@ impl<'a, 'b> WithdrawNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: &'b solana_program::account_info::AccountInfo<'a>,
+        account: &'b solana_account_info::AccountInfo<'a>,
         is_writable: bool,
         is_signer: bool,
     ) -> &mut Self {
@@ -433,11 +416,7 @@ impl<'a, 'b> WithdrawNonceAccountCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[(
-            &'b solana_program::account_info::AccountInfo<'a>,
-            bool,
-            bool,
-        )],
+        accounts: &[(&'b solana_account_info::AccountInfo<'a>, bool, bool)],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -445,7 +424,7 @@ impl<'a, 'b> WithdrawNonceAccountCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn invoke(&self) -> solana_program::entrypoint::ProgramResult {
+    pub fn invoke(&self) -> solana_program_entrypoint::ProgramResult {
         self.invoke_signed(&[])
     }
     #[allow(clippy::clone_on_copy)]
@@ -453,7 +432,7 @@ impl<'a, 'b> WithdrawNonceAccountCpiBuilder<'a, 'b> {
     pub fn invoke_signed(
         &self,
         signers_seeds: &[&[&[u8]]],
-    ) -> solana_program::entrypoint::ProgramResult {
+    ) -> solana_program_entrypoint::ProgramResult {
         let args = WithdrawNonceAccountInstructionArgs {
             withdraw_amount: self
                 .instruction
@@ -499,17 +478,13 @@ impl<'a, 'b> WithdrawNonceAccountCpiBuilder<'a, 'b> {
 
 #[derive(Clone, Debug)]
 struct WithdrawNonceAccountCpiBuilderInstruction<'a, 'b> {
-    __program: &'b solana_program::account_info::AccountInfo<'a>,
-    nonce_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    recipient_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    recent_blockhashes_sysvar: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    rent_sysvar: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    nonce_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __program: &'b solana_account_info::AccountInfo<'a>,
+    nonce_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    recipient_account: Option<&'b solana_account_info::AccountInfo<'a>>,
+    recent_blockhashes_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
+    rent_sysvar: Option<&'b solana_account_info::AccountInfo<'a>>,
+    nonce_authority: Option<&'b solana_account_info::AccountInfo<'a>>,
     withdraw_amount: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
-    __remaining_accounts: Vec<(
-        &'b solana_program::account_info::AccountInfo<'a>,
-        bool,
-        bool,
-    )>,
+    __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/programs.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/programs.rs
@@ -5,7 +5,7 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
-use solana_program::{pubkey, pubkey::Pubkey};
+use solana_pubkey::{pubkey, Pubkey};
 
 /// `system` program ID.
 pub const SYSTEM_ID: Pubkey = pubkey!("11111111111111111111111111111111");

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/shared.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/generated_sdk/shared.rs
@@ -8,8 +8,8 @@
 #[cfg(feature = "fetch")]
 #[derive(Debug, Clone)]
 pub struct DecodedAccount<T> {
-    pub address: solana_program::pubkey::Pubkey,
-    pub account: solana_sdk::account::Account,
+    pub address: solana_pubkey::Pubkey,
+    pub account: solana_account::Account,
     pub data: T,
 }
 
@@ -17,5 +17,5 @@ pub struct DecodedAccount<T> {
 #[derive(Debug, Clone)]
 pub enum MaybeAccount<T> {
     Exists(DecodedAccount<T>),
-    NotFound(solana_program::pubkey::Pubkey),
+    NotFound(solana_pubkey::Pubkey),
 }

--- a/packages/renderers-vixen-parser/e2e/system-parser/src/lib.rs
+++ b/packages/renderers-vixen-parser/e2e/system-parser/src/lib.rs
@@ -3,7 +3,7 @@ mod generated_sdk;
 pub use generated::*;
 pub use generated_parser::*;
 use generated_sdk as generated;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 pub const ID: Pubkey = SYSTEM_ID;
 

--- a/packages/renderers-vixen-parser/public/templates/CargoPage.njk
+++ b/packages/renderers-vixen-parser/public/templates/CargoPage.njk
@@ -10,7 +10,14 @@ edition = "2021"
 [dependencies]
 prost = "0.13.1"
 tonic = { version = "0.12.1", features = ["gzip", "zstd"] }
-solana-program = "^2.1.6"
+solana-account-info = "2.2.1"
+solana-cpi = "2.2.1"
+solana-decode-error = "2.2.1"
+solana-pubkey = { version = "2.2.1", features = ["curve25519", "borsh"] }
+solana-instruction = "2.2.1"
+solana-msg = "2.2.1"
+solana-program-entrypoint = "2.2.1"
+solana-program-error = "2.2.1"
 borsh = "^0.10"
 yellowstone-vixen-core = { git = "https://github.com/rpcpool/yellowstone-vixen", branch = "main",features = ["proto"] }
 num-derive = "0.4"

--- a/packages/renderers-vixen-parser/public/templates/accountsParserPage.njk
+++ b/packages/renderers-vixen-parser/public/templates/accountsParserPage.njk
@@ -123,7 +123,7 @@ impl yellowstone_vixen_core::Parser for AccountParser {
         &self,
         acct: &yellowstone_vixen_core::AccountUpdate,
     ) -> yellowstone_vixen_core::ParseResult<Self::Output> {
-        let inner = acct.account.as_ref().ok_or(solana_program::program_error::ProgramError::InvalidArgument)?;
+        let inner = acct.account.as_ref().ok_or(solana_program_error::ProgramError::InvalidArgument)?;
            {{ programName | pascalCase }}ProgramState::try_unpack(&inner.data)
     }
 }

--- a/packages/renderers-vixen-parser/public/templates/libPage.njk
+++ b/packages/renderers-vixen-parser/public/templates/libPage.njk
@@ -4,7 +4,7 @@ mod generated_sdk;
 pub use generated::*;
 pub use generated_parser::*;
 use generated_sdk as generated;
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 pub const ID: Pubkey = {{ programId | snakeCase | upper }}_ID;
 


### PR DESCRIPTION
### Problem

`renderers-vixen-parser` use bloated `solana-program` crate

### Solution

replace `solana-program` with `solana-*` crates to make deps more granular, agreed in #616 

cc @fernandodeluret 