### PR TITLE
Remove `I` prefixes in Kit types

### DIFF
--- a/.changeset/olive-candles-hunt.md
+++ b/.changeset/olive-candles-hunt.md
@@ -1,0 +1,11 @@
+---
+'@codama/renderers-js': minor
+'@codama/renderers-vixen-parser': patch
+'@codama/nodes-from-anchor': patch
+'@codama/renderers-js-umi': patch
+'@codama/dynamic-parsers': patch
+'@codama/dynamic-codecs': patch
+'@codama/renderers-rust': patch
+---
+
+Update `@solana/kit` dependencies and remove `I` prefixes in types

--- a/packages/dynamic-codecs/package.json
+++ b/packages/dynamic-codecs/package.json
@@ -53,7 +53,7 @@
         "@codama/errors": "workspace:*",
         "@codama/nodes": "workspace:*",
         "@codama/visitors-core": "workspace:*",
-        "@solana/codecs": "2.3.0"
+        "@solana/codecs": "^2.3.0"
     },
     "license": "MIT",
     "repository": {

--- a/packages/dynamic-parsers/README.md
+++ b/packages/dynamic-parsers/README.md
@@ -63,14 +63,14 @@ if (parsedData) {
 
 ### `parseInstruction(rootNode, instruction)`
 
-This function accepts a `RootNode` and an `IInstruction` type — as defined in `@solana/instructions` — in order to return a `ParsedData<InstructionNode>` object that also includes an `accounts` array that match each `IAccountMeta` with its corresponding account name.
+This function accepts a `RootNode` and an `Instruction` type — as defined in `@solana/instructions` — in order to return a `ParsedData<InstructionNode>` object that also includes an `accounts` array that match each `AccountMeta` with its corresponding account name.
 
 ```ts
 const parsedData = parseInstruction(rootNode, instruction);
 
 if (parsedData) {
     const namedAccounts = parsedData.accounts;
-    // ^ Array<IAccountMeta & { name: string }>
+    // ^ Array<AccountMeta & { name: string }>
 }
 ```
 

--- a/packages/dynamic-parsers/package.json
+++ b/packages/dynamic-parsers/package.json
@@ -54,10 +54,10 @@
         "@codama/errors": "workspace:*",
         "@codama/nodes": "workspace:*",
         "@codama/visitors-core": "workspace:*",
-        "@solana/instructions": "2.3.0"
+        "@solana/instructions": "^2.3.0"
     },
     "devDependencies": {
-        "@solana/codecs": "2.3.0"
+        "@solana/codecs": "^2.3.0"
     },
     "license": "MIT",
     "repository": {

--- a/packages/dynamic-parsers/src/parsers.ts
+++ b/packages/dynamic-parsers/src/parsers.ts
@@ -2,11 +2,11 @@ import { getNodeCodec, ReadonlyUint8Array } from '@codama/dynamic-codecs';
 import { AccountNode, CamelCaseString, GetNodeFromKind, InstructionNode, RootNode } from '@codama/nodes';
 import { getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 import type {
-    IAccountLookupMeta,
-    IAccountMeta,
-    IInstruction,
-    IInstructionWithAccounts,
-    IInstructionWithData,
+    AccountLookupMeta,
+    AccountMeta,
+    Instruction,
+    InstructionWithAccounts,
+    InstructionWithData,
 } from '@solana/instructions';
 
 import { identifyData } from './identify';
@@ -42,14 +42,14 @@ export function parseData<TKind extends 'accountNode' | 'instructionNode'>(
     return { data, path };
 }
 
-type ParsedInstructionAccounts = ReadonlyArray<IAccountMeta & { name: CamelCaseString }>;
+type ParsedInstructionAccounts = ReadonlyArray<AccountMeta & { name: CamelCaseString }>;
 type ParsedInstruction = ParsedData<InstructionNode> & { accounts: ParsedInstructionAccounts };
 
 export function parseInstruction(
     root: RootNode,
-    instruction: IInstruction &
-        IInstructionWithAccounts<readonly (IAccountLookupMeta | IAccountMeta)[]> &
-        IInstructionWithData<Uint8Array>,
+    instruction: Instruction &
+        InstructionWithAccounts<readonly (AccountLookupMeta | AccountMeta)[]> &
+        InstructionWithData<Uint8Array>,
 ): ParsedInstruction | undefined {
     const parsedData = parseInstructionData(root, instruction.data);
     if (!parsedData) return undefined;

--- a/packages/nodes-from-anchor/package.json
+++ b/packages/nodes-from-anchor/package.json
@@ -52,7 +52,7 @@
         "@codama/errors": "workspace:*",
         "@codama/nodes": "workspace:*",
         "@codama/visitors": "workspace:*",
-        "@solana/codecs": "2.3.0",
+        "@solana/codecs": "^2.3.0",
         "@noble/hashes": "^1.8.0"
     },
     "license": "MIT",

--- a/packages/renderers-js-umi/package.json
+++ b/packages/renderers-js-umi/package.json
@@ -48,7 +48,7 @@
         "@codama/renderers-core": "workspace:*",
         "@codama/validators": "workspace:*",
         "@codama/visitors-core": "workspace:*",
-        "@solana/codecs-strings": "rc",
+        "@solana/codecs-strings": "^2.3.0",
         "nunjucks": "^3.2.4",
         "prettier": "^3.6.2"
     },

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/createGuard.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/createGuard.ts
@@ -27,15 +27,15 @@ import {
   getUtf8Decoder,
   getUtf8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type Option,
   type OptionOrNullable,
   type ReadonlyAccount,
@@ -78,41 +78,41 @@ export function getCreateGuardDiscriminatorBytes() {
 
 export type CreateGuardInstruction<
   TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountGuard extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountMintTokenAccount extends string | IAccountMeta<string> = string,
-  TAccountGuardAuthority extends string | IAccountMeta<string> = string,
-  TAccountPayer extends string | IAccountMeta<string> = string,
+  TAccountGuard extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountMintTokenAccount extends string | AccountMeta<string> = string,
+  TAccountGuardAuthority extends string | AccountMeta<string> = string,
+  TAccountPayer extends string | AccountMeta<string> = string,
   TAccountAssociatedTokenProgram extends
     | string
-    | IAccountMeta<string> = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
+    | AccountMeta<string> = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
   TAccountTokenProgram extends
     | string
-    | IAccountMeta<string> = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+    | AccountMeta<string> = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
   TAccountSystemProgram extends
     | string
-    | IAccountMeta<string> = '11111111111111111111111111111111',
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = '11111111111111111111111111111111',
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountGuard extends string
         ? WritableAccount<TAccountGuard>
         : TAccountGuard,
       TAccountMint extends string
-        ? WritableSignerAccount<TAccountMint> & IAccountSignerMeta<TAccountMint>
+        ? WritableSignerAccount<TAccountMint> & AccountSignerMeta<TAccountMint>
         : TAccountMint,
       TAccountMintTokenAccount extends string
         ? WritableAccount<TAccountMintTokenAccount>
         : TAccountMintTokenAccount,
       TAccountGuardAuthority extends string
         ? ReadonlySignerAccount<TAccountGuardAuthority> &
-            IAccountSignerMeta<TAccountGuardAuthority>
+            AccountSignerMeta<TAccountGuardAuthority>
         : TAccountGuardAuthority,
       TAccountPayer extends string
         ? WritableSignerAccount<TAccountPayer> &
-            IAccountSignerMeta<TAccountPayer>
+            AccountSignerMeta<TAccountPayer>
         : TAccountPayer,
       TAccountAssociatedTokenProgram extends string
         ? ReadonlyAccount<TAccountAssociatedTokenProgram>
@@ -489,7 +489,7 @@ export function getCreateGuardInstruction<
 
 export type ParsedCreateGuardInstruction<
   TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -507,11 +507,11 @@ export type ParsedCreateGuardInstruction<
 
 export function parseCreateGuardInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedCreateGuardInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 8) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/execute.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/execute.ts
@@ -19,14 +19,14 @@ import {
   getU64Decoder,
   getU64Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlyUint8Array,
 } from '@solana/kit';
@@ -47,19 +47,19 @@ export function getExecuteDiscriminatorBytes() {
 
 export type ExecuteInstruction<
   TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountSourceAccount extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountDestinationAccount extends string | IAccountMeta<string> = string,
-  TAccountOwnerDelegate extends string | IAccountMeta<string> = string,
-  TAccountExtraMetasAccount extends string | IAccountMeta<string> = string,
-  TAccountGuard extends string | IAccountMeta<string> = string,
+  TAccountSourceAccount extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountDestinationAccount extends string | AccountMeta<string> = string,
+  TAccountOwnerDelegate extends string | AccountMeta<string> = string,
+  TAccountExtraMetasAccount extends string | AccountMeta<string> = string,
+  TAccountGuard extends string | AccountMeta<string> = string,
   TAccountInstructionSysvarAccount extends
     | string
-    | IAccountMeta<string> = 'Sysvar1nstructions1111111111111111111111111',
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = 'Sysvar1nstructions1111111111111111111111111',
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountSourceAccount extends string
         ? ReadonlyAccount<TAccountSourceAccount>
@@ -368,7 +368,7 @@ export function getExecuteInstruction<
 
 export type ParsedExecuteInstruction<
   TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -385,11 +385,11 @@ export type ParsedExecuteInstruction<
 
 export function parseExecuteInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedExecuteInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 7) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/initialize.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/initialize.ts
@@ -17,15 +17,15 @@ import {
   getStructDecoder,
   getStructEncoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlyUint8Array,
   type TransactionSigner,
@@ -49,18 +49,18 @@ export function getInitializeDiscriminatorBytes() {
 
 export type InitializeInstruction<
   TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountExtraMetasAccount extends string | IAccountMeta<string> = string,
-  TAccountGuard extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountTransferHookAuthority extends string | IAccountMeta<string> = string,
+  TAccountExtraMetasAccount extends string | AccountMeta<string> = string,
+  TAccountGuard extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountTransferHookAuthority extends string | AccountMeta<string> = string,
   TAccountSystemProgram extends
     | string
-    | IAccountMeta<string> = '11111111111111111111111111111111',
-  TAccountPayer extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = '11111111111111111111111111111111',
+  TAccountPayer extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountExtraMetasAccount extends string
         ? WritableAccount<TAccountExtraMetasAccount>
@@ -73,14 +73,14 @@ export type InitializeInstruction<
         : TAccountMint,
       TAccountTransferHookAuthority extends string
         ? WritableSignerAccount<TAccountTransferHookAuthority> &
-            IAccountSignerMeta<TAccountTransferHookAuthority>
+            AccountSignerMeta<TAccountTransferHookAuthority>
         : TAccountTransferHookAuthority,
       TAccountSystemProgram extends string
         ? ReadonlyAccount<TAccountSystemProgram>
         : TAccountSystemProgram,
       TAccountPayer extends string
         ? WritableSignerAccount<TAccountPayer> &
-            IAccountSignerMeta<TAccountPayer>
+            AccountSignerMeta<TAccountPayer>
         : TAccountPayer,
       ...TRemainingAccounts,
     ]
@@ -327,7 +327,7 @@ export function getInitializeInstruction<
 
 export type ParsedInitializeInstruction<
   TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -343,11 +343,11 @@ export type ParsedInitializeInstruction<
 
 export function parseInitializeInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedInitializeInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 6) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/updateGuard.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/updateGuard.ts
@@ -21,15 +21,15 @@ import {
   getStructDecoder,
   getStructEncoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type Option,
   type OptionOrNullable,
   type ReadonlyAccount,
@@ -71,20 +71,20 @@ export function getUpdateGuardDiscriminatorBytes() {
 
 export type UpdateGuardInstruction<
   TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountGuard extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountTokenAccount extends string | IAccountMeta<string> = string,
-  TAccountGuardAuthority extends string | IAccountMeta<string> = string,
+  TAccountGuard extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountTokenAccount extends string | AccountMeta<string> = string,
+  TAccountGuardAuthority extends string | AccountMeta<string> = string,
   TAccountTokenProgram extends
     | string
-    | IAccountMeta<string> = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+    | AccountMeta<string> = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
   TAccountSystemProgram extends
     | string
-    | IAccountMeta<string> = '11111111111111111111111111111111',
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = '11111111111111111111111111111111',
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountGuard extends string
         ? WritableAccount<TAccountGuard>
@@ -97,7 +97,7 @@ export type UpdateGuardInstruction<
         : TAccountTokenAccount,
       TAccountGuardAuthority extends string
         ? ReadonlySignerAccount<TAccountGuardAuthority> &
-            IAccountSignerMeta<TAccountGuardAuthority>
+            AccountSignerMeta<TAccountGuardAuthority>
         : TAccountGuardAuthority,
       TAccountTokenProgram extends string
         ? ReadonlyAccount<TAccountTokenProgram>
@@ -401,7 +401,7 @@ export function getUpdateGuardInstruction<
 
 export type ParsedUpdateGuardInstruction<
   TProgram extends string = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -417,11 +417,11 @@ export type ParsedUpdateGuardInstruction<
 
 export function parseUpdateGuardInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedUpdateGuardInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 6) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/anchor/src/generated/shared/index.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/shared/index.ts
@@ -10,9 +10,9 @@ import {
   AccountRole,
   isProgramDerivedAddress,
   isTransactionSigner as kitIsTransactionSigner,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
-  type IAccountMeta,
-  type IAccountSignerMeta,
   type ProgramDerivedAddress,
   type TransactionSigner,
   upgradeRoleToSigner,
@@ -113,7 +113,7 @@ export type ResolvedAccount<
  * Defines an instruction that stores additional bytes on-chain.
  * @internal
  */
-export type IInstructionWithByteDelta = {
+export type InstructionWithByteDelta = {
   byteDelta: number;
 };
 
@@ -127,7 +127,7 @@ export function getAccountMetaFactory(
 ) {
   return (
     account: ResolvedAccount
-  ): IAccountMeta | IAccountSignerMeta | undefined => {
+  ): AccountMeta | AccountSignerMeta | undefined => {
     if (!account.value) {
       if (optionalAccountStrategy === 'omitted') return;
       return Object.freeze({

--- a/packages/renderers-js/e2e/anchor/test/_setup.ts
+++ b/packages/renderers-js/e2e/anchor/test/_setup.ts
@@ -1,11 +1,12 @@
 import {
+  type BaseTransactionMessage,
   type Commitment,
-  type CompilableTransactionMessage,
   type Rpc,
   type RpcSubscriptions,
   type SolanaRpcApi,
   type SolanaRpcSubscriptionsApi,
   type TransactionMessageWithBlockhashLifetime,
+  type TransactionMessageWithFeePayer,
   type TransactionSigner,
   airdropFactory,
   createSolanaRpc,
@@ -48,7 +49,11 @@ export const generateKeyPairSignerWithSol = async (
 export const createDefaultTransaction = async (
   client: Client,
   feePayer: TransactionSigner
-) => {
+): Promise<
+  BaseTransactionMessage &
+    TransactionMessageWithFeePayer &
+    TransactionMessageWithBlockhashLifetime
+> => {
   const { value: latestBlockhash } = await client.rpc
     .getLatestBlockhash()
     .send();
@@ -61,7 +66,8 @@ export const createDefaultTransaction = async (
 
 export const signAndSendTransaction = async (
   client: Client,
-  transactionMessage: CompilableTransactionMessage &
+  transactionMessage: BaseTransactionMessage &
+    TransactionMessageWithFeePayer &
     TransactionMessageWithBlockhashLifetime,
   commitment: Commitment = 'confirmed'
 ) => {

--- a/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction1.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction1.ts
@@ -7,17 +7,17 @@
  */
 
 import {
+  type AccountMeta,
   type Address,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
+  type Instruction,
+  type InstructionWithAccounts,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
 export type Instruction1Instruction<
   TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> & IInstructionWithAccounts<TRemainingAccounts>;
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> & InstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction1Input = {};
 
@@ -43,7 +43,7 @@ export type ParsedInstruction1Instruction<
 };
 
 export function parseInstruction1Instruction<TProgram extends string>(
-  instruction: IInstruction<TProgram>
+  instruction: Instruction<TProgram>
 ): ParsedInstruction1Instruction<TProgram> {
   return {
     programAddress: instruction.programAddress,

--- a/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction2.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction2.ts
@@ -8,17 +8,17 @@
 
 import {
   AccountRole,
+  type AccountMeta,
   type Address,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
+  type Instruction,
+  type InstructionWithAccounts,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
 export type Instruction2Instruction<
   TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> & IInstructionWithAccounts<TRemainingAccounts>;
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> & InstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction2Input = {
   remainingAccounts?: Array<Address>;
@@ -37,7 +37,7 @@ export function getInstruction2Instruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.remainingAccounts ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.remainingAccounts ?? []).map(
     (address) => ({ address, role: AccountRole.READONLY })
   );
 
@@ -56,7 +56,7 @@ export type ParsedInstruction2Instruction<
 };
 
 export function parseInstruction2Instruction<TProgram extends string>(
-  instruction: IInstruction<TProgram>
+  instruction: Instruction<TProgram>
 ): ParsedInstruction2Instruction<TProgram> {
   return {
     programAddress: instruction.programAddress,

--- a/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction3.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction3.ts
@@ -13,14 +13,14 @@ import {
   getU32Decoder,
   getU32Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
@@ -32,10 +32,10 @@ export function getInstruction3DiscriminatorBytes() {
 
 export type Instruction3Instruction<
   TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<TRemainingAccounts>;
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction3InstructionData = { discriminator: number };
 
@@ -88,7 +88,7 @@ export type ParsedInstruction3Instruction<
 };
 
 export function parseInstruction3Instruction<TProgram extends string>(
-  instruction: IInstruction<TProgram> & IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> & InstructionWithData<Uint8Array>
 ): ParsedInstruction3Instruction<TProgram> {
   return {
     programAddress: instruction.programAddress,

--- a/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction4.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction4.ts
@@ -12,23 +12,23 @@ import {
   getStructEncoder,
   getU64Decoder,
   getU64Encoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
 export type Instruction4Instruction<
   TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<TRemainingAccounts>;
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction4InstructionData = { myArgument: bigint };
 
@@ -86,7 +86,7 @@ export type ParsedInstruction4Instruction<
 };
 
 export function parseInstruction4Instruction<TProgram extends string>(
-  instruction: IInstruction<TProgram> & IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> & InstructionWithData<Uint8Array>
 ): ParsedInstruction4Instruction<TProgram> {
   return {
     programAddress: instruction.programAddress,

--- a/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction5.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction5.ts
@@ -13,23 +13,23 @@ import {
   getU64Decoder,
   getU64Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
 
 export type Instruction5Instruction<
   TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<TRemainingAccounts>;
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<TRemainingAccounts>;
 
 export type Instruction5InstructionData = { myArgument: bigint };
 
@@ -90,7 +90,7 @@ export type ParsedInstruction5Instruction<
 };
 
 export function parseInstruction5Instruction<TProgram extends string>(
-  instruction: IInstruction<TProgram> & IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> & InstructionWithData<Uint8Array>
 ): ParsedInstruction5Instruction<TProgram> {
   return {
     programAddress: instruction.programAddress,

--- a/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction6.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction6.ts
@@ -7,10 +7,10 @@
  */
 
 import {
+  type AccountMeta,
   type Address,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
+  type Instruction,
+  type InstructionWithAccounts,
   type WritableAccount,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
@@ -18,10 +18,10 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
 export type Instruction6Instruction<
   TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TAccountMyAccount extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithAccounts<
+  TAccountMyAccount extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithAccounts<
     [
       TAccountMyAccount extends string
         ? WritableAccount<TAccountMyAccount>
@@ -64,7 +64,7 @@ export function getInstruction6Instruction<
 
 export type ParsedInstruction6Instruction<
   TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -74,9 +74,9 @@ export type ParsedInstruction6Instruction<
 
 export function parseInstruction6Instruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> & IInstructionWithAccounts<TAccountMetas>
+  instruction: Instruction<TProgram> & InstructionWithAccounts<TAccountMetas>
 ): ParsedInstruction6Instruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction7.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction7.ts
@@ -7,10 +7,10 @@
  */
 
 import {
+  type AccountMeta,
   type Address,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
+  type Instruction,
+  type InstructionWithAccounts,
   type WritableAccount,
 } from '@solana/kit';
 import { DUMMY_PROGRAM_ADDRESS } from '../programs';
@@ -18,10 +18,10 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
 export type Instruction7Instruction<
   TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TAccountMyAccount extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithAccounts<
+  TAccountMyAccount extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithAccounts<
     [
       TAccountMyAccount extends string
         ? WritableAccount<TAccountMyAccount>
@@ -64,7 +64,7 @@ export function getInstruction7Instruction<
 
 export type ParsedInstruction7Instruction<
   TProgram extends string = typeof DUMMY_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -74,9 +74,9 @@ export type ParsedInstruction7Instruction<
 
 export function parseInstruction7Instruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> & IInstructionWithAccounts<TAccountMetas>
+  instruction: Instruction<TProgram> & InstructionWithAccounts<TAccountMetas>
 ): ParsedInstruction7Instruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/dummy/src/generated/shared/index.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/shared/index.ts
@@ -10,9 +10,9 @@ import {
   AccountRole,
   isProgramDerivedAddress,
   isTransactionSigner as kitIsTransactionSigner,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
-  type IAccountMeta,
-  type IAccountSignerMeta,
   type ProgramDerivedAddress,
   type TransactionSigner,
   upgradeRoleToSigner,
@@ -113,7 +113,7 @@ export type ResolvedAccount<
  * Defines an instruction that stores additional bytes on-chain.
  * @internal
  */
-export type IInstructionWithByteDelta = {
+export type InstructionWithByteDelta = {
   byteDelta: number;
 };
 
@@ -127,7 +127,7 @@ export function getAccountMetaFactory(
 ) {
   return (
     account: ResolvedAccount
-  ): IAccountMeta | IAccountSignerMeta | undefined => {
+  ): AccountMeta | AccountSignerMeta | undefined => {
     if (!account.value) {
       if (optionalAccountStrategy === 'omitted') return;
       return Object.freeze({

--- a/packages/renderers-js/e2e/dummy/test/_setup.ts
+++ b/packages/renderers-js/e2e/dummy/test/_setup.ts
@@ -1,11 +1,12 @@
 import {
+  type BaseTransactionMessage,
   type Commitment,
-  type CompilableTransactionMessage,
   type Rpc,
   type RpcSubscriptions,
   type SolanaRpcApi,
   type SolanaRpcSubscriptionsApi,
   type TransactionMessageWithBlockhashLifetime,
+  type TransactionMessageWithFeePayer,
   type TransactionSigner,
   airdropFactory,
   createSolanaRpc,
@@ -48,7 +49,11 @@ export const generateKeyPairSignerWithSol = async (
 export const createDefaultTransaction = async (
   client: Client,
   feePayer: TransactionSigner
-) => {
+): Promise<
+  BaseTransactionMessage &
+    TransactionMessageWithFeePayer &
+    TransactionMessageWithBlockhashLifetime
+> => {
   const { value: latestBlockhash } = await client.rpc
     .getLatestBlockhash()
     .send();
@@ -61,7 +66,8 @@ export const createDefaultTransaction = async (
 
 export const signAndSendTransaction = async (
   client: Client,
-  transactionMessage: CompilableTransactionMessage &
+  transactionMessage: BaseTransactionMessage &
+    TransactionMessageWithFeePayer &
     TransactionMessageWithBlockhashLifetime,
   commitment: Commitment = 'confirmed'
 ) => {

--- a/packages/renderers-js/e2e/memo/src/generated/instructions/addMemo.ts
+++ b/packages/renderers-js/e2e/memo/src/generated/instructions/addMemo.ts
@@ -13,24 +13,24 @@ import {
   getStructEncoder,
   getUtf8Decoder,
   getUtf8Encoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type TransactionSigner,
 } from '@solana/kit';
 import { MEMO_PROGRAM_ADDRESS } from '../programs';
 
 export type AddMemoInstruction<
   TProgram extends string = typeof MEMO_PROGRAM_ADDRESS,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<TRemainingAccounts>;
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<TRemainingAccounts>;
 
 export type AddMemoInstructionData = { memo: string };
 
@@ -72,7 +72,7 @@ export function getAddMemoInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.signers ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.signers ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -99,7 +99,7 @@ export type ParsedAddMemoInstruction<
 };
 
 export function parseAddMemoInstruction<TProgram extends string>(
-  instruction: IInstruction<TProgram> & IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> & InstructionWithData<Uint8Array>
 ): ParsedAddMemoInstruction<TProgram> {
   return {
     programAddress: instruction.programAddress,

--- a/packages/renderers-js/e2e/memo/src/generated/shared/index.ts
+++ b/packages/renderers-js/e2e/memo/src/generated/shared/index.ts
@@ -10,9 +10,9 @@ import {
   AccountRole,
   isProgramDerivedAddress,
   isTransactionSigner as kitIsTransactionSigner,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
-  type IAccountMeta,
-  type IAccountSignerMeta,
   type ProgramDerivedAddress,
   type TransactionSigner,
   upgradeRoleToSigner,
@@ -113,7 +113,7 @@ export type ResolvedAccount<
  * Defines an instruction that stores additional bytes on-chain.
  * @internal
  */
-export type IInstructionWithByteDelta = {
+export type InstructionWithByteDelta = {
   byteDelta: number;
 };
 
@@ -127,7 +127,7 @@ export function getAccountMetaFactory(
 ) {
   return (
     account: ResolvedAccount
-  ): IAccountMeta | IAccountSignerMeta | undefined => {
+  ): AccountMeta | AccountSignerMeta | undefined => {
     if (!account.value) {
       if (optionalAccountStrategy === 'omitted') return;
       return Object.freeze({

--- a/packages/renderers-js/e2e/memo/test/_setup.ts
+++ b/packages/renderers-js/e2e/memo/test/_setup.ts
@@ -1,11 +1,12 @@
 import {
+  type BaseTransactionMessage,
   type Commitment,
-  type CompilableTransactionMessage,
   type Rpc,
   type RpcSubscriptions,
   type SolanaRpcApi,
   type SolanaRpcSubscriptionsApi,
   type TransactionMessageWithBlockhashLifetime,
+  type TransactionMessageWithFeePayer,
   type TransactionSigner,
   airdropFactory,
   createSolanaRpc,
@@ -48,7 +49,11 @@ export const generateKeyPairSignerWithSol = async (
 export const createDefaultTransaction = async (
   client: Client,
   feePayer: TransactionSigner
-) => {
+): Promise<
+  BaseTransactionMessage &
+    TransactionMessageWithFeePayer &
+    TransactionMessageWithBlockhashLifetime
+> => {
   const { value: latestBlockhash } = await client.rpc
     .getLatestBlockhash()
     .send();
@@ -61,7 +66,8 @@ export const createDefaultTransaction = async (
 
 export const signAndSendTransaction = async (
   client: Client,
-  transactionMessage: CompilableTransactionMessage &
+  transactionMessage: BaseTransactionMessage &
+    TransactionMessageWithFeePayer &
     TransactionMessageWithBlockhashLifetime,
   commitment: Commitment = 'confirmed'
 ) => {

--- a/packages/renderers-js/e2e/memo/test/addMemo.test.ts
+++ b/packages/renderers-js/e2e/memo/test/addMemo.test.ts
@@ -28,7 +28,10 @@ test('it adds custom text to the transaction logs', async (t) => {
 
   // Then the instruction data contains our memo.
   const result = await client.rpc
-    .getTransaction(signature, { maxSupportedTransactionVersion: 0 })
+    .getTransaction(signature, {
+      encoding: 'json',
+      maxSupportedTransactionVersion: 0,
+    })
     .send();
   const instructionDataBase58 =
     result!.transaction.message.instructions[0].data;

--- a/packages/renderers-js/e2e/package.json
+++ b/packages/renderers-js/e2e/package.json
@@ -2,7 +2,7 @@
     "name": "@codama/renderers-js-e2e-monorepo",
     "private": true,
     "peedDependencies": {
-        "@solana/kit": "^2.1.0"
+        "@solana/kit": "^2.3.0"
     },
     "devDependencies": {
         "@ava/typescript": "^6.0.0",

--- a/packages/renderers-js/e2e/system/src/generated/instructions/advanceNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/advanceNonceAccount.ts
@@ -13,15 +13,15 @@ import {
   getU32Decoder,
   getU32Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -38,15 +38,15 @@ export function getAdvanceNonceAccountDiscriminatorBytes() {
 
 export type AdvanceNonceAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNonceAccount extends string | IAccountMeta<string> = string,
+  TAccountNonceAccount extends string | AccountMeta<string> = string,
   TAccountRecentBlockhashesSysvar extends
     | string
-    | IAccountMeta<string> = 'SysvarRecentB1ockHashes11111111111111111111',
-  TAccountNonceAuthority extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = 'SysvarRecentB1ockHashes11111111111111111111',
+  TAccountNonceAuthority extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountNonceAccount extends string
         ? WritableAccount<TAccountNonceAccount>
@@ -56,7 +56,7 @@ export type AdvanceNonceAccountInstruction<
         : TAccountRecentBlockhashesSysvar,
       TAccountNonceAuthority extends string
         ? ReadonlySignerAccount<TAccountNonceAuthority> &
-            IAccountSignerMeta<TAccountNonceAuthority>
+            AccountSignerMeta<TAccountNonceAuthority>
         : TAccountNonceAuthority,
       ...TRemainingAccounts,
     ]
@@ -162,7 +162,7 @@ export function getAdvanceNonceAccountInstruction<
 
 export type ParsedAdvanceNonceAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -175,11 +175,11 @@ export type ParsedAdvanceNonceAccountInstruction<
 
 export function parseAdvanceNonceAccountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedAdvanceNonceAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/allocate.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/allocate.ts
@@ -15,15 +15,15 @@ import {
   getU64Decoder,
   getU64Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type TransactionSigner,
   type WritableSignerAccount,
 } from '@solana/kit';
@@ -38,15 +38,15 @@ export function getAllocateDiscriminatorBytes() {
 
 export type AllocateInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNewAccount extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountNewAccount extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountNewAccount extends string
         ? WritableSignerAccount<TAccountNewAccount> &
-            IAccountSignerMeta<TAccountNewAccount>
+            AccountSignerMeta<TAccountNewAccount>
         : TAccountNewAccount,
       ...TRemainingAccounts,
     ]
@@ -124,7 +124,7 @@ export function getAllocateInstruction<
 
 export type ParsedAllocateInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -135,11 +135,11 @@ export type ParsedAllocateInstruction<
 
 export function parseAllocateInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedAllocateInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/allocateWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/allocateWithSeed.ts
@@ -21,15 +21,15 @@ import {
   getUtf8Decoder,
   getUtf8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlySignerAccount,
   type TransactionSigner,
   type WritableAccount,
@@ -45,19 +45,19 @@ export function getAllocateWithSeedDiscriminatorBytes() {
 
 export type AllocateWithSeedInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNewAccount extends string | IAccountMeta<string> = string,
-  TAccountBaseAccount extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountNewAccount extends string | AccountMeta<string> = string,
+  TAccountBaseAccount extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountNewAccount extends string
         ? WritableAccount<TAccountNewAccount>
         : TAccountNewAccount,
       TAccountBaseAccount extends string
         ? ReadonlySignerAccount<TAccountBaseAccount> &
-            IAccountSignerMeta<TAccountBaseAccount>
+            AccountSignerMeta<TAccountBaseAccount>
         : TAccountBaseAccount,
       ...TRemainingAccounts,
     ]
@@ -172,7 +172,7 @@ export function getAllocateWithSeedInstruction<
 
 export type ParsedAllocateWithSeedInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -184,11 +184,11 @@ export type ParsedAllocateWithSeedInstruction<
 
 export function parseAllocateWithSeedInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedAllocateWithSeedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/assign.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/assign.ts
@@ -15,15 +15,15 @@ import {
   getU32Decoder,
   getU32Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type TransactionSigner,
   type WritableSignerAccount,
 } from '@solana/kit';
@@ -38,15 +38,15 @@ export function getAssignDiscriminatorBytes() {
 
 export type AssignInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountAccount extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountAccount extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountAccount extends string
         ? WritableSignerAccount<TAccountAccount> &
-            IAccountSignerMeta<TAccountAccount>
+            AccountSignerMeta<TAccountAccount>
         : TAccountAccount,
       ...TRemainingAccounts,
     ]
@@ -127,7 +127,7 @@ export function getAssignInstruction<
 
 export type ParsedAssignInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -138,11 +138,11 @@ export type ParsedAssignInstruction<
 
 export function parseAssignInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedAssignInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/assignWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/assignWithSeed.ts
@@ -19,15 +19,15 @@ import {
   getUtf8Decoder,
   getUtf8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlySignerAccount,
   type TransactionSigner,
   type WritableAccount,
@@ -43,19 +43,19 @@ export function getAssignWithSeedDiscriminatorBytes() {
 
 export type AssignWithSeedInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountAccount extends string | IAccountMeta<string> = string,
-  TAccountBaseAccount extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountAccount extends string | AccountMeta<string> = string,
+  TAccountBaseAccount extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountAccount extends string
         ? WritableAccount<TAccountAccount>
         : TAccountAccount,
       TAccountBaseAccount extends string
         ? ReadonlySignerAccount<TAccountBaseAccount> &
-            IAccountSignerMeta<TAccountBaseAccount>
+            AccountSignerMeta<TAccountBaseAccount>
         : TAccountBaseAccount,
       ...TRemainingAccounts,
     ]
@@ -165,7 +165,7 @@ export function getAssignWithSeedInstruction<
 
 export type ParsedAssignWithSeedInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -177,11 +177,11 @@ export type ParsedAssignWithSeedInstruction<
 
 export function parseAssignWithSeedInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedAssignWithSeedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/authorizeNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/authorizeNonceAccount.ts
@@ -15,15 +15,15 @@ import {
   getU32Decoder,
   getU32Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlySignerAccount,
   type TransactionSigner,
   type WritableAccount,
@@ -39,19 +39,19 @@ export function getAuthorizeNonceAccountDiscriminatorBytes() {
 
 export type AuthorizeNonceAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNonceAccount extends string | IAccountMeta<string> = string,
-  TAccountNonceAuthority extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountNonceAccount extends string | AccountMeta<string> = string,
+  TAccountNonceAuthority extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountNonceAccount extends string
         ? WritableAccount<TAccountNonceAccount>
         : TAccountNonceAccount,
       TAccountNonceAuthority extends string
         ? ReadonlySignerAccount<TAccountNonceAuthority> &
-            IAccountSignerMeta<TAccountNonceAuthority>
+            AccountSignerMeta<TAccountNonceAuthority>
         : TAccountNonceAuthority,
       ...TRemainingAccounts,
     ]
@@ -157,7 +157,7 @@ export function getAuthorizeNonceAccountInstruction<
 
 export type ParsedAuthorizeNonceAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -169,11 +169,11 @@ export type ParsedAuthorizeNonceAccountInstruction<
 
 export function parseAuthorizeNonceAccountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedAuthorizeNonceAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
@@ -20,15 +20,15 @@ import {
   getU64Decoder,
   getU64Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type Lamports,
   type TransactionSigner,
   type WritableSignerAccount,
@@ -36,7 +36,7 @@ import {
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import {
   getAccountMetaFactory,
-  type IInstructionWithByteDelta,
+  type InstructionWithByteDelta,
   type ResolvedAccount,
 } from '../shared';
 
@@ -48,20 +48,20 @@ export function getCreateAccountDiscriminatorBytes() {
 
 export type CreateAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountPayer extends string | IAccountMeta<string> = string,
-  TAccountNewAccount extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountPayer extends string | AccountMeta<string> = string,
+  TAccountNewAccount extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountPayer extends string
         ? WritableSignerAccount<TAccountPayer> &
-            IAccountSignerMeta<TAccountPayer>
+            AccountSignerMeta<TAccountPayer>
         : TAccountPayer,
       TAccountNewAccount extends string
         ? WritableSignerAccount<TAccountNewAccount> &
-            IAccountSignerMeta<TAccountNewAccount>
+            AccountSignerMeta<TAccountNewAccount>
         : TAccountNewAccount,
       ...TRemainingAccounts,
     ]
@@ -134,7 +134,7 @@ export function getCreateAccountInstruction<
   TAccountPayer,
   TAccountNewAccount
 > &
-  IInstructionWithByteDelta {
+  InstructionWithByteDelta {
   // Program address.
   const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
@@ -178,7 +178,7 @@ export function getCreateAccountInstruction<
 
 export type ParsedCreateAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -190,11 +190,11 @@ export type ParsedCreateAccountInstruction<
 
 export function parseCreateAccountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedCreateAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/createAccountWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/createAccountWithSeed.ts
@@ -21,15 +21,15 @@ import {
   getUtf8Decoder,
   getUtf8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlySignerAccount,
   type TransactionSigner,
   type WritableAccount,
@@ -46,24 +46,24 @@ export function getCreateAccountWithSeedDiscriminatorBytes() {
 
 export type CreateAccountWithSeedInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountPayer extends string | IAccountMeta<string> = string,
-  TAccountNewAccount extends string | IAccountMeta<string> = string,
-  TAccountBaseAccount extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountPayer extends string | AccountMeta<string> = string,
+  TAccountNewAccount extends string | AccountMeta<string> = string,
+  TAccountBaseAccount extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountPayer extends string
         ? WritableSignerAccount<TAccountPayer> &
-            IAccountSignerMeta<TAccountPayer>
+            AccountSignerMeta<TAccountPayer>
         : TAccountPayer,
       TAccountNewAccount extends string
         ? WritableAccount<TAccountNewAccount>
         : TAccountNewAccount,
       TAccountBaseAccount extends string
         ? ReadonlySignerAccount<TAccountBaseAccount> &
-            IAccountSignerMeta<TAccountBaseAccount>
+            AccountSignerMeta<TAccountBaseAccount>
         : TAccountBaseAccount,
       ...TRemainingAccounts,
     ]
@@ -197,7 +197,7 @@ export function getCreateAccountWithSeedInstruction<
 
 export type ParsedCreateAccountWithSeedInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -210,11 +210,11 @@ export type ParsedCreateAccountWithSeedInstruction<
 
 export function parseCreateAccountWithSeedInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedCreateAccountWithSeedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/initializeNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/initializeNonceAccount.ts
@@ -15,14 +15,14 @@ import {
   getU32Decoder,
   getU32Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type WritableAccount,
 } from '@solana/kit';
@@ -37,17 +37,17 @@ export function getInitializeNonceAccountDiscriminatorBytes() {
 
 export type InitializeNonceAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNonceAccount extends string | IAccountMeta<string> = string,
+  TAccountNonceAccount extends string | AccountMeta<string> = string,
   TAccountRecentBlockhashesSysvar extends
     | string
-    | IAccountMeta<string> = 'SysvarRecentB1ockHashes11111111111111111111',
+    | AccountMeta<string> = 'SysvarRecentB1ockHashes11111111111111111111',
   TAccountRentSysvar extends
     | string
-    | IAccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountNonceAccount extends string
         ? WritableAccount<TAccountNonceAccount>
@@ -183,7 +183,7 @@ export function getInitializeNonceAccountInstruction<
 
 export type ParsedInitializeNonceAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -196,11 +196,11 @@ export type ParsedInitializeNonceAccountInstruction<
 
 export function parseInitializeNonceAccountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedInitializeNonceAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/transferSol.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/transferSol.ts
@@ -15,15 +15,15 @@ import {
   getU64Decoder,
   getU64Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type TransactionSigner,
   type WritableAccount,
   type WritableSignerAccount,
@@ -39,16 +39,16 @@ export function getTransferSolDiscriminatorBytes() {
 
 export type TransferSolInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountSource extends string | IAccountMeta<string> = string,
-  TAccountDestination extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountSource extends string | AccountMeta<string> = string,
+  TAccountDestination extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountSource extends string
         ? WritableSignerAccount<TAccountSource> &
-            IAccountSignerMeta<TAccountSource>
+            AccountSignerMeta<TAccountSource>
         : TAccountSource,
       TAccountDestination extends string
         ? WritableAccount<TAccountDestination>
@@ -149,7 +149,7 @@ export function getTransferSolInstruction<
 
 export type ParsedTransferSolInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -161,11 +161,11 @@ export type ParsedTransferSolInstruction<
 
 export function parseTransferSolInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedTransferSolInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/transferSolWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/transferSolWithSeed.ts
@@ -21,15 +21,15 @@ import {
   getUtf8Decoder,
   getUtf8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlySignerAccount,
   type TransactionSigner,
   type WritableAccount,
@@ -45,20 +45,20 @@ export function getTransferSolWithSeedDiscriminatorBytes() {
 
 export type TransferSolWithSeedInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountSource extends string | IAccountMeta<string> = string,
-  TAccountBaseAccount extends string | IAccountMeta<string> = string,
-  TAccountDestination extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountSource extends string | AccountMeta<string> = string,
+  TAccountBaseAccount extends string | AccountMeta<string> = string,
+  TAccountDestination extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountSource extends string
         ? WritableAccount<TAccountSource>
         : TAccountSource,
       TAccountBaseAccount extends string
         ? ReadonlySignerAccount<TAccountBaseAccount> &
-            IAccountSignerMeta<TAccountBaseAccount>
+            AccountSignerMeta<TAccountBaseAccount>
         : TAccountBaseAccount,
       TAccountDestination extends string
         ? WritableAccount<TAccountDestination>
@@ -185,7 +185,7 @@ export function getTransferSolWithSeedInstruction<
 
 export type ParsedTransferSolWithSeedInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -198,11 +198,11 @@ export type ParsedTransferSolWithSeedInstruction<
 
 export function parseTransferSolWithSeedInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedTransferSolWithSeedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/upgradeNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/upgradeNonceAccount.ts
@@ -13,14 +13,14 @@ import {
   getU32Decoder,
   getU32Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type WritableAccount,
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
@@ -34,11 +34,11 @@ export function getUpgradeNonceAccountDiscriminatorBytes() {
 
 export type UpgradeNonceAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNonceAccount extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountNonceAccount extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountNonceAccount extends string
         ? WritableAccount<TAccountNonceAccount>
@@ -112,7 +112,7 @@ export function getUpgradeNonceAccountInstruction<
 
 export type ParsedUpgradeNonceAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -123,11 +123,11 @@ export type ParsedUpgradeNonceAccountInstruction<
 
 export function parseUpgradeNonceAccountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedUpgradeNonceAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/instructions/withdrawNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/withdrawNonceAccount.ts
@@ -15,15 +15,15 @@ import {
   getU64Decoder,
   getU64Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -40,19 +40,19 @@ export function getWithdrawNonceAccountDiscriminatorBytes() {
 
 export type WithdrawNonceAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNonceAccount extends string | IAccountMeta<string> = string,
-  TAccountRecipientAccount extends string | IAccountMeta<string> = string,
+  TAccountNonceAccount extends string | AccountMeta<string> = string,
+  TAccountRecipientAccount extends string | AccountMeta<string> = string,
   TAccountRecentBlockhashesSysvar extends
     | string
-    | IAccountMeta<string> = 'SysvarRecentB1ockHashes11111111111111111111',
+    | AccountMeta<string> = 'SysvarRecentB1ockHashes11111111111111111111',
   TAccountRentSysvar extends
     | string
-    | IAccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
-  TAccountNonceAuthority extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
+  TAccountNonceAuthority extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountNonceAccount extends string
         ? WritableAccount<TAccountNonceAccount>
@@ -68,7 +68,7 @@ export type WithdrawNonceAccountInstruction<
         : TAccountRentSysvar,
       TAccountNonceAuthority extends string
         ? ReadonlySignerAccount<TAccountNonceAuthority> &
-            IAccountSignerMeta<TAccountNonceAuthority>
+            AccountSignerMeta<TAccountNonceAuthority>
         : TAccountNonceAuthority,
       ...TRemainingAccounts,
     ]
@@ -214,7 +214,7 @@ export function getWithdrawNonceAccountInstruction<
 
 export type ParsedWithdrawNonceAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -229,11 +229,11 @@ export type ParsedWithdrawNonceAccountInstruction<
 
 export function parseWithdrawNonceAccountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedWithdrawNonceAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 5) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/system/src/generated/shared/index.ts
+++ b/packages/renderers-js/e2e/system/src/generated/shared/index.ts
@@ -10,9 +10,9 @@ import {
   AccountRole,
   isProgramDerivedAddress,
   isTransactionSigner as kitIsTransactionSigner,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
-  type IAccountMeta,
-  type IAccountSignerMeta,
   type ProgramDerivedAddress,
   type TransactionSigner,
   upgradeRoleToSigner,
@@ -113,7 +113,7 @@ export type ResolvedAccount<
  * Defines an instruction that stores additional bytes on-chain.
  * @internal
  */
-export type IInstructionWithByteDelta = {
+export type InstructionWithByteDelta = {
   byteDelta: number;
 };
 
@@ -127,7 +127,7 @@ export function getAccountMetaFactory(
 ) {
   return (
     account: ResolvedAccount
-  ): IAccountMeta | IAccountSignerMeta | undefined => {
+  ): AccountMeta | AccountSignerMeta | undefined => {
     if (!account.value) {
       if (optionalAccountStrategy === 'omitted') return;
       return Object.freeze({

--- a/packages/renderers-js/e2e/system/test/_setup.ts
+++ b/packages/renderers-js/e2e/system/test/_setup.ts
@@ -1,12 +1,13 @@
 import {
   type Address,
+  type BaseTransactionMessage,
   type Commitment,
-  type CompilableTransactionMessage,
   type Rpc,
   type RpcSubscriptions,
   type SolanaRpcApi,
   type SolanaRpcSubscriptionsApi,
   type TransactionMessageWithBlockhashLifetime,
+  type TransactionMessageWithFeePayer,
   type TransactionSigner,
   airdropFactory,
   appendTransactionMessageInstruction,
@@ -56,7 +57,11 @@ export const generateKeyPairSignerWithSol = async (
 export const createDefaultTransaction = async (
   client: Client,
   feePayer: TransactionSigner
-) => {
+): Promise<
+  BaseTransactionMessage &
+    TransactionMessageWithFeePayer &
+    TransactionMessageWithBlockhashLifetime
+> => {
   const { value: latestBlockhash } = await client.rpc
     .getLatestBlockhash()
     .send();
@@ -69,7 +74,8 @@ export const createDefaultTransaction = async (
 
 export const signAndSendTransaction = async (
   client: Client,
-  transactionMessage: CompilableTransactionMessage &
+  transactionMessage: BaseTransactionMessage &
+    TransactionMessageWithFeePayer &
     TransactionMessageWithBlockhashLifetime,
   commitment: Commitment = 'confirmed'
 ) => {

--- a/packages/renderers-js/e2e/token/src/generated/instructions/amountToUiAmount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/amountToUiAmount.ts
@@ -15,14 +15,14 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -36,11 +36,11 @@ export function getAmountToUiAmountDiscriminatorBytes() {
 
 export type AmountToUiAmountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountMint extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountMint extends string
         ? ReadonlyAccount<TAccountMint>
@@ -129,7 +129,7 @@ export function getAmountToUiAmountInstruction<
 
 export type ParsedAmountToUiAmountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -141,11 +141,11 @@ export type ParsedAmountToUiAmountInstruction<
 
 export function parseAmountToUiAmountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedAmountToUiAmountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/approve.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/approve.ts
@@ -16,15 +16,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -41,13 +41,13 @@ export function getApproveDiscriminatorBytes() {
 
 export type ApproveInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountSource extends string | IAccountMeta<string> = string,
-  TAccountDelegate extends string | IAccountMeta<string> = string,
-  TAccountOwner extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountSource extends string | AccountMeta<string> = string,
+  TAccountDelegate extends string | AccountMeta<string> = string,
+  TAccountOwner extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountSource extends string
         ? WritableAccount<TAccountSource>
@@ -128,7 +128,7 @@ export function getApproveInstruction<
   TAccountSource,
   TAccountDelegate,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
     : TAccountOwner
 > {
   // Program address.
@@ -149,7 +149,7 @@ export function getApproveInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -174,7 +174,7 @@ export function getApproveInstruction<
     TAccountSource,
     TAccountDelegate,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
       : TAccountOwner
   >;
 
@@ -183,7 +183,7 @@ export function getApproveInstruction<
 
 export type ParsedApproveInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -199,11 +199,11 @@ export type ParsedApproveInstruction<
 
 export function parseApproveInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedApproveInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/approveChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/approveChecked.ts
@@ -16,15 +16,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -41,14 +41,14 @@ export function getApproveCheckedDiscriminatorBytes() {
 
 export type ApproveCheckedInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountSource extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountDelegate extends string | IAccountMeta<string> = string,
-  TAccountOwner extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountSource extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountDelegate extends string | AccountMeta<string> = string,
+  TAccountOwner extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountSource extends string
         ? WritableAccount<TAccountSource>
@@ -149,7 +149,7 @@ export function getApproveCheckedInstruction<
   TAccountMint,
   TAccountDelegate,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
     : TAccountOwner
 > {
   // Program address.
@@ -171,7 +171,7 @@ export function getApproveCheckedInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -198,7 +198,7 @@ export function getApproveCheckedInstruction<
     TAccountMint,
     TAccountDelegate,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
       : TAccountOwner
   >;
 
@@ -207,7 +207,7 @@ export function getApproveCheckedInstruction<
 
 export type ParsedApproveCheckedInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -225,11 +225,11 @@ export type ParsedApproveCheckedInstruction<
 
 export function parseApproveCheckedInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedApproveCheckedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 4) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/burn.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/burn.ts
@@ -16,15 +16,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -41,13 +41,13 @@ export function getBurnDiscriminatorBytes() {
 
 export type BurnInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountAuthority extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountAccount extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountAuthority extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountAccount extends string
         ? WritableAccount<TAccountAccount>
@@ -126,7 +126,7 @@ export function getBurnInstruction<
   TAccountMint,
   (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
     ? ReadonlySignerAccount<TAccountAuthority> &
-        IAccountSignerMeta<TAccountAuthority>
+        AccountSignerMeta<TAccountAuthority>
     : TAccountAuthority
 > {
   // Program address.
@@ -147,7 +147,7 @@ export function getBurnInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -173,7 +173,7 @@ export function getBurnInstruction<
     TAccountMint,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
       ? ReadonlySignerAccount<TAccountAuthority> &
-          IAccountSignerMeta<TAccountAuthority>
+          AccountSignerMeta<TAccountAuthority>
       : TAccountAuthority
   >;
 
@@ -182,7 +182,7 @@ export function getBurnInstruction<
 
 export type ParsedBurnInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -198,11 +198,11 @@ export type ParsedBurnInstruction<
 
 export function parseBurnInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedBurnInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/burnChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/burnChecked.ts
@@ -16,15 +16,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -41,13 +41,13 @@ export function getBurnCheckedDiscriminatorBytes() {
 
 export type BurnCheckedInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountAuthority extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountAccount extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountAuthority extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountAccount extends string
         ? WritableAccount<TAccountAccount>
@@ -136,7 +136,7 @@ export function getBurnCheckedInstruction<
   TAccountMint,
   (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
     ? ReadonlySignerAccount<TAccountAuthority> &
-        IAccountSignerMeta<TAccountAuthority>
+        AccountSignerMeta<TAccountAuthority>
     : TAccountAuthority
 > {
   // Program address.
@@ -157,7 +157,7 @@ export function getBurnCheckedInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -183,7 +183,7 @@ export function getBurnCheckedInstruction<
     TAccountMint,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
       ? ReadonlySignerAccount<TAccountAuthority> &
-          IAccountSignerMeta<TAccountAuthority>
+          AccountSignerMeta<TAccountAuthority>
       : TAccountAuthority
   >;
 
@@ -192,7 +192,7 @@ export function getBurnCheckedInstruction<
 
 export type ParsedBurnCheckedInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -208,11 +208,11 @@ export type ParsedBurnCheckedInstruction<
 
 export function parseBurnCheckedInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedBurnCheckedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/closeAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/closeAccount.ts
@@ -14,15 +14,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -39,13 +39,13 @@ export function getCloseAccountDiscriminatorBytes() {
 
 export type CloseAccountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | IAccountMeta<string> = string,
-  TAccountDestination extends string | IAccountMeta<string> = string,
-  TAccountOwner extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountAccount extends string | AccountMeta<string> = string,
+  TAccountDestination extends string | AccountMeta<string> = string,
+  TAccountOwner extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountAccount extends string
         ? WritableAccount<TAccountAccount>
@@ -112,7 +112,7 @@ export function getCloseAccountInstruction<
   TAccountAccount,
   TAccountDestination,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
     : TAccountOwner
 > {
   // Program address.
@@ -133,7 +133,7 @@ export function getCloseAccountInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -156,7 +156,7 @@ export function getCloseAccountInstruction<
     TAccountAccount,
     TAccountDestination,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
       : TAccountOwner
   >;
 
@@ -165,7 +165,7 @@ export function getCloseAccountInstruction<
 
 export type ParsedCloseAccountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -181,11 +181,11 @@ export type ParsedCloseAccountInstruction<
 
 export function parseCloseAccountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedCloseAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
@@ -20,15 +20,15 @@ import {
   getU64Decoder,
   getU64Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type Lamports,
   type TransactionSigner,
   type WritableSignerAccount,
@@ -36,7 +36,7 @@ import {
 import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
 import {
   getAccountMetaFactory,
-  type IInstructionWithByteDelta,
+  type InstructionWithByteDelta,
   type ResolvedAccount,
 } from '../shared';
 
@@ -48,20 +48,20 @@ export function getCreateAccountDiscriminatorBytes() {
 
 export type CreateAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountPayer extends string | IAccountMeta<string> = string,
-  TAccountNewAccount extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountPayer extends string | AccountMeta<string> = string,
+  TAccountNewAccount extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountPayer extends string
         ? WritableSignerAccount<TAccountPayer> &
-            IAccountSignerMeta<TAccountPayer>
+            AccountSignerMeta<TAccountPayer>
         : TAccountPayer,
       TAccountNewAccount extends string
         ? WritableSignerAccount<TAccountNewAccount> &
-            IAccountSignerMeta<TAccountNewAccount>
+            AccountSignerMeta<TAccountNewAccount>
         : TAccountNewAccount,
       ...TRemainingAccounts,
     ]
@@ -134,7 +134,7 @@ export function getCreateAccountInstruction<
   TAccountPayer,
   TAccountNewAccount
 > &
-  IInstructionWithByteDelta {
+  InstructionWithByteDelta {
   // Program address.
   const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
@@ -178,7 +178,7 @@ export function getCreateAccountInstruction<
 
 export type ParsedCreateAccountInstruction<
   TProgram extends string = typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -190,11 +190,11 @@ export type ParsedCreateAccountInstruction<
 
 export function parseCreateAccountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedCreateAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedToken.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedToken.ts
@@ -13,15 +13,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type TransactionSigner,
   type WritableAccount,
@@ -43,24 +43,24 @@ export function getCreateAssociatedTokenDiscriminatorBytes() {
 
 export type CreateAssociatedTokenInstruction<
   TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-  TAccountPayer extends string | IAccountMeta<string> = string,
-  TAccountAta extends string | IAccountMeta<string> = string,
-  TAccountOwner extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
+  TAccountPayer extends string | AccountMeta<string> = string,
+  TAccountAta extends string | AccountMeta<string> = string,
+  TAccountOwner extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
   TAccountSystemProgram extends
     | string
-    | IAccountMeta<string> = '11111111111111111111111111111111',
+    | AccountMeta<string> = '11111111111111111111111111111111',
   TAccountTokenProgram extends
     | string
-    | IAccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountPayer extends string
         ? WritableSignerAccount<TAccountPayer> &
-            IAccountSignerMeta<TAccountPayer>
+            AccountSignerMeta<TAccountPayer>
         : TAccountPayer,
       TAccountAta extends string ? WritableAccount<TAccountAta> : TAccountAta,
       TAccountOwner extends string
@@ -322,7 +322,7 @@ export function getCreateAssociatedTokenInstruction<
 
 export type ParsedCreateAssociatedTokenInstruction<
   TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -344,11 +344,11 @@ export type ParsedCreateAssociatedTokenInstruction<
 
 export function parseCreateAssociatedTokenInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedCreateAssociatedTokenInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 6) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
@@ -13,15 +13,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type TransactionSigner,
   type WritableAccount,
@@ -45,24 +45,24 @@ export function getCreateAssociatedTokenIdempotentDiscriminatorBytes() {
 
 export type CreateAssociatedTokenIdempotentInstruction<
   TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-  TAccountPayer extends string | IAccountMeta<string> = string,
-  TAccountAta extends string | IAccountMeta<string> = string,
-  TAccountOwner extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
+  TAccountPayer extends string | AccountMeta<string> = string,
+  TAccountAta extends string | AccountMeta<string> = string,
+  TAccountOwner extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
   TAccountSystemProgram extends
     | string
-    | IAccountMeta<string> = '11111111111111111111111111111111',
+    | AccountMeta<string> = '11111111111111111111111111111111',
   TAccountTokenProgram extends
     | string
-    | IAccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountPayer extends string
         ? WritableSignerAccount<TAccountPayer> &
-            IAccountSignerMeta<TAccountPayer>
+            AccountSignerMeta<TAccountPayer>
         : TAccountPayer,
       TAccountAta extends string ? WritableAccount<TAccountAta> : TAccountAta,
       TAccountOwner extends string
@@ -326,7 +326,7 @@ export function getCreateAssociatedTokenIdempotentInstruction<
 
 export type ParsedCreateAssociatedTokenIdempotentInstruction<
   TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -348,11 +348,11 @@ export type ParsedCreateAssociatedTokenIdempotentInstruction<
 
 export function parseCreateAssociatedTokenIdempotentInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedCreateAssociatedTokenIdempotentInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 6) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/freezeAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/freezeAccount.ts
@@ -14,15 +14,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -39,13 +39,13 @@ export function getFreezeAccountDiscriminatorBytes() {
 
 export type FreezeAccountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountOwner extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountAccount extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountOwner extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountAccount extends string
         ? WritableAccount<TAccountAccount>
@@ -112,7 +112,7 @@ export function getFreezeAccountInstruction<
   TAccountAccount,
   TAccountMint,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
     : TAccountOwner
 > {
   // Program address.
@@ -133,7 +133,7 @@ export function getFreezeAccountInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -156,7 +156,7 @@ export function getFreezeAccountInstruction<
     TAccountAccount,
     TAccountMint,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
       : TAccountOwner
   >;
 
@@ -165,7 +165,7 @@ export function getFreezeAccountInstruction<
 
 export type ParsedFreezeAccountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -181,11 +181,11 @@ export type ParsedFreezeAccountInstruction<
 
 export function parseFreezeAccountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedFreezeAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/getAccountDataSize.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/getAccountDataSize.ts
@@ -13,14 +13,14 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -34,11 +34,11 @@ export function getGetAccountDataSizeDiscriminatorBytes() {
 
 export type GetAccountDataSizeInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountMint extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountMint extends string
         ? ReadonlyAccount<TAccountMint>
@@ -111,7 +111,7 @@ export function getGetAccountDataSizeInstruction<
 
 export type ParsedGetAccountDataSizeInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -123,11 +123,11 @@ export type ParsedGetAccountDataSizeInstruction<
 
 export function parseGetAccountDataSizeInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedGetAccountDataSizeInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount.ts
@@ -13,14 +13,14 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type WritableAccount,
 } from '@solana/kit';
@@ -35,16 +35,16 @@ export function getInitializeAccountDiscriminatorBytes() {
 
 export type InitializeAccountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountOwner extends string | IAccountMeta<string> = string,
+  TAccountAccount extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountOwner extends string | AccountMeta<string> = string,
   TAccountRent extends
     | string
-    | IAccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountAccount extends string
         ? WritableAccount<TAccountAccount>
@@ -168,7 +168,7 @@ export function getInitializeAccountInstruction<
 
 export type ParsedInitializeAccountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -186,11 +186,11 @@ export type ParsedInitializeAccountInstruction<
 
 export function parseInitializeAccountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedInitializeAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 4) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount2.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount2.ts
@@ -15,14 +15,14 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type WritableAccount,
 } from '@solana/kit';
@@ -37,15 +37,15 @@ export function getInitializeAccount2DiscriminatorBytes() {
 
 export type InitializeAccount2Instruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
+  TAccountAccount extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
   TAccountRent extends
     | string
-    | IAccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountAccount extends string
         ? WritableAccount<TAccountAccount>
@@ -172,7 +172,7 @@ export function getInitializeAccount2Instruction<
 
 export type ParsedInitializeAccount2Instruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -188,11 +188,11 @@ export type ParsedInitializeAccount2Instruction<
 
 export function parseInitializeAccount2Instruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedInitializeAccount2Instruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount3.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount3.ts
@@ -15,14 +15,14 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type WritableAccount,
 } from '@solana/kit';
@@ -37,12 +37,12 @@ export function getInitializeAccount3DiscriminatorBytes() {
 
 export type InitializeAccount3Instruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountAccount extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountAccount extends string
         ? WritableAccount<TAccountAccount>
@@ -149,7 +149,7 @@ export function getInitializeAccount3Instruction<
 
 export type ParsedInitializeAccount3Instruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -163,11 +163,11 @@ export type ParsedInitializeAccount3Instruction<
 
 export function parseInitializeAccount3Instruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedInitializeAccount3Instruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeImmutableOwner.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeImmutableOwner.ts
@@ -13,14 +13,14 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -34,11 +34,11 @@ export function getInitializeImmutableOwnerDiscriminatorBytes() {
 
 export type InitializeImmutableOwnerInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountAccount extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountAccount extends string
         ? WritableAccount<TAccountAccount>
@@ -113,7 +113,7 @@ export function getInitializeImmutableOwnerInstruction<
 
 export type ParsedInitializeImmutableOwnerInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -125,11 +125,11 @@ export type ParsedInitializeImmutableOwnerInstruction<
 
 export function parseInitializeImmutableOwnerInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedInitializeImmutableOwnerInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint.ts
@@ -18,14 +18,14 @@ import {
   getU8Encoder,
   none,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type Option,
   type OptionOrNullable,
   type ReadonlyAccount,
@@ -42,14 +42,14 @@ export function getInitializeMintDiscriminatorBytes() {
 
 export type InitializeMintInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | IAccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
   TAccountRent extends
     | string
-    | IAccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountMint extends string
         ? WritableAccount<TAccountMint>
@@ -172,7 +172,7 @@ export function getInitializeMintInstruction<
 
 export type ParsedInitializeMintInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -186,11 +186,11 @@ export type ParsedInitializeMintInstruction<
 
 export function parseInitializeMintInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedInitializeMintInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint2.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint2.ts
@@ -18,14 +18,14 @@ import {
   getU8Encoder,
   none,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type Option,
   type OptionOrNullable,
   type WritableAccount,
@@ -41,11 +41,11 @@ export function getInitializeMint2DiscriminatorBytes() {
 
 export type InitializeMint2Instruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountMint extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountMint extends string
         ? WritableAccount<TAccountMint>
@@ -152,7 +152,7 @@ export function getInitializeMint2Instruction<
 
 export type ParsedInitializeMint2Instruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -164,11 +164,11 @@ export type ParsedInitializeMint2Instruction<
 
 export function parseInitializeMint2Instruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedInitializeMint2Instruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig.ts
@@ -14,14 +14,14 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type WritableAccount,
 } from '@solana/kit';
@@ -36,14 +36,14 @@ export function getInitializeMultisigDiscriminatorBytes() {
 
 export type InitializeMultisigInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMultisig extends string | IAccountMeta<string> = string,
+  TAccountMultisig extends string | AccountMeta<string> = string,
   TAccountRent extends
     | string
-    | IAccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = 'SysvarRent111111111111111111111111111111111',
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountMultisig extends string
         ? WritableAccount<TAccountMultisig>
@@ -140,7 +140,7 @@ export function getInitializeMultisigInstruction<
   }
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = args.signers.map((address) => ({
+  const remainingAccounts: AccountMeta[] = args.signers.map((address) => ({
     address,
     role: AccountRole.READONLY,
   }));
@@ -167,7 +167,7 @@ export function getInitializeMultisigInstruction<
 
 export type ParsedInitializeMultisigInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -181,11 +181,11 @@ export type ParsedInitializeMultisigInstruction<
 
 export function parseInitializeMultisigInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedInitializeMultisigInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig2.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig2.ts
@@ -14,14 +14,14 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -35,11 +35,11 @@ export function getInitializeMultisig2DiscriminatorBytes() {
 
 export type InitializeMultisig2Instruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMultisig extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountMultisig extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountMultisig extends string
         ? WritableAccount<TAccountMultisig>
@@ -117,7 +117,7 @@ export function getInitializeMultisig2Instruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = args.signers.map((address) => ({
+  const remainingAccounts: AccountMeta[] = args.signers.map((address) => ({
     address,
     role: AccountRole.READONLY,
   }));
@@ -136,7 +136,7 @@ export function getInitializeMultisig2Instruction<
 
 export type ParsedInitializeMultisig2Instruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -148,11 +148,11 @@ export type ParsedInitializeMultisig2Instruction<
 
 export function parseInitializeMultisig2Instruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedInitializeMultisig2Instruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/mintTo.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/mintTo.ts
@@ -16,15 +16,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -41,13 +41,13 @@ export function getMintToDiscriminatorBytes() {
 
 export type MintToInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountToken extends string | IAccountMeta<string> = string,
-  TAccountMintAuthority extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountToken extends string | AccountMeta<string> = string,
+  TAccountMintAuthority extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountMint extends string
         ? WritableAccount<TAccountMint>
@@ -131,7 +131,7 @@ export function getMintToInstruction<
   TAccountToken,
   (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
     ? ReadonlySignerAccount<TAccountMintAuthority> &
-        IAccountSignerMeta<TAccountMintAuthority>
+        AccountSignerMeta<TAccountMintAuthority>
     : TAccountMintAuthority
 > {
   // Program address.
@@ -152,7 +152,7 @@ export function getMintToInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -178,7 +178,7 @@ export function getMintToInstruction<
     TAccountToken,
     (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
       ? ReadonlySignerAccount<TAccountMintAuthority> &
-          IAccountSignerMeta<TAccountMintAuthority>
+          AccountSignerMeta<TAccountMintAuthority>
       : TAccountMintAuthority
   >;
 
@@ -187,7 +187,7 @@ export function getMintToInstruction<
 
 export type ParsedMintToInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -203,11 +203,11 @@ export type ParsedMintToInstruction<
 
 export function parseMintToInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedMintToInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/mintToChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/mintToChecked.ts
@@ -16,15 +16,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -41,13 +41,13 @@ export function getMintToCheckedDiscriminatorBytes() {
 
 export type MintToCheckedInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountToken extends string | IAccountMeta<string> = string,
-  TAccountMintAuthority extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountToken extends string | AccountMeta<string> = string,
+  TAccountMintAuthority extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountMint extends string
         ? WritableAccount<TAccountMint>
@@ -138,7 +138,7 @@ export function getMintToCheckedInstruction<
   TAccountToken,
   (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
     ? ReadonlySignerAccount<TAccountMintAuthority> &
-        IAccountSignerMeta<TAccountMintAuthority>
+        AccountSignerMeta<TAccountMintAuthority>
     : TAccountMintAuthority
 > {
   // Program address.
@@ -159,7 +159,7 @@ export function getMintToCheckedInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -185,7 +185,7 @@ export function getMintToCheckedInstruction<
     TAccountToken,
     (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
       ? ReadonlySignerAccount<TAccountMintAuthority> &
-          IAccountSignerMeta<TAccountMintAuthority>
+          AccountSignerMeta<TAccountMintAuthority>
       : TAccountMintAuthority
   >;
 
@@ -194,7 +194,7 @@ export function getMintToCheckedInstruction<
 
 export type ParsedMintToCheckedInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -210,11 +210,11 @@ export type ParsedMintToCheckedInstruction<
 
 export function parseMintToCheckedInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedMintToCheckedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
@@ -13,15 +13,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type TransactionSigner,
   type WritableAccount,
@@ -45,23 +45,23 @@ export type RecoverNestedAssociatedTokenInstruction<
   TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
   TAccountNestedAssociatedAccountAddress extends
     | string
-    | IAccountMeta<string> = string,
-  TAccountNestedTokenMintAddress extends string | IAccountMeta<string> = string,
+    | AccountMeta<string> = string,
+  TAccountNestedTokenMintAddress extends string | AccountMeta<string> = string,
   TAccountDestinationAssociatedAccountAddress extends
     | string
-    | IAccountMeta<string> = string,
+    | AccountMeta<string> = string,
   TAccountOwnerAssociatedAccountAddress extends
     | string
-    | IAccountMeta<string> = string,
-  TAccountOwnerTokenMintAddress extends string | IAccountMeta<string> = string,
-  TAccountWalletAddress extends string | IAccountMeta<string> = string,
+    | AccountMeta<string> = string,
+  TAccountOwnerTokenMintAddress extends string | AccountMeta<string> = string,
+  TAccountWalletAddress extends string | AccountMeta<string> = string,
   TAccountTokenProgram extends
     | string
-    | IAccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+    | AccountMeta<string> = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountNestedAssociatedAccountAddress extends string
         ? WritableAccount<TAccountNestedAssociatedAccountAddress>
@@ -80,7 +80,7 @@ export type RecoverNestedAssociatedTokenInstruction<
         : TAccountOwnerTokenMintAddress,
       TAccountWalletAddress extends string
         ? WritableSignerAccount<TAccountWalletAddress> &
-            IAccountSignerMeta<TAccountWalletAddress>
+            AccountSignerMeta<TAccountWalletAddress>
         : TAccountWalletAddress,
       TAccountTokenProgram extends string
         ? ReadonlyAccount<TAccountTokenProgram>
@@ -392,7 +392,7 @@ export function getRecoverNestedAssociatedTokenInstruction<
 
 export type ParsedRecoverNestedAssociatedTokenInstruction<
   TProgram extends string = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -416,11 +416,11 @@ export type ParsedRecoverNestedAssociatedTokenInstruction<
 
 export function parseRecoverNestedAssociatedTokenInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedRecoverNestedAssociatedTokenInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 7) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/revoke.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/revoke.ts
@@ -14,15 +14,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -39,12 +39,12 @@ export function getRevokeDiscriminatorBytes() {
 
 export type RevokeInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountSource extends string | IAccountMeta<string> = string,
-  TAccountOwner extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountSource extends string | AccountMeta<string> = string,
+  TAccountOwner extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountSource extends string
         ? WritableAccount<TAccountSource>
@@ -103,7 +103,7 @@ export function getRevokeInstruction<
   TProgramAddress,
   TAccountSource,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
     : TAccountOwner
 > {
   // Program address.
@@ -123,7 +123,7 @@ export function getRevokeInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -144,7 +144,7 @@ export function getRevokeInstruction<
     TProgramAddress,
     TAccountSource,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
       : TAccountOwner
   >;
 
@@ -153,7 +153,7 @@ export function getRevokeInstruction<
 
 export type ParsedRevokeInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -167,11 +167,11 @@ export type ParsedRevokeInstruction<
 
 export function parseRevokeInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedRevokeInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/setAuthority.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/setAuthority.ts
@@ -18,15 +18,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type Option,
   type OptionOrNullable,
   type ReadonlyAccount,
@@ -51,12 +51,12 @@ export function getSetAuthorityDiscriminatorBytes() {
 
 export type SetAuthorityInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountOwned extends string | IAccountMeta<string> = string,
-  TAccountOwner extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountOwned extends string | AccountMeta<string> = string,
+  TAccountOwner extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountOwned extends string
         ? WritableAccount<TAccountOwned>
@@ -136,7 +136,7 @@ export function getSetAuthorityInstruction<
   TProgramAddress,
   TAccountOwned,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
     : TAccountOwner
 > {
   // Program address.
@@ -156,7 +156,7 @@ export function getSetAuthorityInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -179,7 +179,7 @@ export function getSetAuthorityInstruction<
     TProgramAddress,
     TAccountOwned,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
       : TAccountOwner
   >;
 
@@ -188,7 +188,7 @@ export function getSetAuthorityInstruction<
 
 export type ParsedSetAuthorityInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -202,11 +202,11 @@ export type ParsedSetAuthorityInstruction<
 
 export function parseSetAuthorityInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedSetAuthorityInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 2) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/syncNative.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/syncNative.ts
@@ -13,14 +13,14 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type WritableAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -34,11 +34,11 @@ export function getSyncNativeDiscriminatorBytes() {
 
 export type SyncNativeInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountAccount extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountAccount extends string
         ? WritableAccount<TAccountAccount>
@@ -108,7 +108,7 @@ export function getSyncNativeInstruction<
 
 export type ParsedSyncNativeInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -120,11 +120,11 @@ export type ParsedSyncNativeInstruction<
 
 export function parseSyncNativeInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedSyncNativeInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/thawAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/thawAccount.ts
@@ -14,15 +14,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -39,13 +39,13 @@ export function getThawAccountDiscriminatorBytes() {
 
 export type ThawAccountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountOwner extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountAccount extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountOwner extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountAccount extends string
         ? WritableAccount<TAccountAccount>
@@ -112,7 +112,7 @@ export function getThawAccountInstruction<
   TAccountAccount,
   TAccountMint,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-    ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+    ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
     : TAccountOwner
 > {
   // Program address.
@@ -133,7 +133,7 @@ export function getThawAccountInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -156,7 +156,7 @@ export function getThawAccountInstruction<
     TAccountAccount,
     TAccountMint,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
-      ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
+      ? ReadonlySignerAccount<TAccountOwner> & AccountSignerMeta<TAccountOwner>
       : TAccountOwner
   >;
 
@@ -165,7 +165,7 @@ export function getThawAccountInstruction<
 
 export type ParsedThawAccountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -181,11 +181,11 @@ export type ParsedThawAccountInstruction<
 
 export function parseThawAccountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedThawAccountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/transfer.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/transfer.ts
@@ -16,15 +16,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -41,13 +41,13 @@ export function getTransferDiscriminatorBytes() {
 
 export type TransferInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountSource extends string | IAccountMeta<string> = string,
-  TAccountDestination extends string | IAccountMeta<string> = string,
-  TAccountAuthority extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountSource extends string | AccountMeta<string> = string,
+  TAccountDestination extends string | AccountMeta<string> = string,
+  TAccountAuthority extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountSource extends string
         ? WritableAccount<TAccountSource>
@@ -129,7 +129,7 @@ export function getTransferInstruction<
   TAccountDestination,
   (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
     ? ReadonlySignerAccount<TAccountAuthority> &
-        IAccountSignerMeta<TAccountAuthority>
+        AccountSignerMeta<TAccountAuthority>
     : TAccountAuthority
 > {
   // Program address.
@@ -150,7 +150,7 @@ export function getTransferInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -176,7 +176,7 @@ export function getTransferInstruction<
     TAccountDestination,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
       ? ReadonlySignerAccount<TAccountAuthority> &
-          IAccountSignerMeta<TAccountAuthority>
+          AccountSignerMeta<TAccountAuthority>
       : TAccountAuthority
   >;
 
@@ -185,7 +185,7 @@ export function getTransferInstruction<
 
 export type ParsedTransferInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -201,11 +201,11 @@ export type ParsedTransferInstruction<
 
 export function parseTransferInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedTransferInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 3) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/transferChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/transferChecked.ts
@@ -16,15 +16,15 @@ import {
   getU8Decoder,
   getU8Encoder,
   transformEncoder,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IAccountSignerMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -41,14 +41,14 @@ export function getTransferCheckedDiscriminatorBytes() {
 
 export type TransferCheckedInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountSource extends string | IAccountMeta<string> = string,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TAccountDestination extends string | IAccountMeta<string> = string,
-  TAccountAuthority extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountSource extends string | AccountMeta<string> = string,
+  TAccountMint extends string | AccountMeta<string> = string,
+  TAccountDestination extends string | AccountMeta<string> = string,
+  TAccountAuthority extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountSource extends string
         ? WritableAccount<TAccountSource>
@@ -150,7 +150,7 @@ export function getTransferCheckedInstruction<
   TAccountDestination,
   (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
     ? ReadonlySignerAccount<TAccountAuthority> &
-        IAccountSignerMeta<TAccountAuthority>
+        AccountSignerMeta<TAccountAuthority>
     : TAccountAuthority
 > {
   // Program address.
@@ -172,7 +172,7 @@ export function getTransferCheckedInstruction<
   const args = { ...input };
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = (args.multiSigners ?? []).map(
+  const remainingAccounts: AccountMeta[] = (args.multiSigners ?? []).map(
     (signer) => ({
       address: signer.address,
       role: AccountRole.READONLY_SIGNER,
@@ -200,7 +200,7 @@ export function getTransferCheckedInstruction<
     TAccountDestination,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
       ? ReadonlySignerAccount<TAccountAuthority> &
-          IAccountSignerMeta<TAccountAuthority>
+          AccountSignerMeta<TAccountAuthority>
       : TAccountAuthority
   >;
 
@@ -209,7 +209,7 @@ export function getTransferCheckedInstruction<
 
 export type ParsedTransferCheckedInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -227,11 +227,11 @@ export type ParsedTransferCheckedInstruction<
 
 export function parseTransferCheckedInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedTransferCheckedInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 4) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/instructions/uiAmountToAmount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/uiAmountToAmount.ts
@@ -15,14 +15,14 @@ import {
   getUtf8Decoder,
   getUtf8Encoder,
   transformEncoder,
+  type AccountMeta,
   type Address,
   type Codec,
   type Decoder,
   type Encoder,
-  type IAccountMeta,
-  type IInstruction,
-  type IInstructionWithAccounts,
-  type IInstructionWithData,
+  type Instruction,
+  type InstructionWithAccounts,
+  type InstructionWithData,
   type ReadonlyAccount,
 } from '@solana/kit';
 import { TOKEN_PROGRAM_ADDRESS } from '../programs';
@@ -36,11 +36,11 @@ export function getUiAmountToAmountDiscriminatorBytes() {
 
 export type UiAmountToAmountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint extends string | IAccountMeta<string> = string,
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram> &
-  IInstructionWithData<Uint8Array> &
-  IInstructionWithAccounts<
+  TAccountMint extends string | AccountMeta<string> = string,
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram> &
+  InstructionWithData<Uint8Array> &
+  InstructionWithAccounts<
     [
       TAccountMint extends string
         ? ReadonlyAccount<TAccountMint>
@@ -129,7 +129,7 @@ export function getUiAmountToAmountInstruction<
 
 export type ParsedUiAmountToAmountInstruction<
   TProgram extends string = typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
   programAddress: Address<TProgram>;
   accounts: {
@@ -141,11 +141,11 @@ export type ParsedUiAmountToAmountInstruction<
 
 export function parseUiAmountToAmountInstruction<
   TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[],
+  TAccountMetas extends readonly AccountMeta[],
 >(
-  instruction: IInstruction<TProgram> &
-    IInstructionWithAccounts<TAccountMetas> &
-    IInstructionWithData<Uint8Array>
+  instruction: Instruction<TProgram> &
+    InstructionWithAccounts<TAccountMetas> &
+    InstructionWithData<Uint8Array>
 ): ParsedUiAmountToAmountInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 1) {
     // TODO: Coded error.

--- a/packages/renderers-js/e2e/token/src/generated/shared/index.ts
+++ b/packages/renderers-js/e2e/token/src/generated/shared/index.ts
@@ -10,9 +10,9 @@ import {
   AccountRole,
   isProgramDerivedAddress,
   isTransactionSigner as kitIsTransactionSigner,
+  type AccountMeta,
+  type AccountSignerMeta,
   type Address,
-  type IAccountMeta,
-  type IAccountSignerMeta,
   type ProgramDerivedAddress,
   type TransactionSigner,
   upgradeRoleToSigner,
@@ -113,7 +113,7 @@ export type ResolvedAccount<
  * Defines an instruction that stores additional bytes on-chain.
  * @internal
  */
-export type IInstructionWithByteDelta = {
+export type InstructionWithByteDelta = {
   byteDelta: number;
 };
 
@@ -127,7 +127,7 @@ export function getAccountMetaFactory(
 ) {
   return (
     account: ResolvedAccount
-  ): IAccountMeta | IAccountSignerMeta | undefined => {
+  ): AccountMeta | AccountSignerMeta | undefined => {
     if (!account.value) {
       if (optionalAccountStrategy === 'omitted') return;
       return Object.freeze({

--- a/packages/renderers-js/e2e/token/test/_setup.ts
+++ b/packages/renderers-js/e2e/token/test/_setup.ts
@@ -1,12 +1,13 @@
 import {
   type Address,
+  type BaseTransactionMessage,
   type Commitment,
-  type CompilableTransactionMessage,
   type Rpc,
   type RpcSubscriptions,
   type SolanaRpcApi,
   type SolanaRpcSubscriptionsApi,
   type TransactionMessageWithBlockhashLifetime,
+  type TransactionMessageWithFeePayer,
   type TransactionSigner,
   airdropFactory,
   appendTransactionMessageInstructions,
@@ -59,7 +60,11 @@ export const generateKeyPairSignerWithSol = async (
 export const createDefaultTransaction = async (
   client: Client,
   feePayer: TransactionSigner
-) => {
+): Promise<
+  BaseTransactionMessage &
+    TransactionMessageWithFeePayer &
+    TransactionMessageWithBlockhashLifetime
+> => {
   const { value: latestBlockhash } = await client.rpc
     .getLatestBlockhash()
     .send();
@@ -72,7 +77,8 @@ export const createDefaultTransaction = async (
 
 export const signAndSendTransaction = async (
   client: Client,
-  transactionMessage: CompilableTransactionMessage &
+  transactionMessage: BaseTransactionMessage &
+    TransactionMessageWithFeePayer &
     TransactionMessageWithBlockhashLifetime,
   commitment: Commitment = 'confirmed'
 ) => {

--- a/packages/renderers-js/package.json
+++ b/packages/renderers-js/package.json
@@ -46,7 +46,7 @@
         "@codama/nodes": "workspace:*",
         "@codama/renderers-core": "workspace:*",
         "@codama/visitors-core": "workspace:*",
-        "@solana/codecs-strings": "^2.1.0",
+        "@solana/codecs-strings": "^2.3.0",
         "nunjucks": "^3.2.4",
         "prettier": "^3.6.2"
     },

--- a/packages/renderers-js/public/templates/fragments/instructionParseFunction.njk
+++ b/packages/renderers-js/public/templates/fragments/instructionParseFunction.njk
@@ -3,7 +3,7 @@
 export type {{ instructionParsedType }}<
   TProgram extends string = typeof {{ programAddressConstant }},
   {% if hasAccounts %}
-    TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
+    TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
   {% endif %}
 > = {
   programAddress: Address<TProgram>;
@@ -25,15 +25,15 @@ export type {{ instructionParsedType }}<
 export function {{ instructionParseFunction }}<
   TProgram extends string,
   {% if hasAccounts %}
-    TAccountMetas extends readonly IAccountMeta[],
+    TAccountMetas extends readonly AccountMeta[],
   {% endif %}
 >(
-  instruction: IInstruction<TProgram>
+  instruction: Instruction<TProgram>
     {% if hasAccounts %}
-      & IInstructionWithAccounts<TAccountMetas>
+      & InstructionWithAccounts<TAccountMetas>
     {% endif %}
     {% if hasData %}
-      & IInstructionWithData<Uint8Array>
+      & InstructionWithData<Uint8Array>
     {% endif %}
 ): {{ instructionParsedType }}<TProgram {{ ', TAccountMetas' if hasAccounts }}> {
   {% if hasAccounts %}

--- a/packages/renderers-js/public/templates/fragments/instructionType.njk
+++ b/packages/renderers-js/public/templates/fragments/instructionType.njk
@@ -5,14 +5,14 @@ export type {{ instructionType }}<
   {% if hasAccounts %}
     {{ accountTypeParams }},
   {% endif %}
-  TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
-> = IInstruction<TProgram>
+  TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> = Instruction<TProgram>
   {% if hasData %}
-    & IInstructionWithData<Uint8Array>
+    & InstructionWithData<Uint8Array>
   {% endif %}
   {% if hasAccounts %}
-    & IInstructionWithAccounts<[{{ accountMetas }}, ...TRemainingAccounts]>
+    & InstructionWithAccounts<[{{ accountMetas }}, ...TRemainingAccounts]>
   {% else %}
-    & IInstructionWithAccounts<TRemainingAccounts>
+    & InstructionWithAccounts<TRemainingAccounts>
   {% endif %}
 ;

--- a/packages/renderers-js/public/templates/pages/sharedPage.njk
+++ b/packages/renderers-js/public/templates/pages/sharedPage.njk
@@ -73,7 +73,7 @@ export type ResolvedAccount<T extends string = string, U extends Address<T> | Pr
  * Defines an instruction that stores additional bytes on-chain.
  * @internal
  */
-export type IInstructionWithByteDelta = {
+export type InstructionWithByteDelta = {
   byteDelta: number;
 };
 
@@ -85,7 +85,7 @@ export function getAccountMetaFactory(
   programAddress: Address,
   optionalAccountStrategy: 'omitted' | 'programId',
 ) {
-  return (account: ResolvedAccount): IAccountMeta | IAccountSignerMeta | undefined => {
+  return (account: ResolvedAccount): AccountMeta | AccountSignerMeta | undefined => {
     if (!account.value) {
       if (optionalAccountStrategy === 'omitted') return;
       return Object.freeze({ address: programAddress, role: AccountRole.READONLY });

--- a/packages/renderers-js/src/fragments/instructionAccountMeta.ts
+++ b/packages/renderers-js/src/fragments/instructionAccountMeta.ts
@@ -7,16 +7,16 @@ export function getInstructionAccountMetaFragment(instructionAccountNode: Instru
 
     // Writable, signer.
     if (instructionAccountNode.isSigner === true && instructionAccountNode.isWritable) {
-        return fragment(`WritableSignerAccount<${typeParam}> & IAccountSignerMeta<${typeParam}>`)
+        return fragment(`WritableSignerAccount<${typeParam}> & AccountSignerMeta<${typeParam}>`)
             .addImports('solanaInstructions', ['type WritableSignerAccount'])
-            .addImports('solanaSigners', ['type IAccountSignerMeta']);
+            .addImports('solanaSigners', ['type AccountSignerMeta']);
     }
 
     // Readonly, signer.
     if (instructionAccountNode.isSigner === true) {
-        return fragment(`ReadonlySignerAccount<${typeParam}> & IAccountSignerMeta<${typeParam}>`)
+        return fragment(`ReadonlySignerAccount<${typeParam}> & AccountSignerMeta<${typeParam}>`)
             .addImports('solanaInstructions', ['type ReadonlySignerAccount'])
-            .addImports('solanaSigners', ['type IAccountSignerMeta']);
+            .addImports('solanaSigners', ['type AccountSignerMeta']);
     }
 
     // Writable, non-signer or optional signer.

--- a/packages/renderers-js/src/fragments/instructionAccountTypeParam.ts
+++ b/packages/renderers-js/src/fragments/instructionAccountTypeParam.ts
@@ -22,10 +22,10 @@ export function getInstructionAccountTypeParamFragment(
     const instructionNode = findInstructionNodeFromPath(instructionAccountPath)!;
     const programNode = findProgramNodeFromPath(instructionAccountPath)!;
     const typeParam = `TAccount${pascalCase(instructionAccountNode.name)}`;
-    const accountMeta = allowAccountMeta ? ' | IAccountMeta<string>' : '';
+    const accountMeta = allowAccountMeta ? ' | AccountMeta<string>' : '';
     const imports = new ImportMap();
     if (allowAccountMeta) {
-        imports.add('solanaInstructions', 'type IAccountMeta');
+        imports.add('solanaInstructions', 'type AccountMeta');
     }
 
     if (instructionNode.optionalAccountStrategy === 'omitted' && instructionAccountNode.isOptional) {

--- a/packages/renderers-js/src/fragments/instructionFunction.ts
+++ b/packages/renderers-js/src/fragments/instructionFunction.ts
@@ -107,7 +107,7 @@ export function getInstructionFunctionFragment(
     const getReturnType = (instructionType: string) => {
         let returnType = instructionType;
         if (hasByteDeltas) {
-            returnType = `${returnType} & IInstructionWithByteDelta`;
+            returnType = `${returnType} & InstructionWithByteDelta`;
         }
         return useAsync ? `Promise<${returnType}>` : returnType;
     };
@@ -150,12 +150,12 @@ export function getInstructionFunctionFragment(
 
     if (hasAccounts) {
         functionFragment
-            .addImports('solanaInstructions', ['type IAccountMeta'])
+            .addImports('solanaInstructions', ['type AccountMeta'])
             .addImports('shared', ['getAccountMetaFactory', 'type ResolvedAccount']);
     }
 
     if (hasByteDeltas) {
-        functionFragment.addImports('shared', ['type IInstructionWithByteDelta']);
+        functionFragment.addImports('shared', ['type InstructionWithByteDelta']);
     }
 
     return functionFragment;
@@ -183,11 +183,11 @@ function getInstructionType(scope: { instructionPath: NodePath<InstructionNode>;
             const signerRole = account.isWritable ? 'WritableSignerAccount' : 'ReadonlySignerAccount';
             return fragment(
                 `typeof input["${camelName}"] extends TransactionSigner<${typeParam}> ` +
-                    `? ${signerRole}<${typeParam}> & IAccountSignerMeta<${typeParam}> ` +
+                    `? ${signerRole}<${typeParam}> & AccountSignerMeta<${typeParam}> ` +
                     `: ${typeParam}`,
             )
                 .addImports('solanaInstructions', [`type ${signerRole}`])
-                .addImports('solanaSigners', ['type IAccountSignerMeta']);
+                .addImports('solanaSigners', ['type AccountSignerMeta']);
         }
 
         return fragment(typeParam);

--- a/packages/renderers-js/src/fragments/instructionParseFunction.ts
+++ b/packages/renderers-js/src/fragments/instructionParseFunction.ts
@@ -49,7 +49,7 @@ export function getInstructionParseFunctionFragment(
     })
         .mergeImportsWith(dataTypeFragment)
         .addImports('generatedPrograms', [programAddressConstant])
-        .addImports('solanaInstructions', ['type IInstruction'])
-        .addImports('solanaInstructions', hasAccounts ? ['type IInstructionWithAccounts', 'type IAccountMeta'] : [])
-        .addImports('solanaInstructions', hasData ? ['type IInstructionWithData'] : []);
+        .addImports('solanaInstructions', ['type Instruction'])
+        .addImports('solanaInstructions', hasAccounts ? ['type InstructionWithAccounts', 'type AccountMeta'] : [])
+        .addImports('solanaInstructions', hasData ? ['type InstructionWithData'] : []);
 }

--- a/packages/renderers-js/src/fragments/instructionRemainingAccounts.ts
+++ b/packages/renderers-js/src/fragments/instructionRemainingAccounts.ts
@@ -24,8 +24,8 @@ export function getInstructionRemainingAccountsFragment(
         fragments,
         r =>
             `// Remaining accounts.\n` +
-            `const remainingAccounts: IAccountMeta[] = ${r.length === 1 ? r[0] : `[...${r.join(', ...')}]`}`,
-    ).addImports('solanaInstructions', ['type IAccountMeta']);
+            `const remainingAccounts: AccountMeta[] = ${r.length === 1 ? r[0] : `[...${r.join(', ...')}]`}`,
+    ).addImports('solanaInstructions', ['type AccountMeta']);
 }
 
 function getRemainingAccountsFragment(

--- a/packages/renderers-js/src/fragments/instructionType.ts
+++ b/packages/renderers-js/src/fragments/instructionType.ts
@@ -57,13 +57,13 @@ export function getInstructionTypeFragment(
         .mergeImportsWith(accountTypeParamsFragment, accountMetasFragment)
         .addImports('generatedPrograms', [programAddressConstant])
         .addImports('solanaInstructions', [
-            'type IAccountMeta',
-            'type IInstruction',
-            'type IInstructionWithAccounts',
-            ...(hasData ? ['type IInstructionWithData'] : []),
+            'type AccountMeta',
+            'type Instruction',
+            'type InstructionWithAccounts',
+            ...(hasData ? ['type InstructionWithData'] : []),
         ]);
 
-    // TODO: if link, add import for data type. Unless we don't need to inject the data type in IInstructionWithData.
+    // TODO: if link, add import for data type. Unless we don't need to inject the data type in InstructionWithData.
 
     return fragment;
 }

--- a/packages/renderers-js/src/getRenderMapVisitor.ts
+++ b/packages/renderers-js/src/getRenderMapVisitor.ts
@@ -397,11 +397,11 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                                     ])
                                     .add('solanaInstructions', [
                                         'AccountRole',
-                                        'type IAccountMeta',
+                                        'type AccountMeta',
                                         'upgradeRoleToSigner',
                                     ])
                                     .add('solanaSigners', [
-                                        'type IAccountSignerMeta',
+                                        'type AccountSignerMeta',
                                         'isTransactionSigner',
                                         'type TransactionSigner',
                                     ])

--- a/packages/renderers-js/test/ImportMap.test.ts
+++ b/packages/renderers-js/test/ImportMap.test.ts
@@ -6,7 +6,7 @@ test('it renders JavaScript import statements', () => {
     // Given an import map with 3 imports from 2 sources.
     const importMap = new ImportMap()
         .add('@solana/addresses', ['getAddressEncoder', 'type Address'])
-        .add('@solana/instructions', 'type IInstructionWithData');
+        .add('@solana/instructions', 'type InstructionWithData');
 
     // When we render it.
     const importStatements = importMap.toString();
@@ -14,7 +14,7 @@ test('it renders JavaScript import statements', () => {
     // Then we expect the following import statements.
     expect(importStatements).toBe(
         "import { getAddressEncoder, type Address } from '@solana/addresses';\n" +
-            "import { type IInstructionWithData } from '@solana/instructions';",
+            "import { type InstructionWithData } from '@solana/instructions';",
     );
 });
 

--- a/packages/renderers-rust/package.json
+++ b/packages/renderers-rust/package.json
@@ -46,7 +46,7 @@
         "@codama/nodes": "workspace:*",
         "@codama/renderers-core": "workspace:*",
         "@codama/visitors-core": "workspace:*",
-        "@solana/codecs-strings": "rc",
+        "@solana/codecs-strings": "^2.3.0",
         "nunjucks": "^3.2.4"
     },
     "devDependencies": {

--- a/packages/renderers-vixen-parser/package.json
+++ b/packages/renderers-vixen-parser/package.json
@@ -44,7 +44,7 @@
         "@codama/renderers-core": "workspace:*",
         "@codama/visitors-core": "workspace:*",
         "@codama/renderers-rust": "workspace:*",
-        "@solana/codecs-strings": "rc",
+        "@solana/codecs-strings": "^2.3.0",
         "nunjucks": "^3.2.4"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
         specifier: workspace:*
         version: link:../visitors-core
       '@solana/codecs':
-        specifier: 2.3.0
+        specifier: ^2.3.0
         version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
 
   packages/dynamic-parsers:
@@ -148,11 +148,11 @@ importers:
         specifier: workspace:*
         version: link:../visitors-core
       '@solana/instructions':
-        specifier: 2.3.0
+        specifier: ^2.3.0
         version: 2.3.0(typescript@5.8.3)
     devDependencies:
       '@solana/codecs':
-        specifier: 2.3.0
+        specifier: ^2.3.0
         version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
 
   packages/errors:
@@ -214,7 +214,7 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
       '@solana/codecs':
-        specifier: 2.3.0
+        specifier: ^2.3.0
         version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
 
   packages/renderers:
@@ -256,8 +256,8 @@ importers:
         specifier: workspace:*
         version: link:../visitors-core
       '@solana/codecs-strings':
-        specifier: ^2.1.0
-        version: 2.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+        specifier: ^2.3.0
+        version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       nunjucks:
         specifier: ^3.2.4
         version: 3.2.4(chokidar@3.6.0)
@@ -290,8 +290,8 @@ importers:
         specifier: workspace:*
         version: link:../visitors-core
       '@solana/codecs-strings':
-        specifier: rc
-        version: 2.0.0-rc.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+        specifier: ^2.3.0
+        version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       nunjucks:
         specifier: ^3.2.4
         version: 3.2.4(chokidar@3.6.0)
@@ -318,8 +318,8 @@ importers:
         specifier: workspace:*
         version: link:../visitors-core
       '@solana/codecs-strings':
-        specifier: rc
-        version: 2.0.0-rc.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+        specifier: ^2.3.0
+        version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       nunjucks:
         specifier: ^3.2.4
         version: 3.2.4(chokidar@3.6.0)
@@ -349,8 +349,8 @@ importers:
         specifier: workspace:*
         version: link:../visitors-core
       '@solana/codecs-strings':
-        specifier: rc
-        version: 2.0.0-rc.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+        specifier: ^2.3.0
+        version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       nunjucks:
         specifier: ^3.2.4
         version: 3.2.4(chokidar@3.6.0)
@@ -1372,18 +1372,6 @@ packages:
   '@sinonjs/fake-timers@11.3.1':
     resolution: {integrity: sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==}
 
-  '@solana/codecs-core@2.0.0-rc.4':
-    resolution: {integrity: sha512-JIrTSps032mSE3wBxW3bXOqWfoy4CMy1CX/XeVCijyh5kLVxZTSDIdRTYdePdL1yzaOZF1Xysvt1DhOUgBdM+A==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/codecs-core@2.1.1':
-    resolution: {integrity: sha512-iPQW3UZ2Vi7QFBo2r9tw0NubtH8EdrhhmZulx6lC8V5a+qjaxovtM/q/UW2BTNpqqHLfO0tIcLyBLrNH4HTWPg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/codecs-core@2.3.0':
     resolution: {integrity: sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==}
     engines: {node: '>=20.18.0'}
@@ -1396,36 +1384,10 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/codecs-numbers@2.0.0-rc.4':
-    resolution: {integrity: sha512-ZJR7TaUO65+3Hzo3YOOUCS0wlzh17IW+j0MZC2LCk1R0woaypRpHKj4iSMYeQOZkMxsd9QT3WNvjFrPC2qA6Sw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/codecs-numbers@2.1.1':
-    resolution: {integrity: sha512-m20IUPJhPUmPkHSlZ2iMAjJ7PaYUvlMtFhCQYzm9BEBSI6OCvXTG3GAPpAnSGRBfg5y+QNqqmKn4QHU3B6zzCQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/codecs-numbers@2.3.0':
     resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/codecs-strings@2.0.0-rc.4':
-    resolution: {integrity: sha512-LGfK2RL0BKjYYUfzu2FG/gTgCsYOMz9FKVs2ntji6WneZygPxJTV5W98K3J8Rl0JewpCSCFQH3xjLSHBJUS0fA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: '>=5'
-
-  '@solana/codecs-strings@2.1.1':
-    resolution: {integrity: sha512-uhj+A7eT6IJn4nuoX8jDdvZa7pjyZyN+k64EZ8+aUtJGt5Ft4NjRM8Jl5LljwYBWKQCgouVuigZHtTO2yAWExA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5.3.3'
 
   '@solana/codecs-strings@2.3.0':
@@ -1438,20 +1400,6 @@ packages:
   '@solana/codecs@2.3.0':
     resolution: {integrity: sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==}
     engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/errors@2.0.0-rc.4':
-    resolution: {integrity: sha512-0PPaMyB81keEHG/1pnyEuiBVKctbXO641M2w3CIOrYT/wzjunfF0FTxsqq9wYJeYo0AyiefCKGgSPs6wiY2PpQ==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5'
-
-  '@solana/errors@2.1.1':
-    resolution: {integrity: sha512-sj6DaWNbSJFvLzT8UZoabMefQUfSW/8tXK7NTiagsDmh+Q87eyQDDC9L3z+mNmx9b6dEf6z660MOIplDD2nfEw==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
     peerDependencies:
       typescript: '>=5.3.3'
 
@@ -2039,14 +1987,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
-
-  commander@13.1.0:
-    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
-    engines: {node: '>=18'}
 
   commander@14.0.0:
     resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
@@ -4677,16 +4617,6 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@solana/codecs-core@2.0.0-rc.4(typescript@5.8.3)':
-    dependencies:
-      '@solana/errors': 2.0.0-rc.4(typescript@5.8.3)
-      typescript: 5.8.3
-
-  '@solana/codecs-core@2.1.1(typescript@5.8.3)':
-    dependencies:
-      '@solana/errors': 2.1.1(typescript@5.8.3)
-      typescript: 5.8.3
-
   '@solana/codecs-core@2.3.0(typescript@5.8.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.8.3)
@@ -4699,38 +4629,10 @@ snapshots:
       '@solana/errors': 2.3.0(typescript@5.8.3)
       typescript: 5.8.3
 
-  '@solana/codecs-numbers@2.0.0-rc.4(typescript@5.8.3)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.4(typescript@5.8.3)
-      '@solana/errors': 2.0.0-rc.4(typescript@5.8.3)
-      typescript: 5.8.3
-
-  '@solana/codecs-numbers@2.1.1(typescript@5.8.3)':
-    dependencies:
-      '@solana/codecs-core': 2.1.1(typescript@5.8.3)
-      '@solana/errors': 2.1.1(typescript@5.8.3)
-      typescript: 5.8.3
-
   '@solana/codecs-numbers@2.3.0(typescript@5.8.3)':
     dependencies:
       '@solana/codecs-core': 2.3.0(typescript@5.8.3)
       '@solana/errors': 2.3.0(typescript@5.8.3)
-      typescript: 5.8.3
-
-  '@solana/codecs-strings@2.0.0-rc.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-rc.4(typescript@5.8.3)
-      '@solana/errors': 2.0.0-rc.4(typescript@5.8.3)
-      fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.8.3
-
-  '@solana/codecs-strings@2.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
-    dependencies:
-      '@solana/codecs-core': 2.1.1(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.1.1(typescript@5.8.3)
-      '@solana/errors': 2.1.1(typescript@5.8.3)
-      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.8.3
 
   '@solana/codecs-strings@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
@@ -4751,18 +4653,6 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-
-  '@solana/errors@2.0.0-rc.4(typescript@5.8.3)':
-    dependencies:
-      chalk: 5.4.1
-      commander: 12.1.0
-      typescript: 5.8.3
-
-  '@solana/errors@2.1.1(typescript@5.8.3)':
-    dependencies:
-      chalk: 5.4.1
-      commander: 13.1.0
-      typescript: 5.8.3
 
   '@solana/errors@2.3.0(typescript@5.8.3)':
     dependencies:
@@ -5461,10 +5351,6 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  commander@12.1.0: {}
-
-  commander@13.1.0: {}
 
   commander@14.0.0: {}
 


### PR DESCRIPTION
This PR updates `@solana/kit` to the latest version and uses the latest type definitions in generated code.