### PR TITLE
[renderers-js] Fix missing `getNextOptionalAccount`

### DIFF
--- a/.changeset/stupid-bobcats-hug.md
+++ b/.changeset/stupid-bobcats-hug.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Fix an issue where `getNextOptionalAccount` would not get generated even if optional accounts exist on the instruction.

--- a/packages/renderers-js/public/templates/fragments/instructionParseFunction.njk
+++ b/packages/renderers-js/public/templates/fragments/instructionParseFunction.njk
@@ -47,17 +47,17 @@ export function {{ instructionParseFunction }}<
       accountIndex += 1;
       return accountMeta;
     }
-    {% if hasOptionalAccounts and instruction.optionalAccountStrategy === 'programId' %}
-      const getNextOptionalAccount = () => {
-        const accountMeta = getNextAccount();
-        return accountMeta.address === {{ programAddressConstant }} ? undefined : accountMeta;
-      };
-    {% elif hasOptionalAccounts and instruction.optionalAccountStrategy === 'omitted' %}
+    {% if hasOptionalAccounts and instruction.optionalAccountStrategy === 'omitted' %}
       let optionalAccountsRemaining = instruction.accounts.length - {{ minimumNumberOfAccounts }};
       const getNextOptionalAccount = () => {
         if (optionalAccountsRemaining === 0) return undefined;
         optionalAccountsRemaining -= 1;
         return getNextAccount();
+      };
+    {% elif hasOptionalAccounts %}
+      const getNextOptionalAccount = () => {
+        const accountMeta = getNextAccount();
+        return accountMeta.address === {{ programAddressConstant }} ? undefined : accountMeta;
       };
     {% endif %}
   {% endif %}


### PR DESCRIPTION
This PR uses the `programId` optional account strategy as a fallback strategy to ensure the `getNextOptionalAccount` helper is always generated when optional account exist on the instruction.