### PR TITLE
[renderers-rust] Export discriminator constants for accounts and instructions

### DIFF
--- a/.changeset/purple-melons-lie.md
+++ b/.changeset/purple-melons-lie.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-rust': patch
+---
+
+Export discriminator constants for accounts and instructions

--- a/packages/renderers-rust/e2e/anchor/src/generated/accounts/guard_v1.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/accounts/guard_v1.rs
@@ -32,6 +32,8 @@ pub struct GuardV1 {
     pub additional_fields_rule: Vec<MetadataAdditionalFieldRule>,
 }
 
+pub const GUARD_V1_DISCRIMINATOR: [u8; 8] = [185, 149, 156, 78, 245, 108, 172, 68];
+
 impl GuardV1 {
     #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {

--- a/packages/renderers-rust/e2e/anchor/src/generated/instructions/create_guard.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/instructions/create_guard.rs
@@ -11,6 +11,8 @@ use crate::generated::types::TransferAmountRule;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
+pub const CREATE_GUARD_DISCRIMINATOR: [u8; 8] = [251, 254, 17, 198, 219, 218, 154, 99];
+
 /// Accounts.
 #[derive(Debug)]
 pub struct CreateGuard {

--- a/packages/renderers-rust/e2e/anchor/src/generated/instructions/execute.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/instructions/execute.rs
@@ -8,6 +8,8 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
+pub const EXECUTE_DISCRIMINATOR: [u8; 8] = [105, 37, 101, 197, 75, 251, 102, 26];
+
 /// Accounts.
 #[derive(Debug)]
 pub struct Execute {

--- a/packages/renderers-rust/e2e/anchor/src/generated/instructions/initialize.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/instructions/initialize.rs
@@ -8,6 +8,8 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
+pub const INITIALIZE_DISCRIMINATOR: [u8; 8] = [43, 34, 13, 49, 167, 88, 235, 235];
+
 /// Accounts.
 #[derive(Debug)]
 pub struct Initialize {

--- a/packages/renderers-rust/e2e/anchor/src/generated/instructions/update_guard.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/instructions/update_guard.rs
@@ -11,6 +11,8 @@ use crate::generated::types::TransferAmountRule;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
+pub const UPDATE_GUARD_DISCRIMINATOR: [u8; 8] = [51, 38, 175, 180, 25, 249, 39, 24];
+
 /// Accounts.
 #[derive(Debug)]
 pub struct UpdateGuard {

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction3.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction3.rs
@@ -8,6 +8,8 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
+pub const INSTRUCTION3_DISCRIMINATOR: u32 = 42;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct Instruction3 {}

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/advance_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/advance_nonce_account.rs
@@ -8,6 +8,8 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
+pub const ADVANCE_NONCE_ACCOUNT_DISCRIMINATOR: u32 = 4;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct AdvanceNonceAccount {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/allocate.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/allocate.rs
@@ -8,6 +8,8 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
+pub const ALLOCATE_DISCRIMINATOR: u32 = 8;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct Allocate {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/allocate_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/allocate_with_seed.rs
@@ -9,6 +9,8 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_pubkey::Pubkey;
 
+pub const ALLOCATE_WITH_SEED_DISCRIMINATOR: u32 = 9;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct AllocateWithSeed {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/assign.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/assign.rs
@@ -9,6 +9,8 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_pubkey::Pubkey;
 
+pub const ASSIGN_DISCRIMINATOR: u32 = 1;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct Assign {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/assign_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/assign_with_seed.rs
@@ -9,6 +9,8 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_pubkey::Pubkey;
 
+pub const ASSIGN_WITH_SEED_DISCRIMINATOR: u32 = 10;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct AssignWithSeed {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/authorize_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/authorize_nonce_account.rs
@@ -9,6 +9,8 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_pubkey::Pubkey;
 
+pub const AUTHORIZE_NONCE_ACCOUNT_DISCRIMINATOR: u32 = 7;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct AuthorizeNonceAccount {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/create_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/create_account.rs
@@ -9,6 +9,8 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_pubkey::Pubkey;
 
+pub const CREATE_ACCOUNT_DISCRIMINATOR: u32 = 0;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct CreateAccount {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/create_account_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/create_account_with_seed.rs
@@ -9,6 +9,8 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_pubkey::Pubkey;
 
+pub const CREATE_ACCOUNT_WITH_SEED_DISCRIMINATOR: u32 = 3;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct CreateAccountWithSeed {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/initialize_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/initialize_nonce_account.rs
@@ -9,6 +9,8 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_pubkey::Pubkey;
 
+pub const INITIALIZE_NONCE_ACCOUNT_DISCRIMINATOR: u32 = 6;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct InitializeNonceAccount {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol.rs
@@ -8,6 +8,8 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
+pub const TRANSFER_SOL_DISCRIMINATOR: u32 = 2;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct TransferSol {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol_with_seed.rs
@@ -9,6 +9,8 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_pubkey::Pubkey;
 
+pub const TRANSFER_SOL_WITH_SEED_DISCRIMINATOR: u32 = 11;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct TransferSolWithSeed {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/upgrade_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/upgrade_nonce_account.rs
@@ -8,6 +8,8 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
+pub const UPGRADE_NONCE_ACCOUNT_DISCRIMINATOR: u32 = 12;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct UpgradeNonceAccount {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/withdraw_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/withdraw_nonce_account.rs
@@ -8,6 +8,8 @@
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
+pub const WITHDRAW_NONCE_ACCOUNT_DISCRIMINATOR: u32 = 5;
+
 /// Accounts.
 #[derive(Debug)]
 pub struct WithdrawNonceAccount {

--- a/packages/renderers-rust/public/templates/accountsPage.njk
+++ b/packages/renderers-rust/public/templates/accountsPage.njk
@@ -12,6 +12,8 @@
 {{ nestedStruct }}
 {% endfor %}
 
+{{ discriminatorConstants }}
+
 impl {{ account.name | pascalCase }} {
   {% if account.size != null %}
     pub const LEN: usize = {{ account.size }};

--- a/packages/renderers-rust/public/templates/instructionsPage.njk
+++ b/packages/renderers-rust/public/templates/instructionsPage.njk
@@ -5,6 +5,8 @@
 
 {{ imports }}
 
+{{ discriminatorConstants }}
+
 /// Accounts.
 #[derive(Debug)]
 pub struct {{ instruction.name | pascalCase }} {

--- a/packages/renderers-rust/src/utils/discriminatorConstant.ts
+++ b/packages/renderers-rust/src/utils/discriminatorConstant.ts
@@ -1,0 +1,107 @@
+import {
+    camelCase,
+    ConstantDiscriminatorNode,
+    DiscriminatorNode,
+    FieldDiscriminatorNode,
+    InstructionArgumentNode,
+    isNode,
+    isNodeFilter,
+    snakeCase,
+    StructFieldTypeNode,
+    VALUE_NODES,
+} from '@codama/nodes';
+import { visit } from '@codama/visitors-core';
+
+import { getTypeManifestVisitor, TypeManifest } from '../getTypeManifestVisitor';
+import { ImportMap } from '../ImportMap';
+import { renderValueNode } from '../renderValueNodeVisitor';
+import { GetImportFromFunction } from './linkOverrides';
+
+type Fragment = { imports: ImportMap; render: string };
+
+function mergeFragments(fragments: Fragment[], merge: (parts: string[]) => string): Fragment {
+    const imports = fragments.reduce((acc, frag) => acc.mergeWith(frag.imports), new ImportMap());
+    const render = merge(fragments.map(frag => frag.render));
+    return { imports, render };
+}
+
+export function getDiscriminatorConstants(scope: {
+    discriminatorNodes: DiscriminatorNode[];
+    fields: InstructionArgumentNode[] | StructFieldTypeNode[];
+    getImportFrom: GetImportFromFunction;
+    prefix: string;
+    typeManifestVisitor: ReturnType<typeof getTypeManifestVisitor>;
+}): Fragment {
+    const fragments = scope.discriminatorNodes
+        .map(node => getDiscriminatorConstant(node, scope))
+        .filter(Boolean) as Fragment[];
+
+    return mergeFragments(fragments, r => r.join('\n\n'));
+}
+
+function getDiscriminatorConstant(
+    discriminatorNode: DiscriminatorNode,
+    scope: {
+        discriminatorNodes: DiscriminatorNode[];
+        fields: InstructionArgumentNode[] | StructFieldTypeNode[];
+        getImportFrom: GetImportFromFunction;
+        prefix: string;
+        typeManifestVisitor: ReturnType<typeof getTypeManifestVisitor>;
+    },
+) {
+    switch (discriminatorNode.kind) {
+        case 'constantDiscriminatorNode':
+            return getConstantDiscriminatorConstant(discriminatorNode, scope);
+        case 'fieldDiscriminatorNode':
+            return getFieldDiscriminatorConstant(discriminatorNode, scope);
+        default:
+            return null;
+    }
+}
+
+function getConstantDiscriminatorConstant(
+    discriminatorNode: ConstantDiscriminatorNode,
+    scope: {
+        discriminatorNodes: DiscriminatorNode[];
+        getImportFrom: GetImportFromFunction;
+        prefix: string;
+        typeManifestVisitor: ReturnType<typeof getTypeManifestVisitor>;
+    },
+): Fragment {
+    const { discriminatorNodes, getImportFrom, prefix, typeManifestVisitor } = scope;
+
+    const index = discriminatorNodes.filter(isNodeFilter('constantDiscriminatorNode')).indexOf(discriminatorNode);
+    const suffix = index <= 0 ? '' : `_${index + 1}`;
+
+    const name = camelCase(`${prefix}_discriminator${suffix}`);
+    const typeManifest = visit(discriminatorNode.constant.type, typeManifestVisitor);
+    const value = renderValueNode(discriminatorNode.constant.value, getImportFrom);
+    return getConstant(name, typeManifest, value);
+}
+
+function getFieldDiscriminatorConstant(
+    discriminatorNode: FieldDiscriminatorNode,
+    scope: {
+        fields: InstructionArgumentNode[] | StructFieldTypeNode[];
+        getImportFrom: GetImportFromFunction;
+        prefix: string;
+        typeManifestVisitor: ReturnType<typeof getTypeManifestVisitor>;
+    },
+): Fragment | null {
+    const { fields, prefix, getImportFrom, typeManifestVisitor } = scope;
+
+    const field = fields.find(f => f.name === discriminatorNode.name);
+    if (!field || !field.defaultValue || !isNode(field.defaultValue, VALUE_NODES)) {
+        return null;
+    }
+
+    const name = camelCase(`${prefix}_${discriminatorNode.name}`);
+    const typeManifest = visit(field.type, typeManifestVisitor);
+    const value = renderValueNode(field.defaultValue, getImportFrom);
+    return getConstant(name, typeManifest, value);
+}
+
+function getConstant(name: string, typeManifest: TypeManifest, value: Fragment): Fragment {
+    const type: Fragment = { imports: typeManifest.imports, render: typeManifest.type };
+    return mergeFragments([type, value], ([t, v]) => `pub const ${snakeCase(name).toUpperCase()}: ${t} = ${v};`);
+}

--- a/packages/renderers-rust/src/utils/index.ts
+++ b/packages/renderers-rust/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './codecs';
+export * from './discriminatorConstant';
 export * from './linkOverrides';
 export * from './render';
 export * from './traitOptions';


### PR DESCRIPTION
This PR exports a constant for each `DiscriminatorNode` attached to an account or instruction that has a value.

For instance,

```rust
pub const TRANSFER_SOL_DISCRIMINATOR: u32 = 2;
```

or 

```rust
pub const MY_ACCOUNT_DISCRIMINATOR: [u8; 8] = [185, 149, 156, 78, 245, 108, 172, 68];
```