### PR TITLE
Use type cast on codecs of fixed-size data enums

### DIFF
--- a/.changeset/true-readers-enter.md
+++ b/.changeset/true-readers-enter.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Use type cast on generated encoder and decoder functions when dealing with fixed-size data enums. This is because the `getDiscriminatedUnion(Encoder|Decoder)` functions do not propagate the fixed-size information.

--- a/packages/renderers-js/public/templates/fragments/typeDecoder.njk
+++ b/packages/renderers-js/public/templates/fragments/typeDecoder.njk
@@ -2,5 +2,5 @@
 
 {{ macros.docblock(docs) }}
 export function {{ decoderFunction }}(): {{ decoderType }}<{{ strictName }}> {
-  return {{ manifest.decoder.render }};
+  return {{ manifest.decoder.render }}{% if useTypeCast %} as {{ decoderType }}<{{ strictName }}>{% endif %};
 }

--- a/packages/renderers-js/public/templates/fragments/typeEncoder.njk
+++ b/packages/renderers-js/public/templates/fragments/typeEncoder.njk
@@ -2,5 +2,5 @@
 
 {{ macros.docblock(docs) }}
 export function {{ encoderFunction }}(): {{ encoderType }}<{{ looseName }}> {
-  return {{ manifest.encoder.render }};
+  return {{ manifest.encoder.render }}{% if useTypeCast %} as {{ encoderType }}<{{ strictName }}>{% endif %};
 }

--- a/packages/renderers-js/public/templates/fragments/typeEncoder.njk
+++ b/packages/renderers-js/public/templates/fragments/typeEncoder.njk
@@ -2,5 +2,5 @@
 
 {{ macros.docblock(docs) }}
 export function {{ encoderFunction }}(): {{ encoderType }}<{{ looseName }}> {
-  return {{ manifest.encoder.render }}{% if useTypeCast %} as {{ encoderType }}<{{ strictName }}>{% endif %};
+  return {{ manifest.encoder.render }}{% if useTypeCast %} as {{ encoderType }}<{{ looseName }}>{% endif %};
 }

--- a/packages/renderers-js/src/fragments/accountType.ts
+++ b/packages/renderers-js/src/fragments/accountType.ts
@@ -1,4 +1,4 @@
-import { AccountNode } from '@codama/nodes';
+import { AccountNode, resolveNestedTypeNode } from '@codama/nodes';
 import { getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
@@ -24,6 +24,7 @@ export function getAccountTypeFragment(
         manifest: typeManifest,
         name: accountNode.name,
         nameApi,
+        node: resolveNestedTypeNode(accountNode.data),
         size: scope.size,
     });
 }

--- a/packages/renderers-js/src/fragments/instructionData.ts
+++ b/packages/renderers-js/src/fragments/instructionData.ts
@@ -1,4 +1,4 @@
-import { InstructionNode } from '@codama/nodes';
+import { InstructionNode, structTypeNodeFromInstructionArgumentNodes } from '@codama/nodes';
 import { getLastNodeFromPath, NodePath } from '@codama/visitors-core';
 
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
@@ -24,6 +24,7 @@ export function getInstructionDataFragment(
         manifest: dataArgsManifest,
         name: instructionDataName,
         nameApi,
+        node: structTypeNodeFromInstructionArgumentNodes(instructionNode.arguments),
         size: scope.size,
     });
 }

--- a/packages/renderers-js/src/fragments/typeCodec.ts
+++ b/packages/renderers-js/src/fragments/typeCodec.ts
@@ -1,3 +1,5 @@
+import type { TypeNode } from '@codama/nodes';
+
 import { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { TypeManifest } from '../TypeManifest';
 import { Fragment, fragmentFromTemplate, mergeFragments } from './common';
@@ -11,6 +13,7 @@ export function getTypeCodecFragment(
         encoderDocs?: string[];
         manifest: Pick<TypeManifest, 'decoder' | 'encoder'>;
         name: string;
+        node: TypeNode;
         size: number | null;
     },
 ): Fragment {

--- a/packages/renderers-js/src/fragments/typeDecoder.ts
+++ b/packages/renderers-js/src/fragments/typeDecoder.ts
@@ -1,3 +1,5 @@
+import { isDataEnum, isNode, TypeNode } from '@codama/nodes';
+
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { TypeManifest } from '../TypeManifest';
 import { Fragment, fragmentFromTemplate } from './common';
@@ -7,11 +9,14 @@ export function getTypeDecoderFragment(
         docs?: string[];
         manifest: Pick<TypeManifest, 'decoder'>;
         name: string;
+        node: TypeNode;
         size: number | null;
     },
 ): Fragment {
-    const { name, manifest, nameApi, docs = [] } = scope;
+    const { name, node, manifest, nameApi, docs = [] } = scope;
     const decoderType = typeof scope.size === 'number' ? 'FixedSizeDecoder' : 'Decoder';
+    const useTypeCast = isNode(node, 'enumTypeNode') && isDataEnum(node) && typeof scope.size === 'number';
+
     return fragmentFromTemplate('typeDecoder.njk', {
         decoderFunction: nameApi.decoderFunction(name),
         decoderType,
@@ -19,6 +24,7 @@ export function getTypeDecoderFragment(
         looseName: nameApi.dataArgsType(name),
         manifest,
         strictName: nameApi.dataType(name),
+        useTypeCast,
     })
         .mergeImportsWith(manifest.decoder)
         .addImports('solanaCodecsCore', `type ${decoderType}`);

--- a/packages/renderers-js/src/fragments/typeEncoder.ts
+++ b/packages/renderers-js/src/fragments/typeEncoder.ts
@@ -1,3 +1,5 @@
+import { isDataEnum, isNode, TypeNode } from '@codama/nodes';
+
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { TypeManifest } from '../TypeManifest';
 import { Fragment, fragmentFromTemplate } from './common';
@@ -7,11 +9,14 @@ export function getTypeEncoderFragment(
         docs?: string[];
         manifest: Pick<TypeManifest, 'encoder'>;
         name: string;
+        node: TypeNode;
         size: number | null;
     },
 ): Fragment {
-    const { name, manifest, nameApi, docs = [] } = scope;
+    const { name, node, manifest, nameApi, docs = [] } = scope;
     const encoderType = typeof scope.size === 'number' ? 'FixedSizeEncoder' : 'Encoder';
+    const useTypeCast = isNode(node, 'enumTypeNode') && isDataEnum(node) && typeof scope.size === 'number';
+
     return fragmentFromTemplate('typeEncoder.njk', {
         docs,
         encoderFunction: nameApi.encoderFunction(name),
@@ -19,6 +24,7 @@ export function getTypeEncoderFragment(
         looseName: nameApi.dataArgsType(name),
         manifest,
         strictName: nameApi.dataType(name),
+        useTypeCast,
     })
         .mergeImportsWith(manifest.encoder)
         .addImports('solanaCodecsCore', `type ${encoderType}`);

--- a/packages/renderers-js/src/fragments/typeWithCodec.ts
+++ b/packages/renderers-js/src/fragments/typeWithCodec.ts
@@ -1,3 +1,5 @@
+import type { TypeNode } from '@codama/nodes';
+
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { TypeManifest } from '../TypeManifest';
 import { Fragment, mergeFragments } from './common';
@@ -11,6 +13,7 @@ export function getTypeWithCodecFragment(
         encoderDocs?: string[];
         manifest: TypeManifest;
         name: string;
+        node: TypeNode;
         size: number | null;
         typeDocs?: string[];
     },

--- a/packages/renderers-js/src/getRenderMapVisitor.ts
+++ b/packages/renderers-js/src/getRenderMapVisitor.ts
@@ -194,6 +194,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                         encoderDocs: [],
                         manifest: visit(node, typeManifestVisitor),
                         name: node.name,
+                        node: node.type,
                         size: visit(node, byteSizeVisitor),
                         typeDocs: node.docs,
                         typeNode: node.type,


### PR DESCRIPTION
This PR adds type cast on generated encoder and decoder functions when dealing with fixed-size data enums. This is because the `getDiscriminatedUnion(Encoder|Decoder)` functions do not propagate the fixed-size information.

See #730 