### PR TITLE
Update generated JS code to be more linter/formatter friendly

### DIFF
--- a/.changeset/fuzzy-emus-hammer.md
+++ b/.changeset/fuzzy-emus-hammer.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Update generated JS code to be more linter/formatter friendly

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/createGuard.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/createGuard.ts
@@ -519,7 +519,7 @@ export function parseCreateGuardInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/execute.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/execute.ts
@@ -397,7 +397,7 @@ export function parseExecuteInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/initialize.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/initialize.ts
@@ -355,7 +355,7 @@ export function parseInitializeInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/updateGuard.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/updateGuard.ts
@@ -429,7 +429,7 @@ export function parseUpdateGuardInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/anchor/src/generated/shared/index.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/shared/index.ts
@@ -23,7 +23,7 @@ import {
  * @internal
  */
 export function expectSome<T>(value: T | null | undefined): T {
-  if (value == null) {
+  if (value === null || value === undefined) {
     throw new Error('Expected a value but received null or undefined.');
   }
   return value;
@@ -48,7 +48,7 @@ export function expectAddress<T extends string = string>(
     return value.address;
   }
   if (Array.isArray(value)) {
-    return value[0];
+    return value[0] as Address<T>;
   }
   return value as Address<T>;
 }

--- a/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction6.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction6.ts
@@ -84,7 +84,7 @@ export function parseInstruction6Instruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction7.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/instructions/instruction7.ts
@@ -84,7 +84,7 @@ export function parseInstruction7Instruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/dummy/src/generated/shared/index.ts
+++ b/packages/renderers-js/e2e/dummy/src/generated/shared/index.ts
@@ -23,7 +23,7 @@ import {
  * @internal
  */
 export function expectSome<T>(value: T | null | undefined): T {
-  if (value == null) {
+  if (value === null || value === undefined) {
     throw new Error('Expected a value but received null or undefined.');
   }
   return value;
@@ -48,7 +48,7 @@ export function expectAddress<T extends string = string>(
     return value.address;
   }
   if (Array.isArray(value)) {
-    return value[0];
+    return value[0] as Address<T>;
   }
   return value as Address<T>;
 }

--- a/packages/renderers-js/e2e/memo/src/generated/shared/index.ts
+++ b/packages/renderers-js/e2e/memo/src/generated/shared/index.ts
@@ -23,7 +23,7 @@ import {
  * @internal
  */
 export function expectSome<T>(value: T | null | undefined): T {
-  if (value == null) {
+  if (value === null || value === undefined) {
     throw new Error('Expected a value but received null or undefined.');
   }
   return value;
@@ -48,7 +48,7 @@ export function expectAddress<T extends string = string>(
     return value.address;
   }
   if (Array.isArray(value)) {
-    return value[0];
+    return value[0] as Address<T>;
   }
   return value as Address<T>;
 }

--- a/packages/renderers-js/e2e/system/src/generated/instructions/advanceNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/advanceNonceAccount.ts
@@ -188,7 +188,7 @@ export function parseAdvanceNonceAccountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/allocate.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/allocate.ts
@@ -148,7 +148,7 @@ export function parseAllocateInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/allocateWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/allocateWithSeed.ts
@@ -197,7 +197,7 @@ export function parseAllocateWithSeedInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/assign.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/assign.ts
@@ -151,7 +151,7 @@ export function parseAssignInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/assignWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/assignWithSeed.ts
@@ -190,7 +190,7 @@ export function parseAssignWithSeedInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/authorizeNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/authorizeNonceAccount.ts
@@ -182,7 +182,7 @@ export function parseAuthorizeNonceAccountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
@@ -203,7 +203,7 @@ export function parseCreateAccountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/createAccountWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/createAccountWithSeed.ts
@@ -223,7 +223,7 @@ export function parseCreateAccountWithSeedInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/initializeNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/initializeNonceAccount.ts
@@ -209,7 +209,7 @@ export function parseInitializeNonceAccountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/transferSol.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/transferSol.ts
@@ -174,7 +174,7 @@ export function parseTransferSolInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/transferSolWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/transferSolWithSeed.ts
@@ -211,7 +211,7 @@ export function parseTransferSolWithSeedInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/upgradeNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/upgradeNonceAccount.ts
@@ -136,7 +136,7 @@ export function parseUpgradeNonceAccountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/instructions/withdrawNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/withdrawNonceAccount.ts
@@ -242,7 +242,7 @@ export function parseWithdrawNonceAccountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/system/src/generated/shared/index.ts
+++ b/packages/renderers-js/e2e/system/src/generated/shared/index.ts
@@ -23,7 +23,7 @@ import {
  * @internal
  */
 export function expectSome<T>(value: T | null | undefined): T {
-  if (value == null) {
+  if (value === null || value === undefined) {
     throw new Error('Expected a value but received null or undefined.');
   }
   return value;
@@ -48,7 +48,7 @@ export function expectAddress<T extends string = string>(
     return value.address;
   }
   if (Array.isArray(value)) {
-    return value[0];
+    return value[0] as Address<T>;
   }
   return value as Address<T>;
 }

--- a/packages/renderers-js/e2e/token/src/generated/instructions/amountToUiAmount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/amountToUiAmount.ts
@@ -154,7 +154,7 @@ export function parseAmountToUiAmountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/approve.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/approve.ts
@@ -212,7 +212,7 @@ export function parseApproveInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/approveChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/approveChecked.ts
@@ -238,7 +238,7 @@ export function parseApproveCheckedInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/burn.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/burn.ts
@@ -211,7 +211,7 @@ export function parseBurnInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/burnChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/burnChecked.ts
@@ -221,7 +221,7 @@ export function parseBurnCheckedInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/closeAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/closeAccount.ts
@@ -194,7 +194,7 @@ export function parseCloseAccountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
@@ -203,7 +203,7 @@ export function parseCreateAccountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedToken.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedToken.ts
@@ -357,7 +357,7 @@ export function parseCreateAssociatedTokenInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
@@ -361,7 +361,7 @@ export function parseCreateAssociatedTokenIdempotentInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/freezeAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/freezeAccount.ts
@@ -194,7 +194,7 @@ export function parseFreezeAccountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/getAccountDataSize.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/getAccountDataSize.ts
@@ -136,7 +136,7 @@ export function parseGetAccountDataSizeInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount.ts
@@ -199,7 +199,7 @@ export function parseInitializeAccountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount2.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount2.ts
@@ -201,7 +201,7 @@ export function parseInitializeAccount2Instruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount3.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount3.ts
@@ -176,7 +176,7 @@ export function parseInitializeAccount3Instruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeImmutableOwner.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeImmutableOwner.ts
@@ -138,7 +138,7 @@ export function parseInitializeImmutableOwnerInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint.ts
@@ -199,7 +199,7 @@ export function parseInitializeMintInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint2.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint2.ts
@@ -177,7 +177,7 @@ export function parseInitializeMint2Instruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig.ts
@@ -194,7 +194,7 @@ export function parseInitializeMultisigInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig2.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig2.ts
@@ -161,7 +161,7 @@ export function parseInitializeMultisig2Instruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/mintTo.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/mintTo.ts
@@ -216,7 +216,7 @@ export function parseMintToInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/mintToChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/mintToChecked.ts
@@ -223,7 +223,7 @@ export function parseMintToCheckedInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
@@ -429,7 +429,7 @@ export function parseRecoverNestedAssociatedTokenInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/revoke.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/revoke.ts
@@ -180,7 +180,7 @@ export function parseRevokeInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/setAuthority.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/setAuthority.ts
@@ -215,7 +215,7 @@ export function parseSetAuthorityInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/syncNative.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/syncNative.ts
@@ -133,7 +133,7 @@ export function parseSyncNativeInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/thawAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/thawAccount.ts
@@ -194,7 +194,7 @@ export function parseThawAccountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/transfer.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/transfer.ts
@@ -214,7 +214,7 @@ export function parseTransferInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/transferChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/transferChecked.ts
@@ -240,7 +240,7 @@ export function parseTransferCheckedInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/instructions/uiAmountToAmount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/uiAmountToAmount.ts
@@ -154,7 +154,7 @@ export function parseUiAmountToAmountInstruction<
   }
   let accountIndex = 0;
   const getNextAccount = () => {
-    const accountMeta = instruction.accounts![accountIndex]!;
+    const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
     accountIndex += 1;
     return accountMeta;
   };

--- a/packages/renderers-js/e2e/token/src/generated/shared/index.ts
+++ b/packages/renderers-js/e2e/token/src/generated/shared/index.ts
@@ -23,7 +23,7 @@ import {
  * @internal
  */
 export function expectSome<T>(value: T | null | undefined): T {
-  if (value == null) {
+  if (value === null || value === undefined) {
     throw new Error('Expected a value but received null or undefined.');
   }
   return value;
@@ -48,7 +48,7 @@ export function expectAddress<T extends string = string>(
     return value.address;
   }
   if (Array.isArray(value)) {
-    return value[0];
+    return value[0] as Address<T>;
   }
   return value as Address<T>;
 }

--- a/packages/renderers-js/public/templates/fragments/instructionParseFunction.njk
+++ b/packages/renderers-js/public/templates/fragments/instructionParseFunction.njk
@@ -43,7 +43,7 @@ export function {{ instructionParseFunction }}<
     }
     let accountIndex = 0;
     const getNextAccount = () => {
-      const accountMeta = instruction.accounts![accountIndex]!;
+      const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
       accountIndex += 1;
       return accountMeta;
     }

--- a/packages/renderers-js/public/templates/fragments/programErrors.njk
+++ b/packages/renderers-js/public/templates/fragments/programErrors.njk
@@ -2,7 +2,7 @@
 
 {% for error in errors | sort(false, false, 'code') %}
   {{ macros.docblock(error.docs) }}
-  export const {{ getProgramErrorConstant(error.name) }} = 0x{{ error.code.toString(16) }}, // {{ error.code }}
+  export const {{ getProgramErrorConstant(error.name) }} = 0x{{ error.code.toString(16) }}; // {{ error.code }}
 {% endfor %}
 
 export type {{ programErrorUnion }} =

--- a/packages/renderers-js/public/templates/pages/sharedPage.njk
+++ b/packages/renderers-js/public/templates/pages/sharedPage.njk
@@ -9,7 +9,7 @@
  * @internal
  */
 export function expectSome<T>(value: T | null | undefined): T {
-  if (value == null) {
+  if (value === null || value === undefined) {
     throw new Error('Expected a value but received null or undefined.');
   }
   return value;
@@ -29,7 +29,7 @@ export function expectAddress<T extends string = string>(
     return value.address;
   }
   if (Array.isArray(value)) {
-    return value[0];
+    return value[0] as Address<T>;
   }
   return value as Address<T>;
 }


### PR DESCRIPTION
A notable change is using semicolons after error codes in constants.

This extracts the non-ESM specific logic in this previously closed PR: https://github.com/codama-idl/codama/pull/676