### PR TITLE
Deprecate @codama/renderers package

### DIFF
--- a/.changeset/cold-cats-crash.md
+++ b/.changeset/cold-cats-crash.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers': patch
+---
+
+Deprecate exports of `@codama/renderers` package

--- a/packages/renderers/src/index.ts
+++ b/packages/renderers/src/index.ts
@@ -1,3 +1,12 @@
-export { renderVisitor as renderJavaScriptVisitor } from '@codama/renderers-js';
-export { renderVisitor as renderJavaScriptUmiVisitor } from '@codama/renderers-js-umi';
-export { renderVisitor as renderRustVisitor } from '@codama/renderers-rust';
+import { renderVisitor as renderersJs } from '@codama/renderers-js';
+import { renderVisitor as renderersJsUmi } from '@codama/renderers-js-umi';
+import { renderVisitor as renderersRust } from '@codama/renderers-rust';
+
+/** @deprecated Use `renderVisitor` from `@codama/renderers-js` instead. */
+export const renderJavaScriptVisitor = renderersJs;
+
+/** @deprecated Use `renderVisitor` from `@codama/renderers-js-umi` instead. */
+export const renderJavaScriptUmiVisitor = renderersJsUmi;
+
+/** @deprecated Use `renderVisitor` from `@codama/renderers-rust` instead. */
+export const renderRustVisitor = renderersRust;


### PR DESCRIPTION
This PR deprecates the exported functions of the `@codama/renderers` package in preparation to removing this umbrella package entirely.

Having such a package re-exporting renderers from various places not only makes versioning each renderer complicated, it also deincentivises consumers from finding community-maintained renderers.