### PR TITLE
Remove bundled renderers in CLI

### DIFF
--- a/.changeset/slow-ducks-beg.md
+++ b/.changeset/slow-ducks-beg.md
@@ -1,0 +1,5 @@
+---
+'@codama/cli': minor
+---
+
+The CLI no longer bundles the latest renderers to ensure the user has complete control over the renderer they use and their versions.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,10 +45,6 @@
     "dependencies": {
         "@codama/nodes": "workspace:*",
         "@codama/nodes-from-anchor": "workspace:*",
-        "@codama/renderers": "workspace:*",
-        "@codama/renderers-js": "workspace:*",
-        "@codama/renderers-js-umi": "workspace:*",
-        "@codama/renderers-rust": "workspace:*",
         "@codama/visitors": "workspace:*",
         "@codama/visitors-core": "workspace:*",
         "commander": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,18 +86,6 @@ importers:
       '@codama/nodes-from-anchor':
         specifier: workspace:*
         version: link:../nodes-from-anchor
-      '@codama/renderers':
-        specifier: workspace:*
-        version: link:../renderers
-      '@codama/renderers-js':
-        specifier: workspace:*
-        version: link:../renderers-js
-      '@codama/renderers-js-umi':
-        specifier: workspace:*
-        version: link:../renderers-js-umi
-      '@codama/renderers-rust':
-        specifier: workspace:*
-        version: link:../renderers-rust
       '@codama/visitors':
         specifier: workspace:*
         version: link:../visitors


### PR DESCRIPTION
This PR removes the bundled renderers from the CLI package.

This is so we can decouple the CLI from specific versions of renderers and let users have more control over which renderer version they want to use.