### PR TITLE
Load Anchor adapter dynamically in CLI

### DIFF
--- a/.changeset/cyan-news-march.md
+++ b/.changeset/cyan-news-march.md
@@ -1,0 +1,5 @@
+---
+'@codama/cli': minor
+---
+
+The CLI now offers to install `@codama/nodes-from-anchor` dynamically when an Anchor IDL is detected instead of bundling it in the CLI package. This allows users to have more control over the version of their Anchor adapter.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,6 @@
     },
     "dependencies": {
         "@codama/nodes": "workspace:*",
-        "@codama/nodes-from-anchor": "workspace:*",
         "@codama/visitors": "workspace:*",
         "@codama/visitors-core": "workspace:*",
         "commander": "^14.0.0",

--- a/packages/cli/src/parsedConfig.ts
+++ b/packages/cli/src/parsedConfig.ts
@@ -45,7 +45,7 @@ async function parseConfig(
 ): Promise<ParsedConfig> {
     const idlPath = parseIdlPath(config, configPath, options);
     const idlContent = await importModuleItem('IDL', idlPath);
-    const rootNode = getRootNodeFromIdl(idlContent);
+    const rootNode = await getRootNodeFromIdl(idlContent);
     const scripts = parseScripts(config.scripts ?? {}, configPath);
     const visitors = (config.before ?? []).map((v, i) => parseVisitorConfig(v, configPath, i, null));
 

--- a/packages/cli/test/exports/mock-idl.json
+++ b/packages/cli/test/exports/mock-idl.json
@@ -1,6 +1,15 @@
 {
     "kind": "rootNode",
-    "spec": "codama",
+    "standard": "codama",
     "version": "1.0.0",
-    "program": { "kind": "programNode" }
+    "program": {
+        "kind": "programNode",
+        "name": "myProgram",
+        "accounts": [],
+        "instructions": [],
+        "definedTypes": [],
+        "errors": [],
+        "pdas": []
+    },
+    "additionalPrograms": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       '@codama/nodes':
         specifier: workspace:*
         version: link:../nodes
-      '@codama/nodes-from-anchor':
-        specifier: workspace:*
-        version: link:../nodes-from-anchor
       '@codama/visitors':
         specifier: workspace:*
         version: link:../visitors


### PR DESCRIPTION
This PR removes the `nodes-from-anchor` dependency from the CLI package and, instead, offers the user to install if and only if the used IDL is identified to be an Anchor IDL.

This decouples the CLI from this package making it possible to add it to the main `codama` library without any linked versioning issues, but also allows the user to control the exact version they want to use for their Anchor adapter.