### PR TITLE
Check missing dependencies before `run` CLI command

### DIFF
--- a/.changeset/cold-colts-agree.md
+++ b/.changeset/cold-colts-agree.md
@@ -1,0 +1,5 @@
+---
+'@codama/cli': minor
+---
+
+Check missing dependencies before `run` CLI commands


### PR DESCRIPTION
This PR adds a new dependency check before running scripts in the `codama run` CLI command. In other words, it'll check that all external dependencies about to be imported from a script are all installed before running these scripts. When some dependencies are missing, it'll prompt the user to install them.