### PR TITLE
Remove redundant semicolon from generation of discriminator condition fragments

### DIFF
--- a/.changeset/light-ghosts-fall.md
+++ b/.changeset/light-ghosts-fall.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-js': patch
+---
+
+Remove redundant semicolon from generation of discriminator condition fragments

--- a/packages/renderers-js/src/fragments/discriminatorCondition.ts
+++ b/packages/renderers-js/src/fragments/discriminatorCondition.ts
@@ -58,7 +58,7 @@ export function getDiscriminatorConditionFragment(
             }),
             c => c.join(' && '),
         ),
-        f => mapFragmentContent(f, c => `if (${c}) { ${scope.ifTrue}; }`),
+        f => mapFragmentContent(f, c => `if (${c}) { ${scope.ifTrue} }`),
     );
 }
 


### PR DESCRIPTION
- **Remove redundant semicolon from generation of discriminator condition fragments**
- **Add changeset**

Although Prettier removes this if formatting is enabled, this ensures the render map visitor is generating valid code.