### PR TITLE
Fix size computation of `RemainderOptionTypeNode`

### DIFF
--- a/.changeset/long-trees-fetch.md
+++ b/.changeset/long-trees-fetch.md
@@ -1,0 +1,5 @@
+---
+'@codama/visitors-core': patch
+---
+
+Fix size computation of the `RemainderOptionTypeNode`. This node should always be of variable size unless the item it wraps is of size 0.

--- a/packages/visitors-core/src/getByteSizeVisitor.ts
+++ b/packages/visitors-core/src/getByteSizeVisitor.ts
@@ -141,6 +141,11 @@ export function getByteSizeVisitor(
                     return 32;
                 },
 
+                visitRemainderOptionType(node, { self }) {
+                    const itemSize = visit(node.item, self);
+                    return itemSize === 0 ? 0 : null;
+                },
+
                 visitSetType(node, { self }) {
                     if (!isNode(node.count, 'fixedCountNode')) return null;
                     const count = node.count.value;

--- a/packages/visitors-core/test/getByteSizeVisitor.test.ts
+++ b/packages/visitors-core/test/getByteSizeVisitor.test.ts
@@ -17,6 +17,7 @@ import {
     programNode,
     publicKeyTypeNode,
     remainderCountNode,
+    remainderOptionTypeNode,
     rootNode,
     setTypeNode,
     stringTypeNode,
@@ -133,6 +134,11 @@ test('it returns null for array-like nodes with `RemainderCountNodes`', () => {
     expectSize(arrayTypeNode(numberTypeNode('u16'), remainderCountNode()), null);
     expectSize(setTypeNode(numberTypeNode('u16'), remainderCountNode()), null);
     expectSize(mapTypeNode(numberTypeNode('u16'), numberTypeNode('u8'), remainderCountNode()), null);
+});
+
+test('it returns null with visiting remainder option types', () => {
+    expectSize(remainderOptionTypeNode(stringTypeNode('utf8')), null);
+    expectSize(remainderOptionTypeNode(numberTypeNode('u16')), null);
 });
 
 test('it follows linked nodes using the correct paths', () => {


### PR DESCRIPTION
Fix size computation of the `RemainderOptionTypeNode`. This node should always be of variable size unless the item it wraps is of size 0.