### PR TITLE
Replace chalk with picocolors

### DIFF
--- a/.changeset/heavy-waves-thank.md
+++ b/.changeset/heavy-waves-thank.md
@@ -1,0 +1,5 @@
+---
+'@codama/errors': patch
+---
+
+Replace chalk with picocolors in CLI

--- a/packages/cli/src/utils/logs.ts
+++ b/packages/cli/src/utils/logs.ts
@@ -49,11 +49,10 @@ function logItems(items: string[], color?: (text: string) => string): void {
 }
 
 export function logBanner(): void {
-    console.log(getBanner());
+    console.log(pico.bold(codamaColor('Welcome to Codama!')));
 }
 
-function getBanner(): string {
-    const textBanner = 'Welcome to Codama!';
-    const gradientBanner = pico.bold(`\x1b[38;2;231;171;97m${textBanner}\x1b[0m`);
-    return process.stdout.isTTY && process.stdout.getColorDepth() > 8 ? gradientBanner : textBanner;
+function codamaColor(text: string): string {
+    if (!pico.isColorSupported) return text;
+    return `\x1b[38;2;231;171;97m${text}\x1b[0m`;
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -50,7 +50,7 @@
     "dependencies": {
         "@codama/node-types": "workspace:*",
         "commander": "^14.0.0",
-        "chalk": "^5.6.2"
+        "picocolors": "^1.1.1"
     },
     "license": "MIT",
     "repository": {

--- a/packages/errors/src/cli/index.ts
+++ b/packages/errors/src/cli/index.ts
@@ -3,8 +3,8 @@
  * @see https://github.com/anza-xyz/kit/blob/main/packages/errors
  */
 
-import chalk from 'chalk';
 import { Command, InvalidArgumentError } from 'commander';
+import pico from 'picocolors';
 
 import { version } from '../../package.json';
 import { CodamaErrorCode } from '../codes';
@@ -37,29 +37,21 @@ program
         }
     })
     .action((code: number, context: object | undefined) => {
+        const header = codamaColor(pico.bold('[Decoded]') + ` Codama error code #${code}`);
         const message = getHumanReadableErrorMessage(code as CodamaErrorCode, context);
-        console.log(`
-${
-    chalk.bold(
-        chalk.rgb(154, 71, 255)('[') +
-            chalk.rgb(144, 108, 244)('D') +
-            chalk.rgb(134, 135, 233)('e') +
-            chalk.rgb(122, 158, 221)('c') +
-            chalk.rgb(110, 178, 209)('o') +
-            chalk.rgb(95, 195, 196)('d') +
-            chalk.rgb(79, 212, 181)('e') +
-            chalk.rgb(57, 227, 166)('d') +
-            chalk.rgb(19, 241, 149)(']'),
-    ) + chalk.rgb(19, 241, 149)(' Codama error code #' + code)
-}
-    - ${message}`);
+        console.log(`\n${header}\n    ${message}`);
         if (context) {
-            console.log(`
-${chalk.yellowBright(chalk.bold('[Context]'))}
-    ${JSON.stringify(context, null, 4).split('\n').join('\n    ')}`);
+            const contextHeader = pico.blue(pico.bold('[Context]'));
+            const contextString = JSON.stringify(context, null, 4).split('\n').join('\n    ');
+            console.log(`\n${contextHeader}\n    ${contextString}`);
         }
     });
 
 export function run(argv: readonly string[]) {
     program.parse(argv);
+}
+
+function codamaColor(text: string): string {
+    if (!pico.isColorSupported) return text;
+    return `\x1b[38;2;231;171;97m${text}\x1b[0m`;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,12 +142,12 @@ importers:
       '@codama/node-types':
         specifier: workspace:*
         version: link:../node-types
-      chalk:
-        specifier: ^5.6.2
-        version: 5.6.2
       commander:
         specifier: ^14.0.0
         version: 14.0.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
 
   packages/library:
     dependencies:
@@ -1367,12 +1367,6 @@ packages:
   '@sinonjs/fake-timers@11.3.1':
     resolution: {integrity: sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==}
 
-  '@solana/codecs-core@3.0.2':
-    resolution: {integrity: sha512-vpy8ySWgPF8+APwpeEr4dQbU/EyHjisd/TywIw3rymguWeZ9/wcThS0WDRi08Z44W6InCIbtI08RdtuHQZoSag==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/codecs-core@3.0.3':
     resolution: {integrity: sha512-emKykJ3h1DmnDOY29Uv9eJXP8E/FHzvlUBJ6te+5EbKdFjj7vdlKYPfDxOI6iGdXTY+YC/ELtbNBh6QwF2uEDQ==}
     engines: {node: '>=20.18.0'}
@@ -1401,13 +1395,6 @@ packages:
   '@solana/codecs@3.0.3':
     resolution: {integrity: sha512-GOHwTlIQsCoJx9Ryr6cEf0FHKAQ7pY4aO4xgncAftrv0lveTQ1rPP2inQ1QT0gJllsIa8nwbfXAADs9nNJxQDA==}
     engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/errors@3.0.2':
-    resolution: {integrity: sha512-0B4y9JUsX8/DzflhdSXSAF+UPUKyo1R1rrQ/ShS/8ApCOIWIFqZlve0TPatuTOGGNBememoukPOvDVtFy0ZYpg==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
     peerDependencies:
       typescript: '>=5.3.3'
 
@@ -4586,11 +4573,6 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@solana/codecs-core@3.0.2(typescript@5.9.2)':
-    dependencies:
-      '@solana/errors': 3.0.2(typescript@5.9.2)
-      typescript: 5.9.2
-
   '@solana/codecs-core@3.0.3(typescript@5.9.2)':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.9.2)
@@ -4627,12 +4609,6 @@ snapshots:
       typescript: 5.9.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-
-  '@solana/errors@3.0.2(typescript@5.9.2)':
-    dependencies:
-      chalk: 5.6.2
-      commander: 14.0.0
-      typescript: 5.9.2
 
   '@solana/errors@3.0.3(typescript@5.9.2)':
     dependencies:


### PR DESCRIPTION
We already use `picocolors` in `@codama/cli` so we might as well use it in the `@codama/errors` CLI so we have one less dependency.