### PR TITLE
Implement branded types without unique symbol

### DIFF
--- a/.changeset/cool-regions-clap.md
+++ b/.changeset/cool-regions-clap.md
@@ -1,0 +1,5 @@
+---
+'@codama/node-types': patch
+---
+
+Branded types now use exact values instead of TypeScript's more restictive `unique symbol`. This will allow multiple versions of the library to coexist.

--- a/packages/node-types/src/shared/stringCases.ts
+++ b/packages/node-types/src/shared/stringCases.ts
@@ -1,19 +1,19 @@
 export type TitleCaseString = string & {
-    readonly __stringCase: unique symbol;
+    readonly ['__stringCase:codama']: 'titleCase';
 };
 
 export type PascalCaseString = string & {
-    readonly __stringCase: unique symbol;
+    readonly ['__stringCase:codama']: 'pascalCase';
 };
 
 export type CamelCaseString = string & {
-    readonly __stringCase: unique symbol;
+    readonly ['__stringCase:codama']: 'camelCase';
 };
 
 export type KebabCaseString = string & {
-    readonly __stringCase: unique symbol;
+    readonly ['__stringCase:codama']: 'kebabCase';
 };
 
 export type SnakeCaseString = string & {
-    readonly __stringCase: unique symbol;
+    readonly ['__stringCase:codama']: 'snakeCase';
 };


### PR DESCRIPTION
This PR changes the implementation of Codama's branded types so it uses exact values instead of TypeScript's `unique symbol`. This is to match [Kit's updated design](https://github.com/anza-xyz/kit/pull/473) and will allow multiple versions of the library to coexists.