### PR TITLE
rust-renderer: fix: don't generate `borsh::to_vec` if no borsh traits

### DIFF
--- a/packages/renderers-rust/e2e/anchor/src/generated/instructions/create_guard.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/instructions/create_guard.rs
@@ -69,8 +69,8 @@ impl CreateGuard {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&CreateGuardInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = CreateGuardInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -93,6 +93,10 @@ impl CreateGuardInstructionData {
             discriminator: [251, 254, 17, 198, 219, 218, 154, 99],
         }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for CreateGuardInstructionData {
@@ -110,6 +114,12 @@ pub struct CreateGuardInstructionArgs {
     pub cpi_rule: Option<CpiRule>,
     pub transfer_amount_rule: Option<TransferAmountRule>,
     pub additional_fields_rule: Vec<MetadataAdditionalFieldRule>,
+}
+
+impl CreateGuardInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `CreateGuard`.
@@ -398,8 +408,8 @@ impl<'a, 'b> CreateGuardCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&CreateGuardInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = CreateGuardInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/anchor/src/generated/instructions/execute.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/instructions/execute.rs
@@ -67,8 +67,8 @@ impl Execute {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&ExecuteInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = ExecuteInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -91,6 +91,10 @@ impl ExecuteInstructionData {
             discriminator: [105, 37, 101, 197, 75, 251, 102, 26],
         }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for ExecuteInstructionData {
@@ -103,6 +107,12 @@ impl Default for ExecuteInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExecuteInstructionArgs {
     pub amount: u64,
+}
+
+impl ExecuteInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `Execute`.
@@ -336,8 +346,8 @@ impl<'a, 'b> ExecuteCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&ExecuteInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = ExecuteInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/anchor/src/generated/instructions/initialize.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/instructions/initialize.rs
@@ -57,7 +57,7 @@ impl Initialize {
         ));
         accounts.push(solana_instruction::AccountMeta::new(self.payer, true));
         accounts.extend_from_slice(remaining_accounts);
-        let data = borsh::to_vec(&InitializeInstructionData::new()).unwrap();
+        let data = InitializeInstructionData::new().try_to_vec().unwrap();
 
         solana_instruction::Instruction {
             program_id: crate::WEN_TRANSFER_GUARD_ID,
@@ -78,6 +78,10 @@ impl InitializeInstructionData {
         Self {
             discriminator: [43, 34, 13, 49, 167, 88, 235, 235],
         }
+    }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
     }
 }
 
@@ -285,7 +289,7 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = borsh::to_vec(&InitializeInstructionData::new()).unwrap();
+        let data = InitializeInstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_instruction::Instruction {
             program_id: crate::WEN_TRANSFER_GUARD_ID,

--- a/packages/renderers-rust/e2e/anchor/src/generated/instructions/update_guard.rs
+++ b/packages/renderers-rust/e2e/anchor/src/generated/instructions/update_guard.rs
@@ -62,8 +62,8 @@ impl UpdateGuard {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&UpdateGuardInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = UpdateGuardInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -86,6 +86,10 @@ impl UpdateGuardInstructionData {
             discriminator: [51, 38, 175, 180, 25, 249, 39, 24],
         }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for UpdateGuardInstructionData {
@@ -100,6 +104,12 @@ pub struct UpdateGuardInstructionArgs {
     pub cpi_rule: Option<CpiRule>,
     pub transfer_amount_rule: Option<TransferAmountRule>,
     pub additional_fields_rule: Vec<MetadataAdditionalFieldRule>,
+}
+
+impl UpdateGuardInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `UpdateGuard`.
@@ -331,8 +341,8 @@ impl<'a, 'b> UpdateGuardCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&UpdateGuardInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = UpdateGuardInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction1.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction1.rs
@@ -24,7 +24,7 @@ impl Instruction1 {
     ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(remaining_accounts.len());
         accounts.extend_from_slice(remaining_accounts);
-        let data = borsh::to_vec(&Instruction1InstructionData::new()).unwrap();
+        let data = Instruction1InstructionData::new().try_to_vec().unwrap();
 
         solana_instruction::Instruction {
             program_id: crate::DUMMY_ID,
@@ -41,6 +41,10 @@ pub struct Instruction1InstructionData {}
 impl Instruction1InstructionData {
     pub fn new() -> Self {
         Self {}
+    }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
     }
 }
 
@@ -130,7 +134,7 @@ impl<'a, 'b> Instruction1Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = borsh::to_vec(&Instruction1InstructionData::new()).unwrap();
+        let data = Instruction1InstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_instruction::Instruction {
             program_id: crate::DUMMY_ID,

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction2.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction2.rs
@@ -24,7 +24,7 @@ impl Instruction2 {
     ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(remaining_accounts.len());
         accounts.extend_from_slice(remaining_accounts);
-        let data = borsh::to_vec(&Instruction2InstructionData::new()).unwrap();
+        let data = Instruction2InstructionData::new().try_to_vec().unwrap();
 
         solana_instruction::Instruction {
             program_id: crate::DUMMY_ID,
@@ -41,6 +41,10 @@ pub struct Instruction2InstructionData {}
 impl Instruction2InstructionData {
     pub fn new() -> Self {
         Self {}
+    }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
     }
 }
 
@@ -130,7 +134,7 @@ impl<'a, 'b> Instruction2Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = borsh::to_vec(&Instruction2InstructionData::new()).unwrap();
+        let data = Instruction2InstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_instruction::Instruction {
             program_id: crate::DUMMY_ID,

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction3.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction3.rs
@@ -26,7 +26,7 @@ impl Instruction3 {
     ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(remaining_accounts.len());
         accounts.extend_from_slice(remaining_accounts);
-        let data = borsh::to_vec(&Instruction3InstructionData::new()).unwrap();
+        let data = Instruction3InstructionData::new().try_to_vec().unwrap();
 
         solana_instruction::Instruction {
             program_id: crate::DUMMY_ID,
@@ -45,6 +45,10 @@ pub struct Instruction3InstructionData {
 impl Instruction3InstructionData {
     pub fn new() -> Self {
         Self { discriminator: 42 }
+    }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
     }
 }
 
@@ -134,7 +138,7 @@ impl<'a, 'b> Instruction3Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = borsh::to_vec(&Instruction3InstructionData::new()).unwrap();
+        let data = Instruction3InstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_instruction::Instruction {
             program_id: crate::DUMMY_ID,

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction4.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction4.rs
@@ -28,8 +28,8 @@ impl Instruction4 {
     ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(remaining_accounts.len());
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&Instruction4InstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = Instruction4InstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -48,6 +48,10 @@ impl Instruction4InstructionData {
     pub fn new() -> Self {
         Self {}
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for Instruction4InstructionData {
@@ -60,6 +64,12 @@ impl Default for Instruction4InstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Instruction4InstructionArgs {
     pub my_argument: u64,
+}
+
+impl Instruction4InstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `Instruction4`.
@@ -159,8 +169,8 @@ impl<'a, 'b> Instruction4Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&Instruction4InstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = Instruction4InstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction5.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction5.rs
@@ -28,8 +28,8 @@ impl Instruction5 {
     ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(remaining_accounts.len());
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&Instruction5InstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = Instruction5InstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -48,6 +48,10 @@ impl Instruction5InstructionData {
     pub fn new() -> Self {
         Self {}
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for Instruction5InstructionData {
@@ -60,6 +64,12 @@ impl Default for Instruction5InstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Instruction5InstructionArgs {
     pub my_argument: u64,
+}
+
+impl Instruction5InstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `Instruction5`.
@@ -160,8 +170,8 @@ impl<'a, 'b> Instruction5Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&Instruction5InstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = Instruction5InstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction6.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction6.rs
@@ -27,7 +27,7 @@ impl Instruction6 {
         let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.my_account, false));
         accounts.extend_from_slice(remaining_accounts);
-        let data = borsh::to_vec(&Instruction6InstructionData::new()).unwrap();
+        let data = Instruction6InstructionData::new().try_to_vec().unwrap();
 
         solana_instruction::Instruction {
             program_id: crate::DUMMY_ID,
@@ -44,6 +44,10 @@ pub struct Instruction6InstructionData {}
 impl Instruction6InstructionData {
     pub fn new() -> Self {
         Self {}
+    }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
     }
 }
 
@@ -159,7 +163,7 @@ impl<'a, 'b> Instruction6Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = borsh::to_vec(&Instruction6InstructionData::new()).unwrap();
+        let data = Instruction6InstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_instruction::Instruction {
             program_id: crate::DUMMY_ID,

--- a/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction7.rs
+++ b/packages/renderers-rust/e2e/dummy/src/generated/instructions/instruction7.rs
@@ -34,7 +34,7 @@ impl Instruction7 {
             ));
         }
         accounts.extend_from_slice(remaining_accounts);
-        let data = borsh::to_vec(&Instruction7InstructionData::new()).unwrap();
+        let data = Instruction7InstructionData::new().try_to_vec().unwrap();
 
         solana_instruction::Instruction {
             program_id: crate::DUMMY_ID,
@@ -51,6 +51,10 @@ pub struct Instruction7InstructionData {}
 impl Instruction7InstructionData {
     pub fn new() -> Self {
         Self {}
+    }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
     }
 }
 
@@ -171,7 +175,7 @@ impl<'a, 'b> Instruction7Cpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = borsh::to_vec(&Instruction7InstructionData::new()).unwrap();
+        let data = Instruction7InstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_instruction::Instruction {
             program_id: crate::DUMMY_ID,

--- a/packages/renderers-rust/e2e/memo/src/generated/instructions/add_memo.rs
+++ b/packages/renderers-rust/e2e/memo/src/generated/instructions/add_memo.rs
@@ -26,8 +26,8 @@ impl AddMemo {
     ) -> solana_instruction::Instruction {
         let mut accounts = Vec::with_capacity(remaining_accounts.len());
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&AddMemoInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = AddMemoInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -46,6 +46,10 @@ impl AddMemoInstructionData {
     pub fn new() -> Self {
         Self {}
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for AddMemoInstructionData {
@@ -58,6 +62,12 @@ impl Default for AddMemoInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddMemoInstructionArgs {
     pub memo: RemainderStr,
+}
+
+impl AddMemoInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `AddMemo`.
@@ -157,8 +167,8 @@ impl<'a, 'b> AddMemoCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&AddMemoInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = AddMemoInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/advance_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/advance_nonce_account.rs
@@ -44,7 +44,9 @@ impl AdvanceNonceAccount {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let data = borsh::to_vec(&AdvanceNonceAccountInstructionData::new()).unwrap();
+        let data = AdvanceNonceAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
@@ -63,6 +65,10 @@ pub struct AdvanceNonceAccountInstructionData {
 impl AdvanceNonceAccountInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 4 }
+    }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
     }
 }
 
@@ -218,7 +224,9 @@ impl<'a, 'b> AdvanceNonceAccountCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = borsh::to_vec(&AdvanceNonceAccountInstructionData::new()).unwrap();
+        let data = AdvanceNonceAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/allocate.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/allocate.rs
@@ -30,8 +30,8 @@ impl Allocate {
         let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.new_account, true));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&AllocateInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = AllocateInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -52,6 +52,10 @@ impl AllocateInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 8 }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for AllocateInstructionData {
@@ -64,6 +68,12 @@ impl Default for AllocateInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocateInstructionArgs {
     pub space: u64,
+}
+
+impl AllocateInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `Allocate`.
@@ -185,8 +195,8 @@ impl<'a, 'b> AllocateCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&AllocateInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = AllocateInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/allocate_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/allocate_with_seed.rs
@@ -43,8 +43,8 @@ impl AllocateWithSeed {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&AllocateWithSeedInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = AllocateWithSeedInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -65,6 +65,10 @@ impl AllocateWithSeedInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 9 }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for AllocateWithSeedInstructionData {
@@ -80,6 +84,12 @@ pub struct AllocateWithSeedInstructionArgs {
     pub seed: String,
     pub space: u64,
     pub program_address: Pubkey,
+}
+
+impl AllocateWithSeedInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `AllocateWithSeed`.
@@ -242,8 +252,8 @@ impl<'a, 'b> AllocateWithSeedCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&AllocateWithSeedInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = AllocateWithSeedInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/assign.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/assign.rs
@@ -31,8 +31,8 @@ impl Assign {
         let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
         accounts.push(solana_instruction::AccountMeta::new(self.account, true));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&AssignInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = AssignInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -53,6 +53,10 @@ impl AssignInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 1 }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for AssignInstructionData {
@@ -65,6 +69,12 @@ impl Default for AssignInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AssignInstructionArgs {
     pub program_address: Pubkey,
+}
+
+impl AssignInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `Assign`.
@@ -189,8 +199,8 @@ impl<'a, 'b> AssignCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&AssignInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = AssignInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/assign_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/assign_with_seed.rs
@@ -40,8 +40,8 @@ impl AssignWithSeed {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&AssignWithSeedInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = AssignWithSeedInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -62,6 +62,10 @@ impl AssignWithSeedInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 10 }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for AssignWithSeedInstructionData {
@@ -76,6 +80,12 @@ pub struct AssignWithSeedInstructionArgs {
     pub base: Pubkey,
     pub seed: String,
     pub program_address: Pubkey,
+}
+
+impl AssignWithSeedInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `AssignWithSeed`.
@@ -231,8 +241,8 @@ impl<'a, 'b> AssignWithSeedCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&AssignWithSeedInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = AssignWithSeedInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/authorize_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/authorize_nonce_account.rs
@@ -43,8 +43,10 @@ impl AuthorizeNonceAccount {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&AuthorizeNonceAccountInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = AuthorizeNonceAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -65,6 +67,10 @@ impl AuthorizeNonceAccountInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 7 }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for AuthorizeNonceAccountInstructionData {
@@ -77,6 +83,12 @@ impl Default for AuthorizeNonceAccountInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AuthorizeNonceAccountInstructionArgs {
     pub new_nonce_authority: Pubkey,
+}
+
+impl AuthorizeNonceAccountInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `AuthorizeNonceAccount`.
@@ -218,8 +230,10 @@ impl<'a, 'b> AuthorizeNonceAccountCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&AuthorizeNonceAccountInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = AuthorizeNonceAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/create_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/create_account.rs
@@ -37,8 +37,8 @@ impl CreateAccount {
         accounts.push(solana_instruction::AccountMeta::new(self.payer, true));
         accounts.push(solana_instruction::AccountMeta::new(self.new_account, true));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&CreateAccountInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = CreateAccountInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -59,6 +59,10 @@ impl CreateAccountInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 0 }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for CreateAccountInstructionData {
@@ -73,6 +77,12 @@ pub struct CreateAccountInstructionArgs {
     pub lamports: u64,
     pub space: u64,
     pub program_address: Pubkey,
+}
+
+impl CreateAccountInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `CreateAccount`.
@@ -225,8 +235,8 @@ impl<'a, 'b> CreateAccountCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&CreateAccountInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = CreateAccountInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/create_account_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/create_account_with_seed.rs
@@ -46,8 +46,10 @@ impl CreateAccountWithSeed {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&CreateAccountWithSeedInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = CreateAccountWithSeedInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -68,6 +70,10 @@ impl CreateAccountWithSeedInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 3 }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for CreateAccountWithSeedInstructionData {
@@ -84,6 +90,12 @@ pub struct CreateAccountWithSeedInstructionArgs {
     pub amount: u64,
     pub space: u64,
     pub program_address: Pubkey,
+}
+
+impl CreateAccountWithSeedInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `CreateAccountWithSeed`.
@@ -267,8 +279,10 @@ impl<'a, 'b> CreateAccountWithSeedCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&CreateAccountWithSeedInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = CreateAccountWithSeedInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/initialize_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/initialize_nonce_account.rs
@@ -49,8 +49,10 @@ impl InitializeNonceAccount {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&InitializeNonceAccountInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = InitializeNonceAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -71,6 +73,10 @@ impl InitializeNonceAccountInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 6 }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for InitializeNonceAccountInstructionData {
@@ -83,6 +89,12 @@ impl Default for InitializeNonceAccountInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InitializeNonceAccountInstructionArgs {
     pub nonce_authority: Pubkey,
+}
+
+impl InitializeNonceAccountInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `InitializeNonceAccount`.
@@ -250,8 +262,10 @@ impl<'a, 'b> InitializeNonceAccountCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&InitializeNonceAccountInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = InitializeNonceAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol.rs
@@ -36,8 +36,8 @@ impl TransferSol {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&TransferSolInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = TransferSolInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -58,6 +58,10 @@ impl TransferSolInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 2 }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for TransferSolInstructionData {
@@ -70,6 +74,12 @@ impl Default for TransferSolInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransferSolInstructionArgs {
     pub amount: u64,
+}
+
+impl TransferSolInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `TransferSol`.
@@ -205,8 +215,8 @@ impl<'a, 'b> TransferSolCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&TransferSolInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = TransferSolInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol_with_seed.rs
@@ -46,8 +46,10 @@ impl TransferSolWithSeed {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&TransferSolWithSeedInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = TransferSolWithSeedInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -68,6 +70,10 @@ impl TransferSolWithSeedInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 11 }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for TransferSolWithSeedInstructionData {
@@ -82,6 +88,12 @@ pub struct TransferSolWithSeedInstructionArgs {
     pub amount: u64,
     pub from_seed: String,
     pub from_owner: Pubkey,
+}
+
+impl TransferSolWithSeedInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `TransferSolWithSeed`.
@@ -251,8 +263,10 @@ impl<'a, 'b> TransferSolWithSeedCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&TransferSolWithSeedInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = TransferSolWithSeedInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/upgrade_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/upgrade_nonce_account.rs
@@ -32,7 +32,9 @@ impl UpgradeNonceAccount {
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let data = borsh::to_vec(&UpgradeNonceAccountInstructionData::new()).unwrap();
+        let data = UpgradeNonceAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,
@@ -51,6 +53,10 @@ pub struct UpgradeNonceAccountInstructionData {
 impl UpgradeNonceAccountInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 12 }
+    }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
     }
 }
 
@@ -166,7 +172,9 @@ impl<'a, 'b> UpgradeNonceAccountCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let data = borsh::to_vec(&UpgradeNonceAccountInstructionData::new()).unwrap();
+        let data = UpgradeNonceAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_instruction::Instruction {
             program_id: crate::SYSTEM_ID,

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/withdraw_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/withdraw_nonce_account.rs
@@ -60,8 +60,10 @@ impl WithdrawNonceAccount {
             true,
         ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = borsh::to_vec(&WithdrawNonceAccountInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&args).unwrap();
+        let mut data = WithdrawNonceAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
         solana_instruction::Instruction {
@@ -82,6 +84,10 @@ impl WithdrawNonceAccountInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 5 }
     }
+
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 impl Default for WithdrawNonceAccountInstructionData {
@@ -94,6 +100,12 @@ impl Default for WithdrawNonceAccountInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WithdrawNonceAccountInstructionArgs {
     pub withdraw_amount: u64,
+}
+
+impl WithdrawNonceAccountInstructionArgs {
+    pub fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+        borsh::to_vec(self)
+    }
 }
 
 /// Instruction builder for `WithdrawNonceAccount`.
@@ -297,8 +309,10 @@ impl<'a, 'b> WithdrawNonceAccountCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = borsh::to_vec(&WithdrawNonceAccountInstructionData::new()).unwrap();
-        let mut args = borsh::to_vec(&self.__args).unwrap();
+        let mut data = WithdrawNonceAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {

--- a/packages/renderers-rust/public/templates/instructionsCpiPage.njk
+++ b/packages/renderers-rust/public/templates/instructionsCpiPage.njk
@@ -151,9 +151,9 @@ impl<'a, 'b> {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
           is_writable: remaining_account.2,
       })
     });
-    let {{ 'mut ' if hasArgs }}data = borsh::to_vec(&{{ instruction.name | pascalCase }}InstructionData::new()).unwrap();
+    let {{ 'mut ' if hasArgs }}data = {{ instruction.name | pascalCase }}InstructionData::new().try_to_vec().unwrap();
     {% if hasArgs %}
-      let mut args = borsh::to_vec(&self.__args).unwrap();
+      let mut args = self.__args.try_to_vec().unwrap();
       data.append(&mut args);
     {% endif %}
 

--- a/packages/renderers-rust/public/templates/instructionsPage.njk
+++ b/packages/renderers-rust/public/templates/instructionsPage.njk
@@ -97,9 +97,9 @@ impl {{ instruction.name | pascalCase }} {
       {% endif %}
     {% endfor %}
     accounts.extend_from_slice(remaining_accounts);
-    let {{ 'mut ' if hasArgs }}data = borsh::to_vec(&{{ instruction.name | pascalCase }}InstructionData::new()).unwrap();
+    let {{ 'mut ' if hasArgs }}data = {{ instruction.name | pascalCase }}InstructionData::new().try_to_vec().unwrap();
     {% if hasArgs %}
-      let mut args = borsh::to_vec(&args).unwrap();
+      let mut args = args.try_to_vec().unwrap();
       data.append(&mut args);
     {% endif %}
 
@@ -129,6 +129,12 @@ impl {{ instruction.name | pascalCase }}InstructionData {
       {% endfor %}
     }
   }
+
+  {% if dataTraits | hasTrait('BorshSerialize', 'borsh::BorshSerialize') %}
+  pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    borsh::to_vec(self)
+  }
+  {% endif %}
 }
 
 impl Default for {{ instruction.name | pascalCase }}InstructionData {
@@ -145,6 +151,14 @@ impl Default for {{ instruction.name | pascalCase }}InstructionData {
     {% endif %}
   {% endfor %}
 }
+
+{% if dataTraits | hasTrait('BorshSerialize', 'borsh::BorshSerialize') %}
+impl {{ instruction.name | pascalCase }}InstructionArgs {
+  pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    borsh::to_vec(self)
+  }
+}
+{% endif %}
 {% endif %}
 
 {% for nestedStruct in typeManifest.nestedStructs %}

--- a/packages/renderers-rust/src/utils/render.ts
+++ b/packages/renderers-rust/src/utils/render.ts
@@ -21,5 +21,12 @@ export const render = (template: string, context?: object, options?: NunJucksOpt
     env.addFilter('kebabCase', kebabCase);
     env.addFilter('titleCase', titleCase);
     env.addFilter('rustDocblock', rustDocblock);
+
+    // Returns whether or not the provided traits are implemented on the type.
+    env.addFilter('hasTrait', (traits: string, ...traitNames: string[]) => {
+        if (typeof traits !== 'string') return false;
+        return traitNames.some(traitName => traits.includes(traitName));
+    });
+
     return env.render(template, context);
 };


### PR DESCRIPTION
The Rust renderer supports a configuration object for determining what traits you'd like to be generated in the `#[derive(..)]` block of each type. However, if you don't include `BorshSerialize` or `BorshDeserialize`, the renderer will still use `borsh::to_vec` for instructions.

This PR changes those `borsh::to_vec` callsites in the generated instructions to instead use `self.try_to_vec()` and conditionally implements a `try_to_vec` method that calls into `borsh::try_to_vec` if the `BorshSerialize` trait is implemented.

The use of a wrapper function `try_to_vec` allows developers to implement their own `try_to_vec` as a workaround in case they want to use an alternative serialization method, such as bytemuck. This is current how the generated deserialization code for accounts works accidentally.