### PR TITLE
Use programId of PdaValueNode when resolving instruction inputs

### DIFF
--- a/packages/visitors-core/src/getResolvedInstructionInputsVisitor.ts
+++ b/packages/visitors-core/src/getResolvedInstructionInputsVisitor.ts
@@ -279,7 +279,10 @@ export function getInstructionDependencies(input: InstructionInput | Instruction
                 dependencies.set(seed.value.name, { ...seed.value });
             }
         });
-        return [...dependencies.values()];
+        return <InstructionDependency[]>[
+            ...dependencies.values(),
+            ...(input.defaultValue.programId ? ([input.defaultValue.programId] as const) : []),
+        ];
     }
 
     if (isNode(input.defaultValue, 'resolverValueNode')) {


### PR DESCRIPTION
Should have been part of https://github.com/codama-idl/codama/pull/915.