### PR TITLE
Add command to convert anchort IDL to codama IDL

### DIFF
--- a/.changeset/funny-trains-press.md
+++ b/.changeset/funny-trains-press.md
@@ -1,0 +1,5 @@
+---
+'@codama/cli': minor
+---
+
+Add command to convert anchor IDL to codama

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -1,0 +1,22 @@
+import { Command } from 'commander';
+
+import { getRootNodeFromIdl, readJson, writeFile } from '../utils';
+
+export function setConvertCommand(program: Command): void {
+    program
+        .command('convert')
+        .argument('<idlPath>', 'Path to the input IDL file (e.g., Anchor or supported standard)')
+        .argument('<outPath>', 'Path for the output Codama IDL file')
+        .description('Convert a supported IDL file to Codama IDL format')
+        .action(doConvert);
+}
+
+async function doConvert(idlPath: string, outPath: string) {
+    const idl = await readJson(idlPath);
+
+    const node = await getRootNodeFromIdl(idl);
+
+    await writeFile(outPath, JSON.stringify(node, null, 2));
+
+    console.log(`Converted IDL written to ${outPath}`);
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,2 +1,3 @@
 export * from './init';
 export * from './run';
+export * from './convert';

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,7 +1,7 @@
 import { Command, createCommand, ParseOptions } from 'commander';
 import pico from 'picocolors';
 
-import { setInitCommand, setRunCommand } from './commands';
+import { setConvertCommand, setInitCommand, setRunCommand } from './commands';
 import { setProgramOptions } from './programOptions';
 import { logDebug, logError } from './utils';
 
@@ -36,6 +36,7 @@ export function createProgram(internalOptions?: { exitOverride?: boolean; suppre
     setProgramOptions(program);
     setInitCommand(program);
     setRunCommand(program);
+    setConvertCommand(program);
 
     // Internal options.
     if (internalOptions?.exitOverride) {


### PR DESCRIPTION
### Changes
Add `convert` command to the cli to transform anchor IDL to codama equivalent. This is being used in Yellowstone Vixen new `include_vixen_parser!("codaman-idl.json")` to generate parser inline using `codama-rs`.
 
```
codama convert ./anchor-idl.json ./codama-idl.json
```