### PR TITLE
Remove string prefix from Anchor seeds

### DIFF
--- a/.changeset/whole-moles-live.md
+++ b/.changeset/whole-moles-live.md
@@ -1,0 +1,5 @@
+---
+'@codama/nodes-from-anchor': patch
+---
+
+Remove string prefix from Anchor seeds

--- a/packages/nodes-from-anchor/src/v01/PdaSeedNode.ts
+++ b/packages/nodes-from-anchor/src/v01/PdaSeedNode.ts
@@ -8,10 +8,12 @@ import {
     argumentValueNode,
     constantPdaSeedNodeFromBytes,
     InstructionArgumentNode,
+    isNode,
     PdaSeedNode,
     PdaSeedValueNode,
     pdaSeedValueNode,
     publicKeyTypeNode,
+    stringTypeNode,
     variablePdaSeedNode,
 } from '@codama/nodes';
 import { getBase58Codec } from '@solana/codecs';
@@ -44,8 +46,20 @@ export function pdaSeedNodeFromAnchorV01(
             if (!argumentNode) {
                 throw new CodamaError(CODAMA_ERROR__ANCHOR__ARGUMENT_TYPE_MISSING, { name: argumentName });
             }
+
+            // Anchor uses unprefixed strings for PDA seeds even though the
+            // argument itself uses a Borsh size-prefixed string. Thus, we
+            // must recognize this case and convert the type accordingly.
+            const isBorshString =
+                isNode(argumentNode.type, 'sizePrefixTypeNode') &&
+                isNode(argumentNode.type.type, 'stringTypeNode') &&
+                argumentNode.type.type.encoding === 'utf8' &&
+                isNode(argumentNode.type.prefix, 'numberTypeNode') &&
+                argumentNode.type.prefix.format === 'u32';
+            const argumentType = isBorshString ? stringTypeNode('utf8') : argumentNode.type;
+
             return {
-                definition: variablePdaSeedNode(argumentName, argumentNode.type),
+                definition: variablePdaSeedNode(argumentName, argumentType),
                 value: pdaSeedValueNode(argumentName, argumentValueNode(argumentName)),
             };
         }

--- a/packages/nodes-from-anchor/test/v01/pdaSeedNode.test.ts
+++ b/packages/nodes-from-anchor/test/v01/pdaSeedNode.test.ts
@@ -1,0 +1,50 @@
+import {
+    accountValueNode,
+    argumentValueNode,
+    constantPdaSeedNodeFromBytes,
+    instructionArgumentNode,
+    numberTypeNode,
+    pdaSeedValueNode,
+    publicKeyTypeNode,
+    sizePrefixTypeNode,
+    stringTypeNode,
+    variablePdaSeedNode,
+} from '@codama/nodes';
+import { expect, test } from 'vitest';
+
+import { pdaSeedNodeFromAnchorV01 } from '../../src';
+
+test('it creates a PdaSeedNode from a const Anchor seed', () => {
+    const nodes = pdaSeedNodeFromAnchorV01({ kind: 'const', value: [11, 57, 246, 240] }, []);
+
+    expect(nodes.definition).toEqual(constantPdaSeedNodeFromBytes('base58', 'HeLLo'));
+    expect(nodes.value).toBeUndefined();
+});
+
+test('it creates a PdaSeedNode from an account Anchor seed', () => {
+    const nodes = pdaSeedNodeFromAnchorV01({ kind: 'account', path: 'authority' }, []);
+
+    expect(nodes.definition).toEqual(variablePdaSeedNode('authority', publicKeyTypeNode()));
+    expect(nodes.value).toEqual(pdaSeedValueNode('authority', accountValueNode('authority')));
+});
+
+test('it creates a PdaSeedNode from an arg Anchor seed', () => {
+    const nodes = pdaSeedNodeFromAnchorV01({ kind: 'arg', path: 'capacity' }, [
+        instructionArgumentNode({ name: 'capacity', type: numberTypeNode('u64') }),
+    ]);
+
+    expect(nodes.definition).toEqual(variablePdaSeedNode('capacity', numberTypeNode('u64')));
+    expect(nodes.value).toEqual(pdaSeedValueNode('capacity', argumentValueNode('capacity')));
+});
+
+test('it removes the string prefix from arg Anchor seeds', () => {
+    const nodes = pdaSeedNodeFromAnchorV01({ kind: 'arg', path: 'identifier' }, [
+        instructionArgumentNode({
+            name: 'identifier',
+            type: sizePrefixTypeNode(stringTypeNode('utf8'), numberTypeNode('u32')),
+        }),
+    ]);
+
+    expect(nodes.definition).toEqual(variablePdaSeedNode('identifier', stringTypeNode('utf8')));
+    expect(nodes.value).toEqual(pdaSeedValueNode('identifier', argumentValueNode('identifier')));
+});


### PR DESCRIPTION
This PR aims to fix #337 by removing the u32 prefix from Anchor's `"string"` seeds.

The Anchor type system uses Borsh and therefore, encountering the `"string"` type means we are dealing with a u32-prefix UTF-8 string. However, when defining PDA seeds, it _should_ automatically remove that prefix and leave us with an unprefixed UTF-8 string.

The distinction here is important, even though the PDA seed _points_ to another argument type, if that type is `"string"` then the type used on the instruction data will be different than the one used when computing the PDA derivation.

This PR fixes this by identifying this specific use case and remove the prefix for PDA derivation purposes only.