### PR TITLE
Make `RenderMaps` store fragments instead of strings

### DIFF
--- a/.changeset/ninety-candies-shave.md
+++ b/.changeset/ninety-candies-shave.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-core': minor
+---
+
+Make RenderMaps store fragments instead of strings. This introduces a small breaking change for renderers but allows them to aggregate all fragment pages — e.g. to figure out dependencies for the whole generated library.

--- a/packages/renderers-core/src/fragment.ts
+++ b/packages/renderers-core/src/fragment.ts
@@ -7,6 +7,13 @@ export function mapFragmentContent<TFragment extends BaseFragment>(
     return setFragmentContent(fragment, mapContent(fragment.content));
 }
 
+export async function mapFragmentContentAsync<TFragment extends BaseFragment>(
+    fragment: TFragment,
+    mapContent: (content: string) => Promise<string>,
+): Promise<TFragment> {
+    return setFragmentContent(fragment, await mapContent(fragment.content));
+}
+
 export function setFragmentContent<TFragment extends BaseFragment>(fragment: TFragment, content: string): TFragment {
     return Object.freeze({ ...fragment, content });
 }

--- a/packages/renderers-core/test/renderMap.test.ts
+++ b/packages/renderers-core/test/renderMap.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, test } from 'vitest';
+import { assert, describe, expect, expectTypeOf, test } from 'vitest';
 
 import {
     addToRenderMap,
@@ -8,34 +8,37 @@ import {
     mapRenderMapContentAsync,
     mergeRenderMaps,
     removeFromRenderMap,
+    RenderMap,
 } from '../src';
 
 describe('createRenderMap', () => {
     test('it creates an empty render map', () => {
         expect(createRenderMap()).toStrictEqual(new Map());
+        expectTypeOf(createRenderMap()).toEqualTypeOf<RenderMap<BaseFragment>>();
     });
 
-    test('it creates a render map from a path and a string', () => {
-        expect(createRenderMap('some/path', 'Some content')).toStrictEqual(new Map([['some/path', 'Some content']]));
+    test('it creates an empty render map using a custom fragment type', () => {
+        type CustomFragment = BaseFragment & { customProperty: number };
+        expect(createRenderMap()).toStrictEqual(new Map());
+        expectTypeOf(createRenderMap<CustomFragment>()).toEqualTypeOf<RenderMap<CustomFragment>>();
     });
 
     test('it creates a render map from a path and a fragment', () => {
-        const fragment: BaseFragment = { content: 'Some fragment content' };
-        expect(createRenderMap('some/fragment/path', fragment)).toStrictEqual(
-            new Map([['some/fragment/path', 'Some fragment content']]),
+        expect(createRenderMap('some/path', { content: 'Some content' })).toStrictEqual(
+            new Map([['some/path', { content: 'Some content' }]]),
         );
     });
 
     test('it creates a render map from a record of entries', () => {
         expect(
             createRenderMap({
-                'some/fragment/path': { content: 'Some fragment content' },
-                'some/path': 'Some content',
+                'some/path/a': { content: 'Some content A' },
+                'some/path/b': { content: 'Some content B' },
             }),
         ).toStrictEqual(
             new Map([
-                ['some/fragment/path', 'Some fragment content'],
-                ['some/path', 'Some content'],
+                ['some/path/a', { content: 'Some content A' }],
+                ['some/path/b', { content: 'Some content B' }],
             ]),
         );
     });
@@ -43,50 +46,50 @@ describe('createRenderMap', () => {
     test('it removes undefined entries from the provided record', () => {
         expect(
             createRenderMap({
-                'some/path': 'Some content',
+                'some/path': { content: 'Some content' },
                 'some/path/undefined': undefined,
             }),
-        ).toStrictEqual(new Map([['some/path', 'Some content']]));
+        ).toStrictEqual(new Map([['some/path', { content: 'Some content' }]]));
     });
 
     test('it freezes the returned render map', () => {
         assert.isFrozen(createRenderMap());
-        assert.isFrozen(createRenderMap('some/path', 'Some content'));
-        assert.isFrozen(createRenderMap({ 'some/path': 'Some content' }));
+        assert.isFrozen(createRenderMap('some/path', { content: 'Some content' }));
+        assert.isFrozen(createRenderMap({ 'some/path': { content: 'Some content' } }));
     });
 });
 
 describe('addToRenderMap', () => {
     test('it adds new entries to render map', () => {
-        const renderMap = createRenderMap('some/path', 'Some content');
-        expect(addToRenderMap(renderMap, 'some/new/path', 'Some new content')).toStrictEqual(
+        const renderMap = createRenderMap('some/path', { content: 'Some content' });
+        expect(addToRenderMap(renderMap, 'some/new/path', { content: 'Some new content' })).toStrictEqual(
             new Map([
-                ['some/path', 'Some content'],
-                ['some/new/path', 'Some new content'],
+                ['some/path', { content: 'Some content' }],
+                ['some/new/path', { content: 'Some new content' }],
             ]),
         );
     });
 
     test('it overwrites existing entries in the render map', () => {
-        const renderMap = createRenderMap('some/path', 'Some content');
-        expect(addToRenderMap(renderMap, 'some/path', 'Some new content')).toStrictEqual(
-            new Map([['some/path', 'Some new content']]),
+        const renderMap = createRenderMap('some/path', { content: 'Some content' });
+        expect(addToRenderMap(renderMap, 'some/path', { content: 'Some new content' })).toStrictEqual(
+            new Map([['some/path', { content: 'Some new content' }]]),
         );
     });
 
     test('it freezes the returned render map', () => {
-        assert.isFrozen(addToRenderMap(createRenderMap(), 'some/new/path', 'Some new content'));
+        assert.isFrozen(addToRenderMap(createRenderMap(), 'some/new/path', { content: 'Some new content' }));
     });
 });
 
 describe('removeFromRenderMap', () => {
     test('it removes existing entries from a render map', () => {
-        const renderMap = createRenderMap({ pathA: 'Content A', pathB: 'Content B' });
-        expect(removeFromRenderMap(renderMap, 'pathA')).toStrictEqual(new Map([['pathB', 'Content B']]));
+        const renderMap = createRenderMap({ pathA: { content: 'Content A' }, pathB: { content: 'Content B' } });
+        expect(removeFromRenderMap(renderMap, 'pathA')).toStrictEqual(new Map([['pathB', { content: 'Content B' }]]));
     });
 
     test('it can remove the last entry of a render map', () => {
-        const renderMap = createRenderMap('pathA', 'Content A');
+        const renderMap = createRenderMap('pathA', { content: 'Content A' });
         expect(removeFromRenderMap(renderMap, 'pathA')).toStrictEqual(new Map());
     });
 
@@ -106,42 +109,42 @@ describe('mergeRenderMaps', () => {
     });
 
     test('it returns the first render map as-is when only one map is provided', () => {
-        const renderMap = createRenderMap('pathA', 'ContentA');
+        const renderMap = createRenderMap('pathA', { content: 'ContentA' });
         expect(mergeRenderMaps([renderMap])).toBe(renderMap);
     });
 
     test('it merges the entries of two render maps', () => {
         expect(
-            mergeRenderMaps([createRenderMap('pathA', 'ContentA'), createRenderMap('pathB', 'ContentB')]),
+            mergeRenderMaps([
+                createRenderMap('pathA', { content: 'ContentA' }),
+                createRenderMap('pathB', { content: 'ContentB' }),
+            ]),
         ).toStrictEqual(
             new Map([
-                ['pathA', 'ContentA'],
-                ['pathB', 'ContentB'],
+                ['pathA', { content: 'ContentA' }],
+                ['pathB', { content: 'ContentB' }],
             ]),
         );
     });
 
     test('later entries overwrite earlier entries', () => {
         expect(
-            mergeRenderMaps([createRenderMap('samePath', 'Old content'), createRenderMap('samePath', 'New content')]),
-        ).toStrictEqual(new Map([['samePath', 'New content']]));
-    });
-
-    test('it merges the entries of two render maps', () => {
-        expect(
-            mergeRenderMaps([createRenderMap('pathA', 'ContentA'), createRenderMap('pathB', 'ContentB')]),
-        ).toStrictEqual(
-            new Map([
-                ['pathA', 'ContentA'],
-                ['pathB', 'ContentB'],
+            mergeRenderMaps([
+                createRenderMap('samePath', { content: 'Old content' }),
+                createRenderMap('samePath', { content: 'New content' }),
             ]),
-        );
+        ).toStrictEqual(new Map([['samePath', { content: 'New content' }]]));
     });
 
     test('it freezes the returned render map', () => {
         assert.isFrozen(mergeRenderMaps([]));
-        assert.isFrozen(mergeRenderMaps([createRenderMap('pathA', 'ContentA')]));
-        assert.isFrozen(mergeRenderMaps([createRenderMap('pathA', 'ContentA'), createRenderMap('pathB', 'ContentB')]));
+        assert.isFrozen(mergeRenderMaps([createRenderMap('pathA', { content: 'ContentA' })]));
+        assert.isFrozen(
+            mergeRenderMaps([
+                createRenderMap('pathA', { content: 'ContentA' }),
+                createRenderMap('pathB', { content: 'ContentB' }),
+            ]),
+        );
     });
 });
 
@@ -149,16 +152,13 @@ describe('mapRenderMapContent', () => {
     test('it maps the content of all entries inside a render map', () => {
         expect(
             mapRenderMapContent(
-                createRenderMap({
-                    pathA: 'ContentA',
-                    pathB: 'ContentB',
-                }),
+                createRenderMap({ pathA: { content: 'ContentA' }, pathB: { content: 'ContentB' } }),
                 content => `Mapped: ${content}`,
             ),
         ).toStrictEqual(
             new Map([
-                ['pathA', 'Mapped: ContentA'],
-                ['pathB', 'Mapped: ContentB'],
+                ['pathA', { content: 'Mapped: ContentA' }],
+                ['pathB', { content: 'Mapped: ContentB' }],
             ]),
         );
     });
@@ -173,15 +173,15 @@ describe('mapRenderMapContentAsync', () => {
         expect(
             await mapRenderMapContentAsync(
                 createRenderMap({
-                    pathA: 'ContentA',
-                    pathB: 'ContentB',
+                    pathA: { content: 'ContentA' },
+                    pathB: { content: 'ContentB' },
                 }),
                 content => Promise.resolve(`Mapped: ${content}`),
             ),
         ).toStrictEqual(
             new Map([
-                ['pathA', 'Mapped: ContentA'],
-                ['pathB', 'Mapped: ContentB'],
+                ['pathA', { content: 'Mapped: ContentA' }],
+                ['pathB', { content: 'Mapped: ContentB' }],
             ]),
         );
     });


### PR DESCRIPTION
This PR changes the type of the `RenderMap` helper type from `Map<Path, string>` to `Map<Path, TFragment>` where `TFragment extends BaseFragment`. In other words, it makes `RenderMaps` store fragments instead of strings.

Whilst this is may be a small breaking change for renderer (when they bump `renderers-core` to the next minor version[^1]), it will allow them to keep track of all fragments rendered in their generated library and perform aggregations such as figuring out the final dependencies needed for that library.

For instance, this change will allow the JS and Rust renderers to create and keep up-to-date the `package.json` and `Cargo.toml` of their generated libraries respectively.

[^1]: Unfortunately, the versioning of `renderers-core` is currently linked to the `nodes` package which means using a major bump would essentially release Codama v2.