### PR TITLE
Add `fileExists` helper to `renderers-core`

### DIFF
--- a/.changeset/huge-windows-attend.md
+++ b/.changeset/huge-windows-attend.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-core': patch
+---
+
+Add `fileExists` helper function

--- a/packages/renderers-core/src/fs.ts
+++ b/packages/renderers-core/src/fs.ts
@@ -4,15 +4,15 @@ import { CODAMA_ERROR__NODE_FILESYSTEM_FUNCTION_UNAVAILABLE, CodamaError } from 
 
 import { Path, pathDirectory } from './path';
 
-export const createDirectory = (path: Path): void => {
+export function createDirectory(path: Path): void {
     if (!__NODEJS__) {
         throw new CodamaError(CODAMA_ERROR__NODE_FILESYSTEM_FUNCTION_UNAVAILABLE, { fsFunction: 'mkdirSync' });
     }
 
     mkdirSync(path, { recursive: true });
-};
+}
 
-export const deleteDirectory = (path: Path): void => {
+export function deleteDirectory(path: Path): void {
     if (!__NODEJS__) {
         throw new CodamaError(CODAMA_ERROR__NODE_FILESYSTEM_FUNCTION_UNAVAILABLE, { fsFunction: 'rmSync' });
     }
@@ -20,9 +20,9 @@ export const deleteDirectory = (path: Path): void => {
     if (existsSync(path)) {
         rmSync(path, { recursive: true });
     }
-};
+}
 
-export const writeFile = (path: Path, content: string): void => {
+export function writeFile(path: Path, content: string): void {
     if (!__NODEJS__) {
         throw new CodamaError(CODAMA_ERROR__NODE_FILESYSTEM_FUNCTION_UNAVAILABLE, { fsFunction: 'writeFileSync' });
     }
@@ -32,7 +32,15 @@ export const writeFile = (path: Path, content: string): void => {
         createDirectory(directory);
     }
     writeFileSync(path, content);
-};
+}
+
+export function fileExists(path: Path): boolean {
+    if (!__NODEJS__) {
+        throw new CodamaError(CODAMA_ERROR__NODE_FILESYSTEM_FUNCTION_UNAVAILABLE, { fsFunction: 'existsSync' });
+    }
+
+    return existsSync(path);
+}
 
 export function readFile(path: Path): string {
     if (!__NODEJS__) {

--- a/packages/renderers-core/test/fs.test.ts
+++ b/packages/renderers-core/test/fs.test.ts
@@ -1,17 +1,26 @@
 import { CODAMA_ERROR__NODE_FILESYSTEM_FUNCTION_UNAVAILABLE, CodamaError } from '@codama/errors';
 import { expect, test } from 'vitest';
 
-import { createDirectory, deleteDirectory, readJson, writeFile } from '../src';
+import { createDirectory, deleteDirectory, fileExists, readJson, writeFile } from '../src';
 
 if (__NODEJS__) {
     test('it reads JSON objects from files', () => {
         const result = readJson('./test/fs.test.json');
         expect(result).toEqual({ key: 'value' });
     });
+    test('it checks if a file exists', () => {
+        const result = fileExists('./test/fs.test.json');
+        expect(result).toBe(true);
+    });
 } else {
     test('it fails to call readJson', () => {
         expect(() => readJson('./path')).toThrow(
             new CodamaError(CODAMA_ERROR__NODE_FILESYSTEM_FUNCTION_UNAVAILABLE, { fsFunction: 'readFileSync' }),
+        );
+    });
+    test('it fails to call fileExists', () => {
+        expect(() => fileExists('./path')).toThrow(
+            new CodamaError(CODAMA_ERROR__NODE_FILESYSTEM_FUNCTION_UNAVAILABLE, { fsFunction: 'existsSync' }),
         );
     });
     test('it fails to call createDirectory', () => {


### PR DESCRIPTION
This helper will be used by the JS renderer to check whether or not a `package.json` exists.