### PR TITLE
Remove treeshake workaround for Rollup's deprecated assert syntax

### DIFF
--- a/.changeset/clean-teams-rescue.md
+++ b/.changeset/clean-teams-rescue.md
@@ -1,0 +1,16 @@
+---
+'@codama/cli': patch
+'@codama/dynamic-codecs': patch
+'@codama/dynamic-parsers': patch
+'@codama/errors': patch
+'codama': patch
+'@codama/node-types': patch
+'@codama/nodes': patch
+'@codama/nodes-from-anchor': patch
+'@codama/renderers-core': patch
+'@codama/validators': patch
+'@codama/visitors': patch
+'@codama/visitors-core': patch
+---
+
+Remove treeshake workaround for Rollup's deprecated assert syntax

--- a/tsup.config.base.ts
+++ b/tsup.config.base.ts
@@ -54,14 +54,6 @@ export function getBuildConfig(options: BuildOptions): TsupConfig {
         publicDir: true,
         pure: ['process'],
         sourcemap: format !== 'iife',
-
-        // Treeshaking already happens with esbuild but tsup offers this options
-        // for "better" treeshaking strategies using Rollup as an additional step.
-        // The issue is Rollup now uses the deprecated "assert" import keyword by default
-        // And tsup doesn't offer a way to change this behavior. Since the CLI package
-        // relies on using the "with" keyword to dynamically import JSON files,
-        // we can't use Rollup for treeshaking.
-        treeshake: false,
     };
 }
 


### PR DESCRIPTION
It seems Rollup has since fixed the issue where it used the deprecated "assert" import keyword instead of "with" for import attributes when tree-shaking. We can now remove the `treeshake: false` workaround that was added to prevent conflicts with the CLI package's dynamic JSON imports.

See: #487