### PR TITLE
Enable Rollup treeshaking pass by default, disable only for CLI builds

### DIFF
--- a/.changeset/pink-peaches-grab.md
+++ b/.changeset/pink-peaches-grab.md
@@ -1,0 +1,16 @@
+---
+'@codama/cli': patch
+'@codama/dynamic-codecs': patch
+'@codama/dynamic-parsers': patch
+'@codama/errors': patch
+'codama': patch
+'@codama/node-types': patch
+'@codama/nodes': patch
+'@codama/nodes-from-anchor': patch
+'@codama/renderers-core': patch
+'@codama/validators': patch
+'@codama/visitors': patch
+'@codama/visitors-core': patch
+---
+
+Enable Rollup treeshaking pass by default, disable only for CLI builds

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,9 +1,23 @@
-import { defineConfig } from 'tsup';
+import { defineConfig, Options as TsupConfig } from 'tsup';
 
 import { getBuildConfig, getCliBuildConfig } from '../../tsup.config.base';
 
 export default defineConfig([
-    getBuildConfig({ format: 'cjs', platform: 'node' }),
-    getBuildConfig({ format: 'esm', platform: 'node' }),
-    getCliBuildConfig(),
+    removeAdditionalTreeShaking(getBuildConfig({ format: 'cjs', platform: 'node' })),
+    removeAdditionalTreeShaking(getBuildConfig({ format: 'esm', platform: 'node' })),
+    removeAdditionalTreeShaking(getCliBuildConfig()),
 ]);
+
+function removeAdditionalTreeShaking(config: TsupConfig): TsupConfig {
+    return {
+        ...config,
+
+        // Treeshaking already happens with esbuild but tsup offers this options
+        // for "better" treeshaking strategies using Rollup as an additional step.
+        // The issue is Rollup now uses the deprecated "assert" import keyword by default
+        // And tsup doesn't offer a way to change this behavior. Since the CLI package
+        // relies on using the "with" keyword to dynamically import JSON files,
+        // we can't use Rollup for treeshaking.
+        treeshake: false,
+    };
+}

--- a/tsup.config.base.ts
+++ b/tsup.config.base.ts
@@ -54,6 +54,7 @@ export function getBuildConfig(options: BuildOptions): TsupConfig {
         publicDir: true,
         pure: ['process'],
         sourcemap: format !== 'iife',
+        treeshake: true,
     };
 }
 


### PR DESCRIPTION
This PR enables Rollup's additional treeshaking pass (on top of esbuild's) by default across all packages except on the `@codama/cli` package.

For `@codama/cli` builds, a new `removeAdditionalTreeShaking` helper explicitly disables this second pass to avoid conflicts with dynamic JSON imports that use the "with" keyword (Rollup still defaults to the deprecated "assert" syntax and tsup doesn't provide a way to configure this).

This allows most packages to benefit from Rollup's improved treeshaking while working around the import attributes issue only where necessary. Particular, it completely removes dead code from global variable such as `if(__NODEJS__) {...}`.