### PR TITLE
doc: add `renderers-go` to the list of program clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ Feel free to PR your own visitor here for others to discover. Note that they are
 
 | Visitor                                                                                         | Description                                                                                             | Maintainer                                   |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `@codama/renderers-go` ([docs](https://github.com/codama-idl/renderers-go))                     | Generates a Go client compatible with [the Solana Go SDK](https://github.com/gagliardetto/solana-go).   | [Sonic](hhttps://github.com/sonicfromnewyoke)|
 | `@codama/renderers-js` ([docs](https://github.com/codama-idl/renderers-js))                     | Generates a JavaScript client compatible with [Solana Kit](https://www.solanakit.com/).                 | [Anza](https://www.anza.xyz/)                |
 | `@codama/renderers-js-umi` ([docs](https://github.com/codama-idl/renderers-js-umi))             | Generates a JavaScript client compatible with [the Umi framework](https://developers.metaplex.com/umi). | [Metaplex](https://www.metaplex.com/)        |
 | `@codama/renderers-rust` ([docs](https://github.com/codama-idl/renderers-rust))                 | Generates a Rust client compatible with [the Solana SDK](https://github.com/anza-xyz/solana-sdk).       | [Anza](https://www.anza.xyz/)                |
 | `@codama/renderers-vixen-parser` ([docs](https://github.com/codama-idl/renderers-vixen-parser)) | Generates [Yellowstone](https://github.com/rpcpool/yellowstone-grpc) account and instruction parsers.   | [Triton One](https://triton.one/)            |
 | `@limechain/codama-dart` ([docs](https://github.com/limechain/codama-dart))                     | Generates a Dart client.                                                                                | [LimeChain](https://github.com/limechain/)   |
 | `codama-py` ([docs](https://github.com/Solana-ZH/codama-py))                                    | Generates a Python client.                                                                              | [Solar](https://github.com/Solana-ZH)        |
-| `@codama/renderers-go` ([docs](https://github.com/codama-idl/renderers-go))                     | Generates a Go client compatible with [the Solana Go SDK](https://github.com/gagliardetto/solana-go).   | [Sonic](hhttps://github.com/sonicfromnewyoke)|
 
 ### Provides utility
 


### PR DESCRIPTION
### Problem

**Generates program clients** lacks of reference to the `renderers-go` package

### Solution

add missed links which lead to the Go SDK and renderer itself