### PR TITLE
Guard against undefined events in getAllEvents and identifyData

### DIFF
--- a/.changeset/guard-undefined-events.md
+++ b/.changeset/guard-undefined-events.md
@@ -1,0 +1,6 @@
+---
+"@codama/nodes": patch
+"@codama/dynamic-parsers": patch
+---
+
+Guard against undefined `events` on ProgramNode in `getAllEvents` and `identifyData`.

--- a/packages/dynamic-parsers/src/identify.ts
+++ b/packages/dynamic-parsers/src/identify.ts
@@ -96,7 +96,9 @@ export function getByteIdentificationVisitor<TKind extends 'accountNode' | 'even
                 return match ? stack.getPath(node.kind) : undefined;
             },
             visitProgram(node) {
-                const candidates = [...node.accounts, ...node.events, ...node.instructions].filter(isNodeFilter(kind));
+                const candidates = [...node.accounts, ...(node.events ?? []), ...node.instructions].filter(
+                    isNodeFilter(kind),
+                );
                 for (const candidate of candidates) {
                     const result = visit(candidate, this);
                     if (result) return result;

--- a/packages/dynamic-parsers/test/identify.test.ts
+++ b/packages/dynamic-parsers/test/identify.test.ts
@@ -9,6 +9,7 @@ import {
     hiddenPrefixTypeNode,
     instructionNode,
     numberTypeNode,
+    type ProgramNode,
     programNode,
     rootNode,
     sizeDiscriminatorNode,
@@ -230,6 +231,17 @@ describe('identifyEventData', () => {
         );
         const result = identifyEventData(root, hex('01020304'));
         expect(result).toBeUndefined();
+    });
+    test('it handles ProgramNode with missing events field', () => {
+        const program = programNode({
+            accounts: [accountNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myAccount' })],
+            name: 'myProgram',
+            publicKey: '1111',
+        });
+        const raw = { ...program, events: undefined } as unknown as ProgramNode;
+        const root = rootNode(raw);
+        expect(() => identifyEventData(root, hex('01020304'))).not.toThrow();
+        expect(identifyEventData(root, hex('01020304'))).toBeUndefined();
     });
     test('it identifies tuple events using constant discriminators', () => {
         const root = rootNode(

--- a/packages/nodes/src/ProgramNode.ts
+++ b/packages/nodes/src/ProgramNode.ts
@@ -72,7 +72,7 @@ export function getAllAccounts(node: ProgramNode | ProgramNode[] | RootNode): Ac
 }
 
 export function getAllEvents(node: ProgramNode | ProgramNode[] | RootNode): EventNode[] {
-    return getAllPrograms(node).flatMap(program => program.events);
+    return getAllPrograms(node).flatMap(program => program.events ?? []);
 }
 
 export function getAllDefinedTypes(node: ProgramNode | ProgramNode[] | RootNode): DefinedTypeNode[] {

--- a/packages/nodes/test/ProgramNode.test.ts
+++ b/packages/nodes/test/ProgramNode.test.ts
@@ -1,6 +1,7 @@
+import type { ProgramNode } from '@codama/node-types';
 import { expect, test } from 'vitest';
 
-import { programNode } from '../src';
+import { getAllEvents, programNode } from '../src';
 
 test('it returns the right node kind', () => {
     const node = programNode({ name: 'foo', publicKey: '1111' });
@@ -10,4 +11,11 @@ test('it returns the right node kind', () => {
 test('it returns a frozen object', () => {
     const node = programNode({ name: 'foo', publicKey: '1111' });
     expect(Object.isFrozen(node)).toBe(true);
+});
+
+test('getAllEvents handles ProgramNode with missing events field', () => {
+    const node = programNode({ name: 'foo', publicKey: '1111' });
+    const raw = { ...node, events: undefined } as unknown as ProgramNode;
+    expect(() => getAllEvents(raw)).not.toThrow();
+    expect(getAllEvents(raw)).toEqual([]);
 });

--- a/packages/visitors-core/test/nodes/ProgramNode.test.ts
+++ b/packages/visitors-core/test/nodes/ProgramNode.test.ts
@@ -6,11 +6,13 @@ import {
     eventNode,
     instructionNode,
     pdaNode,
+    type ProgramNode,
     programNode,
     structTypeNode,
 } from '@codama/nodes';
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 
+import { identityVisitor, mergeVisitor, visit } from '../../src';
 import {
     expectDebugStringVisitor,
     expectDeleteNodesVisitor,
@@ -52,6 +54,22 @@ test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[instructionNode]', { ...node, instructions: [] });
     expectDeleteNodesVisitor(node, '[definedTypeNode]', { ...node, definedTypes: [] });
     expectDeleteNodesVisitor(node, '[errorNode]', { ...node, errors: [] });
+});
+
+test('mergeVisitor handles ProgramNode with missing events field', () => {
+    const raw = { ...programNode({ name: 'foo', publicKey: '1111' }), events: undefined } as unknown as ProgramNode;
+    const visitor = mergeVisitor(
+        () => 1,
+        (_, values) => values.reduce((a, b) => a + b, 1),
+    );
+    expect(() => visit(raw, visitor)).not.toThrow();
+});
+
+test('identityVisitor handles ProgramNode with missing events field', () => {
+    const raw = { ...programNode({ name: 'foo', publicKey: '1111' }), events: undefined } as unknown as ProgramNode;
+    const result = visit(raw, identityVisitor());
+    expect(result).not.toBeNull();
+    expect((result as ProgramNode).events).toEqual([]);
 });
 
 test('debugStringVisitor', () => {


### PR DESCRIPTION
I ran into this issue after rebasing my fork to 35516d4b0757456dbcd52473d275f9361348b308. If you want me to merge the commits into one let me know.

`getAllEvents` returns `[undefined]` and `identifyData` throws when `program.events` is undefined. ProgramNodes from JSON deserialization or pre-events codama trees won't have the field.

The visitors already guard with `(node.events ?? [])` but I also added tests for them.

NOTE: Same gap exists in all `getAll*` functions. They all do bare `program.X` without `?? []`.

I think the root cause is `rootNode()`. It passes programs through without calling `programNode()`, so raw JSON objects keep `undefined` for missing fields like `events`. The `?? []` guards are the safe incremental fix. A deeper fix would be normalizing through `programNode()` in `rootNode()`, but unsure if that has side-effects

Happy to update this PR if you want