### PR TITLE
feat(nodes-from-anchor): add event support to V00 anchor IDLs

### DIFF
--- a/.changeset/v00-anchor-events.md
+++ b/.changeset/v00-anchor-events.md
@@ -1,0 +1,5 @@
+---
+'@codama/nodes-from-anchor': minor
+---
+
+Add event support to V00 anchor IDLs

--- a/packages/nodes-from-anchor/src/discriminators.ts
+++ b/packages/nodes-from-anchor/src/discriminators.ts
@@ -19,3 +19,9 @@ export const getAnchorAccountDiscriminatorV00 = (idlName: string): BytesValueNod
     const hash = sha256(bytes as Uint8Array).slice(0, 8);
     return bytesValueNode('base16', hex(hash));
 };
+
+export const getAnchorEventDiscriminatorV00 = (idlName: string): BytesValueNode => {
+    const bytes = getUtf8Codec().encode(`event:${pascalCase(idlName)}`);
+    const hash = sha256(bytes as Uint8Array).slice(0, 8);
+    return bytesValueNode('base16', hex(hash));
+};

--- a/packages/nodes-from-anchor/src/v00/EventNode.ts
+++ b/packages/nodes-from-anchor/src/v00/EventNode.ts
@@ -1,0 +1,28 @@
+import {
+    bytesTypeNode,
+    camelCase,
+    constantDiscriminatorNode,
+    constantValueNode,
+    EventNode,
+    eventNode,
+    fixedSizeTypeNode,
+    hiddenPrefixTypeNode,
+} from '@codama/nodes';
+
+import { getAnchorEventDiscriminatorV00 } from '../discriminators';
+import { IdlV00Event } from './idl';
+import { structTypeNodeFromAnchorV00 } from './typeNodes';
+
+export function eventNodeFromAnchorV00(idl: IdlV00Event): EventNode {
+    const idlName = idl.name ?? '';
+    const name = camelCase(idlName);
+    const data = structTypeNodeFromAnchorV00({ fields: idl.fields ?? [], kind: 'struct' });
+    const discriminator = getAnchorEventDiscriminatorV00(idlName);
+    const discriminatorConstant = constantValueNode(fixedSizeTypeNode(bytesTypeNode(), 8), discriminator);
+
+    return eventNode({
+        data: hiddenPrefixTypeNode(data, [discriminatorConstant]),
+        discriminators: [constantDiscriminatorNode(discriminatorConstant)],
+        name,
+    });
+}

--- a/packages/nodes-from-anchor/src/v00/ProgramNode.ts
+++ b/packages/nodes-from-anchor/src/v00/ProgramNode.ts
@@ -4,6 +4,7 @@ import { accountNodeFromAnchorV00 } from './AccountNode';
 import { constantNodeFromAnchorV00 } from './ConstantNode';
 import { definedTypeNodeFromAnchorV00 } from './DefinedTypeNode';
 import { errorNodeFromAnchorV00 } from './ErrorNode';
+import { eventNodeFromAnchorV00 } from './EventNode';
 import { IdlV00 } from './idl';
 import { instructionNodeFromAnchorV00 } from './InstructionNode';
 import { pdaNodeFromAnchorV00 } from './PdaNode';
@@ -15,11 +16,13 @@ export function programNodeFromAnchorV00(idl: IdlV00): ProgramNode {
     const instructions = (idl.instructions ?? []).map((instruction, index) =>
         instructionNodeFromAnchorV00(instruction, index, origin),
     );
+    const events = origin === 'anchor' ? (idl.events ?? []).map(eventNodeFromAnchorV00) : [];
     return programNode({
         accounts,
         constants: (idl?.constants ?? []).map(constantNodeFromAnchorV00),
         definedTypes: (idl?.types ?? []).map(definedTypeNodeFromAnchorV00),
         errors: (idl?.errors ?? []).map(errorNodeFromAnchorV00),
+        events,
         instructions,
         name: idl?.name ?? '',
         origin,

--- a/packages/nodes-from-anchor/src/v00/index.ts
+++ b/packages/nodes-from-anchor/src/v00/index.ts
@@ -2,6 +2,7 @@ export * from './AccountNode';
 export * from './ConstantNode';
 export * from './DefinedTypeNode';
 export * from './ErrorNode';
+export * from './EventNode';
 export * from './InstructionAccountNode';
 export * from './InstructionArgumentNode';
 export * from './InstructionNode';

--- a/packages/nodes-from-anchor/test/discriminator.test.ts
+++ b/packages/nodes-from-anchor/test/discriminator.test.ts
@@ -1,7 +1,11 @@
 import { bytesValueNode } from '@codama/nodes';
 import { expect, test } from 'vitest';
 
-import { getAnchorAccountDiscriminatorV00, getAnchorInstructionDiscriminatorV00 } from '../src/index.js';
+import {
+    getAnchorAccountDiscriminatorV00,
+    getAnchorEventDiscriminatorV00,
+    getAnchorInstructionDiscriminatorV00,
+} from '../src/index.js';
 
 test('it can compute the discriminator of an Anchor account', () => {
     // Given an account named "StakeEntry" on the IDL.
@@ -12,6 +16,17 @@ test('it can compute the discriminator of an Anchor account', () => {
 
     // Then we get the expected value.
     expect(discriminator).toEqual(bytesValueNode('base16', 'bb7f09239b445628'));
+});
+
+test('it can compute the discriminator of an Anchor event', () => {
+    // Given an event named "MyEvent" on the IDL.
+    const idlName = 'MyEvent';
+
+    // When we compute its Anchor discriminator.
+    const discriminator = getAnchorEventDiscriminatorV00(idlName);
+
+    // Then we get the expected value.
+    expect(discriminator).toEqual(bytesValueNode('base16', '60b8c5f38b025a94'));
 });
 
 test('it can compute the discriminator of an Anchor instruction', () => {

--- a/packages/nodes-from-anchor/test/v00/EventNode.test.ts
+++ b/packages/nodes-from-anchor/test/v00/EventNode.test.ts
@@ -1,0 +1,60 @@
+import {
+    bytesTypeNode,
+    constantDiscriminatorNode,
+    constantValueNode,
+    eventNode,
+    fixedSizeTypeNode,
+    hiddenPrefixTypeNode,
+    numberTypeNode,
+    structFieldTypeNode,
+    structTypeNode,
+} from '@codama/nodes';
+import { expect, test } from 'vitest';
+
+import { eventNodeFromAnchorV00, getAnchorEventDiscriminatorV00 } from '../../src';
+
+test('it creates event nodes with anchor discriminators', () => {
+    const node = eventNodeFromAnchorV00({
+        fields: [{ index: false, name: 'amount', type: 'u32' }],
+        name: 'MyEvent',
+    });
+
+    expect(node).toEqual(
+        eventNode({
+            data: hiddenPrefixTypeNode(
+                structTypeNode([structFieldTypeNode({ name: 'amount', type: numberTypeNode('u32') })]),
+                [constantValueNode(fixedSizeTypeNode(bytesTypeNode(), 8), getAnchorEventDiscriminatorV00('MyEvent'))],
+            ),
+            discriminators: [
+                constantDiscriminatorNode(
+                    constantValueNode(fixedSizeTypeNode(bytesTypeNode(), 8), getAnchorEventDiscriminatorV00('MyEvent')),
+                ),
+            ],
+            name: 'myEvent',
+        }),
+    );
+});
+
+test('it creates event nodes with no fields', () => {
+    const node = eventNodeFromAnchorV00({
+        fields: [],
+        name: 'EmptyEvent',
+    });
+
+    expect(node).toEqual(
+        eventNode({
+            data: hiddenPrefixTypeNode(structTypeNode([]), [
+                constantValueNode(fixedSizeTypeNode(bytesTypeNode(), 8), getAnchorEventDiscriminatorV00('EmptyEvent')),
+            ]),
+            discriminators: [
+                constantDiscriminatorNode(
+                    constantValueNode(
+                        fixedSizeTypeNode(bytesTypeNode(), 8),
+                        getAnchorEventDiscriminatorV00('EmptyEvent'),
+                    ),
+                ),
+            ],
+            name: 'emptyEvent',
+        }),
+    );
+});


### PR DESCRIPTION
Old (V00) anchor IDLs define events inline with fields and rely on a SHA256("event:EventName") discriminator. Bring V00 in line with V01 by emitting EventNodes for these IDLs.