### PR TITLE
Bump @codama/spec to 1.6.0-rc.6

### DIFF
--- a/.changeset/wise-otters-hum.md
+++ b/.changeset/wise-otters-hum.md
@@ -1,0 +1,7 @@
+---
+'@codama/node-types': patch
+---
+
+Bump `@codama/spec` from `1.6.0-rc.4` to `1.6.0-rc.6`. The encoded surface in `@codama/node-types` is functionally unchanged; one docstring paragraph on `NestedTypeNode` now reads `nestedTypeNode<T>` instead of `NestedTypeNode<T>` to mirror the spec's new camelCase nested-union alias name.
+
+Behind the scenes, `@codama-internal/spec-generators` learns about the new `{ kind: 'address' }` `TypeExpr` (rendered as plain `string` on the v1 TS surface — a dedicated `Address` brand may follow in a future spec major), the camelCase rename of every union and enumeration name on the spec side (the generated PascalCase TS identifiers are unaffected since the generator runs each name through `pascalCase()` at render time), and a constructor-signature bug where an attribute that was both `optional` and supplied with a default would emit invalid TS (`param?: T = default`). The bug never triggered against the rc.4 v1 spec but would have surfaced once any future attribute combined `optional: true` with a configured default; the fix is to omit the `?` mark whenever an initializer is present.

--- a/packages/node-types/src/generated/typeNodes/NestedTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/NestedTypeNode.ts
@@ -9,7 +9,7 @@ import type { TypeNode } from './TypeNode';
 
 /**
  * A type, possibly wrapped in zero-or-more size, offset, sentinel, or hidden prefix/suffix modifiers.
- * The wrapping is recursive: each modifier wraps another `NestedTypeNode<T>` until the inner `T` is reached.
+ * The wrapping is recursive: each modifier wraps another `nestedTypeNode<T>` until the inner `T` is reached.
  */
 export type NestedTypeNode<TType extends TypeNode> =
     | FixedSizeTypeNode<NestedTypeNode<TType>>

--- a/packages/spec-generators/package.json
+++ b/packages/spec-generators/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@codama/fragments": "workspace:*",
-        "@codama/spec": "1.6.0-rc.4"
+        "@codama/spec": "1.6.0-rc.6"
     },
     "devDependencies": {
         "@types/node": "^25",

--- a/packages/spec-generators/src/nodeTypes/fragments/typeExpr.ts
+++ b/packages/spec-generators/src/nodeTypes/fragments/typeExpr.ts
@@ -3,6 +3,8 @@ import type { TypeExpr } from '@codama/spec';
 
 export function getTypeExprFragment(expr: TypeExpr): Fragment {
     switch (expr.kind) {
+        case 'address':
+            return fragment`string`;
         case 'string':
             return getStringExprFragment(expr);
         case 'integer':

--- a/packages/spec-generators/src/nodes/fragments/nodeFunctionPositionalArguments.ts
+++ b/packages/spec-generators/src/nodes/fragments/nodeFunctionPositionalArguments.ts
@@ -61,8 +61,13 @@ function renderParamForAttribute(
     const override = config.attributes?.[attr.name];
     const paramName = paramIdentifier(attr, override);
     const baseTsType = renderParamTsType(attr, typeParameterAttribute, override);
-    const optionalMark = attr.optional ? '?' : '';
     const defaultClause = renderParamDefaultClause(override, typeParameterAttribute);
+    // `param?: T = default` is a syntax error; an initializer already
+    // makes the parameter callable without an argument. Emit `?` only
+    // when the spec marks the attribute optional AND the config supplies
+    // no default value.
+    const hasDefault = defaultClause.content !== '';
+    const optionalMark = attr.optional && !hasDefault ? '?' : '';
     return fragment`${paramName}${optionalMark}: ${baseTsType}${defaultClause}`;
 }
 

--- a/packages/spec-generators/src/nodes/fragments/typeExpr.ts
+++ b/packages/spec-generators/src/nodes/fragments/typeExpr.ts
@@ -15,6 +15,8 @@ const NODE_TYPES_PACKAGE = '@codama/node-types';
 
 export function getTypeExprFragment(expr: TypeExpr): Fragment {
     switch (expr.kind) {
+        case 'address':
+            return fragment`string`;
         case 'string':
             return getStringExprFragment(expr);
         case 'integer':

--- a/packages/spec-generators/src/shared/unions.ts
+++ b/packages/spec-generators/src/shared/unions.ts
@@ -1,15 +1,15 @@
 import type { NodeSpec, Spec, UnionSpec } from '@codama/spec';
 
 /**
- * Any union whose name starts with `Registered` is a category-registry
- * union (e.g. `RegisteredContextualValueNode`). Derived from the spec
+ * Any union whose name starts with `registered` is a category-registry
+ * union (e.g. `registeredContextualValueNode`). Derived from the spec
  * so future categories are picked up automatically.
  */
-const REGISTERED_CATEGORY_UNION_PREFIX = 'Registered';
+const REGISTERED_CATEGORY_UNION_PREFIX = 'registered';
 
 /**
  * Return the spec's per-category registry unions (those whose names
- * start with `Registered`), sorted alphabetically by name.
+ * start with `registered`), sorted alphabetically by name.
  */
 export function getRegisteredCategoryUnions(spec: Spec): readonly UnionSpec[] {
     return spec.categories

--- a/packages/spec-generators/src/visitorsCore/options.ts
+++ b/packages/spec-generators/src/visitorsCore/options.ts
@@ -20,20 +20,20 @@ export {
 /**
  * Map from a spec union name to the `@codama/nodes` plural-noun alias
  * the visitors should reference in `assertIsNode` /
- * `removeNullAndAssertIsNodeFilter` calls (e.g. `'TypeNode'` →
+ * `removeNullAndAssertIsNodeFilter` calls (e.g. `'typeNode'` →
  * `'TYPE_NODES'`). Unions absent from this map are expanded inline as
  * a literal kind array.
  */
 export const UNION_ALIAS_NAMES: ReadonlyMap<string, string> = new Map([
-    ['ContextualValueNode', 'CONTEXTUAL_VALUE_NODES'],
-    ['CountNode', 'COUNT_NODES'],
-    ['DiscriminatorNode', 'DISCRIMINATOR_NODES'],
-    ['EnumVariantTypeNode', 'ENUM_VARIANT_TYPE_NODES'],
-    ['InstructionInputValueNode', 'INSTRUCTION_INPUT_VALUE_NODES'],
-    ['LinkNode', 'LINK_NODES'],
-    ['PdaSeedNode', 'PDA_SEED_NODES'],
-    ['TypeNode', 'TYPE_NODES'],
-    ['ValueNode', 'VALUE_NODES'],
+    ['contextualValueNode', 'CONTEXTUAL_VALUE_NODES'],
+    ['countNode', 'COUNT_NODES'],
+    ['discriminatorNode', 'DISCRIMINATOR_NODES'],
+    ['enumVariantTypeNode', 'ENUM_VARIANT_TYPE_NODES'],
+    ['instructionInputValueNode', 'INSTRUCTION_INPUT_VALUE_NODES'],
+    ['linkNode', 'LINK_NODES'],
+    ['pdaSeedNode', 'PDA_SEED_NODES'],
+    ['typeNode', 'TYPE_NODES'],
+    ['valueNode', 'VALUE_NODES'],
 ]);
 
 /**

--- a/packages/spec-generators/test/nodeTypes/fragments/nodeRegistry.test.ts
+++ b/packages/spec-generators/test/nodeTypes/fragments/nodeRegistry.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 import { getNodeRegistryFragment } from '../../../src/nodeTypes/fragments/nodeRegistry';
 
-// The renderer derives the registered-union list from any `Registered*`
+// The renderer derives the registered-union list from any `registered*`
 // union in the spec. This helper plumbs a minimum but complete spec:
 // one stub node per registered category, each registered union
 // referencing that node, plus extra top-level nodes the caller can
@@ -24,13 +24,13 @@ function buildSpecWithAllRegisteredUnions(extraTopLevelNodes: readonly string[] 
             defineCategory('topLevel', {
                 nodes: [...stubKinds, ...extraTopLevelNodes].map(k => defineNode(k, { attributes: [] })),
                 unions: [
-                    defineUnion('RegisteredContextualValueNode', { members: ['someContextualValueNode'] }),
-                    defineUnion('RegisteredCountNode', { members: ['someCountNode'] }),
-                    defineUnion('RegisteredDiscriminatorNode', { members: ['someDiscriminatorNode'] }),
-                    defineUnion('RegisteredLinkNode', { members: ['someLinkNode'] }),
-                    defineUnion('RegisteredPdaSeedNode', { members: ['somePdaSeedNode'] }),
-                    defineUnion('RegisteredTypeNode', { members: ['someTypeNode'] }),
-                    defineUnion('RegisteredValueNode', { members: ['someValueNode'] }),
+                    defineUnion('registeredContextualValueNode', { members: ['someContextualValueNode'] }),
+                    defineUnion('registeredCountNode', { members: ['someCountNode'] }),
+                    defineUnion('registeredDiscriminatorNode', { members: ['someDiscriminatorNode'] }),
+                    defineUnion('registeredLinkNode', { members: ['someLinkNode'] }),
+                    defineUnion('registeredPdaSeedNode', { members: ['somePdaSeedNode'] }),
+                    defineUnion('registeredTypeNode', { members: ['someTypeNode'] }),
+                    defineUnion('registeredValueNode', { members: ['someValueNode'] }),
                 ],
             }),
         ],
@@ -55,20 +55,20 @@ describe('getNodeRegistryFragment', () => {
         expect(out).toContain('export type GetNodeFromKind<TKind extends NodeKind> = Extract<Node, { kind: TKind }>;');
     });
 
-    it('lists every RegisteredXxxNode union as a Node member', () => {
+    it('lists every registeredXxxNode union as a Node member', () => {
         const result = getNodeRegistryFragment(buildSpecWithAllRegisteredUnions());
         const imports = [...result.imports.keys()].sort();
-        expect(imports).toContain('union:RegisteredContextualValueNode');
-        expect(imports).toContain('union:RegisteredCountNode');
-        expect(imports).toContain('union:RegisteredDiscriminatorNode');
-        expect(imports).toContain('union:RegisteredLinkNode');
-        expect(imports).toContain('union:RegisteredPdaSeedNode');
-        expect(imports).toContain('union:RegisteredTypeNode');
-        expect(imports).toContain('union:RegisteredValueNode');
+        expect(imports).toContain('union:registeredContextualValueNode');
+        expect(imports).toContain('union:registeredCountNode');
+        expect(imports).toContain('union:registeredDiscriminatorNode');
+        expect(imports).toContain('union:registeredLinkNode');
+        expect(imports).toContain('union:registeredPdaSeedNode');
+        expect(imports).toContain('union:registeredTypeNode');
+        expect(imports).toContain('union:registeredValueNode');
     });
 
     it('lists non-registered nodes as direct Node members', () => {
-        // `accountNode` and `rootNode` aren't inside any RegisteredXxxNode
+        // `accountNode` and `rootNode` aren't inside any registeredXxxNode
         // union, so they should appear as direct members of `Node`.
         const result = getNodeRegistryFragment(buildSpecWithAllRegisteredUnions(['accountNode', 'rootNode']));
         const imports = [...result.imports.keys()];
@@ -76,8 +76,8 @@ describe('getNodeRegistryFragment', () => {
         expect(imports).toContain('node:rootNode');
     });
 
-    it('omits nodes that are reachable through a RegisteredXxxNode union from direct membership', () => {
-        // `someTypeNode` is covered by `RegisteredTypeNode`; it must not
+    it('omits nodes that are reachable through a registeredXxxNode union from direct membership', () => {
+        // `someTypeNode` is covered by `registeredTypeNode`; it must not
         // appear as a direct member of `Node`.
         const result = getNodeRegistryFragment(buildSpecWithAllRegisteredUnions());
         const imports = [...result.imports.keys()];
@@ -85,7 +85,7 @@ describe('getNodeRegistryFragment', () => {
     });
 
     it('walks nested unions and excludes any node reachable through them from direct membership', () => {
-        // Nest a sub-union inside `RegisteredTypeNode`. The sub-union's
+        // Nest a sub-union inside `registeredTypeNode`. The sub-union's
         // members must still be considered "covered" and excluded from
         // direct `Node` membership.
         const spec: Spec = {
@@ -101,15 +101,15 @@ describe('getNodeRegistryFragment', () => {
                         defineNode('deeplyNestedTypeNode', { attributes: [] }),
                     ],
                     unions: [
-                        defineUnion('RegisteredContextualValueNode', { members: ['someContextualValueNode'] }),
-                        defineUnion('RegisteredCountNode', { members: ['someCountNode'] }),
-                        defineUnion('RegisteredDiscriminatorNode', { members: ['someDiscriminatorNode'] }),
-                        defineUnion('RegisteredLinkNode', { members: ['someLinkNode'] }),
-                        defineUnion('RegisteredPdaSeedNode', { members: ['somePdaSeedNode'] }),
-                        defineUnion('RegisteredValueNode', { members: ['someValueNode'] }),
-                        defineUnion('InnerTypeNode', { members: ['deeplyNestedTypeNode'] }),
-                        defineUnion('RegisteredTypeNode', {
-                            members: [{ kind: 'union', name: 'InnerTypeNode' }],
+                        defineUnion('registeredContextualValueNode', { members: ['someContextualValueNode'] }),
+                        defineUnion('registeredCountNode', { members: ['someCountNode'] }),
+                        defineUnion('registeredDiscriminatorNode', { members: ['someDiscriminatorNode'] }),
+                        defineUnion('registeredLinkNode', { members: ['someLinkNode'] }),
+                        defineUnion('registeredPdaSeedNode', { members: ['somePdaSeedNode'] }),
+                        defineUnion('registeredValueNode', { members: ['someValueNode'] }),
+                        defineUnion('innerTypeNode', { members: ['deeplyNestedTypeNode'] }),
+                        defineUnion('registeredTypeNode', {
+                            members: [{ kind: 'union', name: 'innerTypeNode' }],
                         }),
                     ],
                 }),
@@ -123,23 +123,23 @@ describe('getNodeRegistryFragment', () => {
         expect(imports).not.toContain('node:deeplyNestedTypeNode');
     });
 
-    it('only emits the RegisteredXxxNode unions present in the spec', () => {
+    it('only emits the registeredXxxNode unions present in the spec', () => {
         // The registry is derived from `spec` — unions whose names start
-        // with `Registered`. If the spec ships only some of them, the
+        // with `registered`. If the spec ships only some of them, the
         // renderer emits exactly those and quietly omits the rest.
         const spec: Spec = {
             categories: [
                 defineCategory('topLevel', {
                     nodes: [defineNode('someContextualValueNode', { attributes: [] })],
-                    unions: [defineUnion('RegisteredContextualValueNode', { members: ['someContextualValueNode'] })],
+                    unions: [defineUnion('registeredContextualValueNode', { members: ['someContextualValueNode'] })],
                 }),
             ],
             version: '1.0.0',
         };
         const result = getNodeRegistryFragment(spec);
         const imports = [...result.imports.keys()];
-        expect(imports).toContain('union:RegisteredContextualValueNode');
-        expect(imports).not.toContain('union:RegisteredCountNode');
+        expect(imports).toContain('union:registeredContextualValueNode');
+        expect(imports).not.toContain('union:registeredCountNode');
     });
 
     it('sorts the Node members alphabetically for stable output', () => {

--- a/packages/spec-generators/test/nodeTypes/fragments/typeExpr.test.ts
+++ b/packages/spec-generators/test/nodeTypes/fragments/typeExpr.test.ts
@@ -1,4 +1,5 @@
 import {
+    address,
     array,
     boolean,
     codamaVersion,
@@ -21,6 +22,12 @@ import { getTypeExprFragment, getTypeExprWithSelfAliasFragment } from '../../../
 describe('getTypeExprFragment', () => {
     it('renders plain string', () => {
         expect(getTypeExprFragment(string()).content).toBe('string');
+    });
+
+    it('renders address as plain string for v1 (no brand, no import)', () => {
+        const result = getTypeExprFragment(address());
+        expect(result.content).toBe('string');
+        expect(result.imports.size).toBe(0);
     });
 
     it('renders integer as number', () => {

--- a/packages/spec-generators/test/nodes/fragments/typeExpr.test.ts
+++ b/packages/spec-generators/test/nodes/fragments/typeExpr.test.ts
@@ -1,4 +1,5 @@
 import {
+    address,
     array,
     boolean,
     codamaVersion,
@@ -22,6 +23,12 @@ import { getTypeExprFragment } from '../../../src/nodes/fragments/typeExpr';
 describe('getTypeExprFragment', () => {
     it('renders plain string', () => {
         expect(getTypeExprFragment(string()).content).toBe('string');
+    });
+
+    it('renders address as plain string for v1 (no import)', () => {
+        const result = getTypeExprFragment(address());
+        expect(result.content).toBe('string');
+        expect(result.imports.size).toBe(0);
     });
 
     it('renders integer as number', () => {

--- a/packages/spec-generators/test/shared/unions.test.ts
+++ b/packages/spec-generators/test/shared/unions.test.ts
@@ -5,26 +5,26 @@ import { describe, expect, it } from 'vitest';
 import { flattenNodeUnion, getRegisteredCategoryUnions } from '../../src/shared';
 
 describe('getRegisteredCategoryUnions', () => {
-    it('returns only unions whose names start with `Registered`, sorted', () => {
+    it('returns only unions whose names start with `registered`, sorted', () => {
         const spec: Spec = {
             categories: [
                 defineCategory('type', {
                     nodes: [defineNode('aNode', { attributes: [] })],
                     unions: [
-                        defineUnion('TypeNode', { members: ['aNode'] }),
-                        defineUnion('RegisteredTypeNode', { members: ['aNode'] }),
+                        defineUnion('typeNode', { members: ['aNode'] }),
+                        defineUnion('registeredTypeNode', { members: ['aNode'] }),
                     ],
                 }),
                 defineCategory('value', {
                     nodes: [defineNode('bNode', { attributes: [] })],
-                    unions: [defineUnion('RegisteredValueNode', { members: ['bNode'] })],
+                    unions: [defineUnion('registeredValueNode', { members: ['bNode'] })],
                 }),
             ],
             version: '1.0.0',
         };
         expect(getRegisteredCategoryUnions(spec).map(u => u.name)).toEqual([
-            'RegisteredTypeNode',
-            'RegisteredValueNode',
+            'registeredTypeNode',
+            'registeredValueNode',
         ]);
     });
 
@@ -33,7 +33,7 @@ describe('getRegisteredCategoryUnions', () => {
             categories: [
                 defineCategory('type', {
                     nodes: [defineNode('aNode', { attributes: [] })],
-                    unions: [defineUnion('TypeNode', { members: ['aNode'] })],
+                    unions: [defineUnion('typeNode', { members: ['aNode'] })],
                 }),
             ],
             version: '1.0.0',
@@ -46,13 +46,13 @@ describe('getRegisteredCategoryUnions', () => {
             categories: [
                 defineCategory('type', {
                     nodes: [defineNode('aNode', { attributes: [] })],
-                    unions: [defineUnion('RegisteredTypeNode', { members: ['aNode'] })],
+                    unions: [defineUnion('registeredTypeNode', { members: ['aNode'] })],
                 }),
             ],
             version: '1.0.0',
         };
         const [first] = getRegisteredCategoryUnions(spec);
-        expect(first.name).toBe('RegisteredTypeNode');
+        expect(first.name).toBe('registeredTypeNode');
         expect(first.members).toEqual([{ kind: 'node', name: 'aNode' }]);
     });
 });

--- a/packages/spec-generators/test/visitorsCore/fragments/unionConstant.test.ts
+++ b/packages/spec-generators/test/visitorsCore/fragments/unionConstant.test.ts
@@ -11,11 +11,11 @@ const spec: Spec = {
             nodes: [defineNode('aNode', { attributes: [] }), defineNode('bNode', { attributes: [] })],
             unions: [
                 // Resolves to a known alias.
-                defineUnion('TypeNode', { members: ['aNode'] }),
+                defineUnion('typeNode', { members: ['aNode'] }),
                 // No alias — gets inlined as a literal.
-                defineUnion('AbleNode', { members: ['aNode', 'bNode'] }),
+                defineUnion('ableNode', { members: ['aNode', 'bNode'] }),
                 // Composite: one nested union with alias plus extra leaf nodes.
-                defineUnion('AbleOrTypeNode', { members: [union('TypeNode'), 'bNode'] }),
+                defineUnion('ableOrTypeNode', { members: [union('typeNode'), 'bNode'] }),
             ],
         }),
     ],
@@ -26,24 +26,24 @@ const options = { unionAliasNames: UNION_ALIAS_NAMES };
 
 describe('getUnionKindListFragment', () => {
     it('resolves a known union name to its plural-noun alias constant', () => {
-        const result = getUnionKindListFragment('TypeNode', spec, options);
+        const result = getUnionKindListFragment('typeNode', spec, options);
         expect(result.content).toBe('TYPE_NODES');
         expect([...result.imports.keys()]).toContain('@codama/nodes');
     });
 
     it('inlines an unknown union as a literal kind array', () => {
-        const result = getUnionKindListFragment('AbleNode', spec, options);
+        const result = getUnionKindListFragment('ableNode', spec, options);
         expect(result.content).toBe(`['aNode', 'bNode']`);
     });
 
     it('mixes alias spreads and inline kinds for a composite union', () => {
-        const result = getUnionKindListFragment('AbleOrTypeNode', spec, options);
+        const result = getUnionKindListFragment('ableOrTypeNode', spec, options);
         expect(result.content).toBe(`[...TYPE_NODES, 'bNode']`);
     });
 
     it('throws when the union name is not declared in the spec', () => {
-        expect(() => getUnionKindListFragment('GhostNode', spec, options)).toThrow(
-            /union "GhostNode" referenced from a child attribute is not declared in the spec/,
+        expect(() => getUnionKindListFragment('ghostNode', spec, options)).toThrow(
+            /union "ghostNode" referenced from a child attribute is not declared in the spec/,
         );
     });
 
@@ -53,15 +53,15 @@ describe('getUnionKindListFragment', () => {
                 defineCategory('topLevel', {
                     nodes: [defineNode('aNode', { attributes: [] })],
                     unions: [
-                        defineUnion('LeafNode', { members: ['aNode'] }),
-                        defineUnion('OuterNode', { members: [union('LeafNode'), node('aNode')] }),
+                        defineUnion('leafNode', { members: ['aNode'] }),
+                        defineUnion('outerNode', { members: [union('leafNode'), node('aNode')] }),
                     ],
                 }),
             ],
             version: '1.0.0',
         };
-        expect(() => getUnionKindListFragment('OuterNode', composedWithoutAlias, options)).toThrow(
-            /OuterNode" contains a nested union "LeafNode" with no entry in unionAliasNames/,
+        expect(() => getUnionKindListFragment('outerNode', composedWithoutAlias, options)).toThrow(
+            /outerNode" contains a nested union "leafNode" with no entry in unionAliasNames/,
         );
     });
 });

--- a/packages/spec-generators/test/visitorsCore/generate.test.ts
+++ b/packages/spec-generators/test/visitorsCore/generate.test.ts
@@ -11,10 +11,10 @@ const spec: Spec = {
         defineCategory('topLevel', {
             nodes: [
                 defineNode('wrappingTypeNode', {
-                    attributes: [attribute('payload', union('TypeNode'))],
+                    attributes: [attribute('payload', union('typeNode'))],
                 }),
             ],
-            unions: [defineUnion('TypeNode', { members: ['wrappingTypeNode'] })],
+            unions: [defineUnion('typeNode', { members: ['wrappingTypeNode'] })],
         }),
     ],
     version: '1.0.0',

--- a/packages/spec-generators/test/visitorsCore/scope.test.ts
+++ b/packages/spec-generators/test/visitorsCore/scope.test.ts
@@ -31,15 +31,15 @@ describe('buildRenderScope', () => {
         const scope = buildRenderScope(options);
         // The defaulted maps carry the live v1 spec content; assert
         // a representative key from each rather than the full set.
-        expect(scope.unionAliasNames.get('TypeNode')).toBe('TYPE_NODES');
+        expect(scope.unionAliasNames.get('typeNode')).toBe('TYPE_NODES');
         expect(scope.mergeVisitorWalkOrder.get('arrayTypeNode')).toEqual(['count', 'item']);
         expect(scope.identityVisitorWalkOrder.get('programNode')?.[0]).toBe('accounts');
     });
 
     it('honours caller-supplied unionAliasNames overrides', () => {
-        const custom = new Map([['TypeNode', 'CUSTOM_TYPE_NODES']]);
+        const custom = new Map([['typeNode', 'CUSTOM_TYPE_NODES']]);
         const scope = buildRenderScope({ ...options, unionAliasNames: custom });
-        expect(scope.unionAliasNames.get('TypeNode')).toBe('CUSTOM_TYPE_NODES');
+        expect(scope.unionAliasNames.get('typeNode')).toBe('CUSTOM_TYPE_NODES');
     });
 
     it('emits a frozen scope', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,8 +316,8 @@ importers:
         specifier: workspace:*
         version: link:../fragments
       '@codama/spec':
-        specifier: 1.6.0-rc.4
-        version: 1.6.0-rc.4
+        specifier: 1.6.0-rc.6
+        version: 1.6.0-rc.6
     devDependencies:
       '@types/node':
         specifier: ^25
@@ -607,8 +607,9 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@codama/spec@1.6.0-rc.4':
-    resolution: {integrity: sha512-jLTwjgu46MSd3lfuQL9g6SaTcpamlsd975u2GT7BPoXN1mpezY5NvGFMQh467IpnuddOm6NGnLV2M3GUpq0MmQ==}
+  '@codama/spec@1.6.0-rc.6':
+    resolution: {integrity: sha512-5MmIkIBkYFBawkTHqY2NbGV0jOS4uDLeIbfsAP5laXMlEsPXjoI2Uzyp6OdxRN9cfthE+GEXN64ObaY7FrPQ5A==}
+    engines: {node: '>=22.12.0'}
 
   '@esbuild/aix-ppc64@0.27.0':
     resolution: {integrity: sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==}
@@ -4829,7 +4830,7 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@codama/spec@1.6.0-rc.4': {}
+  '@codama/spec@1.6.0-rc.6': {}
 
   '@esbuild/aix-ppc64@0.27.0':
     optional: true
@@ -6943,14 +6944,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.0(@types/node@25.0.3)(yaml@2.8.2)
 
-  '@vitest/mocker@4.0.16(vite@7.3.0(@types/node@25.5.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.0.16
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.0(@types/node@25.5.0)(yaml@2.8.2)
-
   '@vitest/pretty-format@4.0.16':
     dependencies:
       tinyrainbow: 3.0.3
@@ -8997,7 +8990,7 @@ snapshots:
   vitest@4.0.16(@types/node@25.5.0)(happy-dom@20.5.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.5.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16


### PR DESCRIPTION
Pulls in the camelCase rename of every spec union and enumeration name, the new `{ kind: 'address' }` `TypeExpr` (rendered as plain `string` on the v1 TS surface), and the rc.6 revert of the rc.5 vec-of-children optional flips — leaving `programNode`, `rootNode`, `instructionNode`, `pdaNode`, and `pdaValueNode`'s child arrays required as they were in rc.4. The generator picks up the new `address` kind in both `nodeTypes` and `nodes` `typeExpr` fragments, switches the `registered*` prefix and `UNION_ALIAS_NAMES` keys to camelCase to match the new spec naming, and gains a small constructor-signature fix to avoid emitting invalid `param?: T = default` TypeScript whenever an attribute that's both optional and supplied with a default appears (no such attribute exists in v1 today, but the bug would have surfaced the moment one did). The regenerated `@codama/node-types` surface differs from rc.4 by a single docstring paragraph on `NestedTypeNode` — the spec's nested-union alias name is now camelCase. Test fixtures across the generator's suite are updated to mirror the new convention; runtime behaviour and the public TS API are unchanged.