### PR TITLE
Pin blake3 to 1.8.2 in anchor test Cargo.lock to avoid edition2024 build failure

### DIFF
--- a/packages/dynamic-client/test/programs/anchor/Cargo.lock
+++ b/packages/dynamic-client/test/programs/anchor/Cargo.lock
@@ -337,16 +337,15 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -558,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cpufeatures"


### PR DESCRIPTION
This PR fixes the `@codama/dynamic-client#test` build failure that started hitting `main` after PR #994 was merged.

## Root cause (revised)

[The failing CI run](https://github.com/codama-idl/codama/actions/runs/26819996074/job/79071755084):

```
@codama/dynamic-client:test: error: failed to parse manifest at `.../blake3-1.8.3/Cargo.toml`
Caused by:
  feature `edition2024` is required
  The package requires the Cargo feature called `edition2024`, but that feature
  is not stabilized in this version of Cargo (1.84.0 (12fe57a9d 2025-04-07)).
```

`blake3 1.8.3` was published recently and switched its manifest to Rust edition 2024 (stabilized in 1.85). `anchor build` (invoked by `dynamic-client`'s `test:setup`) shells out to `cargo-build-sbf`, which uses the **Anchor 0.32.1 / Solana platform-tools bundled Cargo at 1.84.0** — not the host Cargo (1.93.0) installed by the workflow's `dtolnay/rust-toolchain` step, and not anything controlled by the agave CLI release pinned via `SOLANA_VERSION`. The bundled Cargo can't parse blake3 1.8.3's manifest, so the build fails during dependency resolution, well before any SBF compilation begins.

The merge of #994 didn't cause the breakage; it just retriggered CI on a fresh runner that re-resolved `blake3` to the new version. Any push around this time would have hit the same wall.

## Earlier (no-op) attempt

[An earlier attempt in this PR's history](https://github.com/codama-idl/codama/pull/1003) bumped `SOLANA_VERSION` from 3.1.8 to 3.1.14, on the theory that the agave CLI controls the bundled toolchain. It does not — the platform-tools Rust/Cargo are pinned by Anchor's installed SBF toolchain, independent of the agave CLI version. That bump has been reverted; this PR ships only the lockfile pin.

## Fix

`cargo update -p blake3 --precise 1.8.2` inside `packages/dynamic-client/test/programs/anchor/`. `blake3 1.8.2` is the last edition-2021 release (verified via crates.io) and satisfies `solana-blake3-hasher`'s `^1` requirement.

Three entries in `Cargo.lock` move:

- `blake3 1.8.3 → 1.8.2` (version + checksum + drops `cpufeatures` dep that 1.8.3 added).
- `constant_time_eq 0.4.2 → 0.3.1` (reconciled to match what `blake3 1.8.2` wants).

No manifests change. The pin stays local to `Cargo.lock`; a future deliberate `cargo update` (unqualified) can move blake3 forward whenever the platform-tools bundled Cargo catches up to edition 2024. CI doesn't run blanket `cargo update`, so the lock stays put.

## Verification

CI is the verification gate. Locally we don't have the Solana platform-tools toolchain to reproduce the `anchor build` invocation.

Marked draft so you can review before merging.