### PR TITLE
Bump @codama/spec to 1.6.0

### DIFF
--- a/packages/spec-generators/package.json
+++ b/packages/spec-generators/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@codama/fragments": "workspace:*",
-        "@codama/spec": "1.6.0-rc.6"
+        "@codama/spec": "1.6.0"
     },
     "devDependencies": {
         "@types/node": "^25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,8 +316,8 @@ importers:
         specifier: workspace:*
         version: link:../fragments
       '@codama/spec':
-        specifier: 1.6.0-rc.6
-        version: 1.6.0-rc.6
+        specifier: 1.6.0
+        version: 1.6.0
     devDependencies:
       '@types/node':
         specifier: ^25
@@ -607,8 +607,8 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@codama/spec@1.6.0-rc.6':
-    resolution: {integrity: sha512-5MmIkIBkYFBawkTHqY2NbGV0jOS4uDLeIbfsAP5laXMlEsPXjoI2Uzyp6OdxRN9cfthE+GEXN64ObaY7FrPQ5A==}
+  '@codama/spec@1.6.0':
+    resolution: {integrity: sha512-/lgvuwVUBc6wgBrdajDIV4Hazlx6BcuuqCkoTnm/SPUaDJKTXzuIBe/+Sd5Rd03TJxDORGW1ywZgju9Da4PPdg==}
     engines: {node: '>=22.12.0'}
 
   '@esbuild/aix-ppc64@0.27.0':
@@ -4830,7 +4830,7 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@codama/spec@1.6.0-rc.6': {}
+  '@codama/spec@1.6.0': {}
 
   '@esbuild/aix-ppc64@0.27.0':
     optional: true


### PR DESCRIPTION
This PR bumps the `@codama/spec` dependency in `@codama-internal/spec-generators` from `1.6.0-rc.6` to `1.6.0` now that the first stable release is live on npm. Regenerated artifacts via `pnpm --filter @codama-internal/spec-generators generate` are byte-identical — the spec content is unchanged from rc.6, only the version label moved. All gates pass locally: spec-generators lint + 289 tests, top-level `pnpm build` (17 tasks), `pnpm test` (34 tasks), and `pnpm lint` (17 tasks).