### PR TITLE
fix(cli): allow convert command to work without package.json

### DIFF
--- a/.changeset/fix-convert-package-json.md
+++ b/.changeset/fix-convert-package-json.md
@@ -1,0 +1,5 @@
+---
+"@codama/cli": patch
+---
+
+Allow convert command to work without package.json

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     },
     "dependencies": {
         "@codama/nodes": "workspace:*",
+        "@codama/nodes-from-anchor": "workspace:*",
         "@codama/visitors": "workspace:*",
         "@codama/visitors-core": "workspace:*",
         "commander": "^14.0.2",

--- a/packages/cli/src/utils/nodes.ts
+++ b/packages/cli/src/utils/nodes.ts
@@ -12,6 +12,17 @@ export async function getRootNodeFromIdl(idl: unknown): Promise<RootNode> {
         return idl;
     }
 
+    // Try direct import first — works without a package.json.
+    try {
+        const rootNodeFromAnchor = await importModuleItem<(idl: unknown) => RootNode>({
+            from: '@codama/nodes-from-anchor',
+            item: 'rootNodeFromAnchor',
+        });
+        return rootNodeFromAnchor(idl);
+    } catch {
+        // Module not available via direct import.
+    }
+
     const hasNodesFromAnchor = await installMissingDependencies(
         'Anchor IDL detected. Additional dependencies are required to process Anchor IDLs.',
         ['@codama/nodes-from-anchor'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@codama/nodes':
         specifier: workspace:*
         version: link:../nodes
+      '@codama/nodes-from-anchor':
+        specifier: workspace:*
+        version: link:../nodes-from-anchor
       '@codama/visitors':
         specifier: workspace:*
         version: link:../visitors


### PR DESCRIPTION
- Add @codama/nodes-from-anchor as a dependency of @codama/cli
- Try direct import before falling back to the install flow

This lets users run codama convert without needing a package.json.