### PR TITLE
feat(dynamic-parsers): fallback to identify data for single node kind without discriminator

### DIFF
--- a/.changeset/frank-pans-exist.md
+++ b/.changeset/frank-pans-exist.md
@@ -1,0 +1,7 @@
+---
+'@codama/dynamic-parsers': patch
+---
+
+Decode single-instruction programs that omit a discriminator in `parseInstructionData` / `parseInstruction`
+
+`parseInstructionData` now falls back to decoding the single instruction directly when discriminator-based identification finds nothing and the program declares exactly one instruction with no discriminator (e.g. Memo program).

--- a/.changeset/frank-pans-exist.md
+++ b/.changeset/frank-pans-exist.md
@@ -2,6 +2,6 @@
 '@codama/dynamic-parsers': patch
 ---
 
-Decode single-instruction programs that omit a discriminator in `parseInstructionData` / `parseInstruction`
+Identify and decode nodes that omit a discriminator.
 
-`parseInstructionData` now falls back to decoding the single instruction directly when discriminator-based identification finds nothing and the program declares exactly one instruction with no discriminator (e.g. Memo program).
+When discriminator-based identification finds no match, `identifyData` (and the `identify*` / `parse*` helpers) now fall back to a Node without discriminator but only when the requested kinds resolve to exactly one candidate Node and that Node has no discriminator. Two or more Nodes without discriminator return `undefined`.

--- a/packages/dynamic-parsers/src/identify.ts
+++ b/packages/dynamic-parsers/src/identify.ts
@@ -5,6 +5,7 @@ import {
     GetNodeFromKind,
     InstructionNode,
     isNodeFilter,
+    ProgramNode,
     resolveNestedTypeNode,
     RootNode,
     structTypeNodeFromInstructionArgumentNodes,
@@ -21,6 +22,8 @@ import {
 } from '@codama/visitors-core';
 
 import { matchDiscriminators } from './discriminators';
+
+type IdentifiableNodeKind = 'accountNode' | 'eventNode' | 'instructionNode';
 
 export function identifyAccountData(
     root: RootNode,
@@ -43,27 +46,31 @@ export function identifyInstructionData(
     return identifyData(root, bytes, 'instructionNode');
 }
 
-export function identifyData<TKind extends 'accountNode' | 'eventNode' | 'instructionNode'>(
+export function identifyData<TKind extends IdentifiableNodeKind>(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
     kind?: TKind | TKind[],
 ): NodePath<GetNodeFromKind<TKind>> | undefined {
+    const kinds = kind ?? (['accountNode', 'instructionNode', 'eventNode'] as TKind[]);
+
     const stack = new NodeStack();
     const linkables = new LinkableDictionary();
     visit(root, getRecordLinkablesVisitor(linkables));
 
     const codecAndValueVisitors = getCodecAndValueVisitors(linkables, { stack });
-    const visitor = getByteIdentificationVisitor(
-        kind ?? (['accountNode', 'instructionNode', 'eventNode'] as TKind[]),
-        bytes,
-        codecAndValueVisitors,
-        { stack },
-    );
+    const visitor = getByteIdentificationVisitor(kinds, bytes, codecAndValueVisitors, { stack });
 
-    return visit(root, visitor);
+    const identified = visit(root, visitor);
+    if (identified) return identified;
+
+    // Fallback: When Node of given kind doesn't have a discriminator and is single then we can identify it.
+    // Example: `Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH` program with single instruction omits a discriminator.
+    const candidates = getNodeCandidates(root.program, kinds);
+    if (candidates.length !== 1 || candidates[0].discriminators?.length) return undefined;
+    return [root, root.program, candidates[0]] as unknown as NodePath<GetNodeFromKind<TKind>>;
 }
 
-export function getByteIdentificationVisitor<TKind extends 'accountNode' | 'eventNode' | 'instructionNode'>(
+export function getByteIdentificationVisitor<TKind extends IdentifiableNodeKind>(
     kind: TKind | TKind[],
     bytes: ReadonlyUint8Array | Uint8Array,
     codecAndValueVisitors: CodecAndValueVisitors,
@@ -96,8 +103,7 @@ export function getByteIdentificationVisitor<TKind extends 'accountNode' | 'even
                 return match ? stack.getPath(node.kind) : undefined;
             },
             visitProgram(node) {
-                const candidates = [...node.accounts, ...node.events, ...node.instructions].filter(isNodeFilter(kind));
-                for (const candidate of candidates) {
+                for (const candidate of getNodeCandidates(node, kind)) {
                     const result = visit(candidate, this);
                     if (result) return result;
                 }
@@ -111,4 +117,11 @@ export function getByteIdentificationVisitor<TKind extends 'accountNode' | 'even
         >,
         v => recordNodeStackVisitor(v, stack),
     );
+}
+
+function getNodeCandidates(
+    program: ProgramNode,
+    kind: IdentifiableNodeKind | IdentifiableNodeKind[],
+): (AccountNode | EventNode | InstructionNode)[] {
+    return [...program.accounts, ...program.events, ...program.instructions].filter(isNodeFilter(kind));
 }

--- a/packages/dynamic-parsers/src/parsers.ts
+++ b/packages/dynamic-parsers/src/parsers.ts
@@ -37,7 +37,19 @@ export function parseInstructionData(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
 ): ParsedData<InstructionNode> | undefined {
-    return parseData(root, bytes, 'instructionNode');
+    const parsed = parseData(root, bytes, 'instructionNode');
+    if (parsed) return parsed;
+
+    // Single-instruction programs may omit a discriminator (e.g. Memo program).
+    // parseData returns undefined due to being unable to identify it by discriminator
+    // Decode it directly.
+    const [singleIx, ...rest] = root.program.instructions;
+    if (singleIx && rest.length === 0 && !singleIx.discriminators?.length) {
+        const path = [root, root.program, singleIx] as NodePath<InstructionNode>;
+        return { data: getNodeCodec(path).decode(bytes), path };
+    }
+
+    return undefined;
 }
 
 export function parseData<TKind extends ParsableNodeKind>(

--- a/packages/dynamic-parsers/src/parsers.ts
+++ b/packages/dynamic-parsers/src/parsers.ts
@@ -40,7 +40,7 @@ export function parseInstructionData(
     const parsed = parseData(root, bytes, 'instructionNode');
     if (parsed) return parsed;
 
-    // Single-instruction programs may omit a discriminator (e.g. Memo program).
+    // Single-instruction programs may omit a discriminator (e.g. `Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH`).
     // parseData returns undefined due to being unable to identify it by discriminator
     // Decode it directly.
     const [singleIx, ...rest] = root.program.instructions;

--- a/packages/dynamic-parsers/src/parsers.ts
+++ b/packages/dynamic-parsers/src/parsers.ts
@@ -37,19 +37,7 @@ export function parseInstructionData(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
 ): ParsedData<InstructionNode> | undefined {
-    const parsed = parseData(root, bytes, 'instructionNode');
-    if (parsed) return parsed;
-
-    // Single-instruction programs may omit a discriminator (e.g. `Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH`).
-    // parseData returns undefined due to being unable to identify it by discriminator
-    // Decode it directly.
-    const [singleIx, ...rest] = root.program.instructions;
-    if (singleIx && rest.length === 0 && !singleIx.discriminators?.length) {
-        const path = [root, root.program, singleIx] as NodePath<InstructionNode>;
-        return { data: getNodeCodec(path).decode(bytes), path };
-    }
-
-    return undefined;
+    return parseData(root, bytes, 'instructionNode');
 }
 
 export function parseData<TKind extends ParsableNodeKind>(

--- a/packages/dynamic-parsers/test/identify.test.ts
+++ b/packages/dynamic-parsers/test/identify.test.ts
@@ -17,7 +17,7 @@ import {
 } from '@codama/nodes';
 import { describe, expect, test } from 'vitest';
 
-import { identifyAccountData, identifyEventData, identifyInstructionData } from '../src';
+import { identifyAccountData, identifyData, identifyEventData, identifyInstructionData } from '../src';
 import { hex } from './_setup';
 
 describe('identifyAccountData', () => {
@@ -43,12 +43,15 @@ describe('identifyAccountData', () => {
         const result = identifyAccountData(root, hex('01020304'));
         expect(result).toBeUndefined();
     });
-    test('it fails to identify accounts with no discriminator nodes', () => {
+    test('it identifies a single account without discriminators as a fallback', () => {
+        // Given a program with exactly one account that has no discriminator nodes.
         const root = rootNode(
             programNode({ accounts: [accountNode({ name: 'myAccount' })], name: 'myProgram', publicKey: '1111' }),
         );
+        // When we identify account data that matches no discriminator.
         const result = identifyAccountData(root, hex('01020304'));
-        expect(result).toBeUndefined();
+        // Then we expect the sole non-discriminated account to be identified as the fallback.
+        expect(result).toStrictEqual([root, root.program, root.program.accounts[0]]);
     });
     test('it identifies the first matching account if multiple accounts match', () => {
         const root = rootNode(
@@ -119,7 +122,8 @@ describe('identifyInstructionData', () => {
         const result = identifyInstructionData(root, hex('01020304'));
         expect(result).toBeUndefined();
     });
-    test('it fails to identify instructions with no discriminator nodes', () => {
+    test('it identifies a single instruction without discriminator as a fallback', () => {
+        // Given a program with exactly one instruction that has no discriminator nodes.
         const root = rootNode(
             programNode({
                 instructions: [instructionNode({ name: 'myInstruction' })],
@@ -127,8 +131,10 @@ describe('identifyInstructionData', () => {
                 publicKey: '1111',
             }),
         );
+        // When we identify instruction data that matches no discriminator.
         const result = identifyInstructionData(root, hex('01020304'));
-        expect(result).toBeUndefined();
+        // Then we expect the single instruction to be identified as the fallback.
+        expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
     });
     test('it identifies the first matching instruction if multiple instructions match', () => {
         const root = rootNode(
@@ -172,6 +178,57 @@ describe('identifyInstructionData', () => {
         const result = identifyInstructionData(root, hex('01020304'));
         expect(result).toBeUndefined();
     });
+
+    test('it does not identify via fallback when an instruction with discriminator also exists', () => {
+        // Given a program with instruction with discriminator and instruction without discriminator.
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'withDiscriminator' }),
+                    instructionNode({ name: 'withoutDiscriminator' }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+        // When we identify bytes that match no discriminator (length 5, not 4).
+        const result = identifyInstructionData(root, hex('0102030405'));
+        // Then we expect no result because more than one instruction candidate exists.
+        expect(result).toBeUndefined();
+    });
+
+    test('it prefers a discriminator match over a fallback', () => {
+        // Given a program with a instruction with discriminator and without.
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'withDiscriminator' }),
+                    instructionNode({ name: 'withoutDiscriminator' }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+        // When we identify bytes that match the discriminator (length 4).
+        const result = identifyInstructionData(root, hex('01020304'));
+        // Then we expect the discriminated instruction, not the fallback.
+        expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
+    });
+
+    test('it does not identify via fallback more than one instructions without discriminator', () => {
+        // Given a program with two instructions that have no discriminator.
+        const root = rootNode(
+            programNode({
+                instructions: [instructionNode({ name: 'instructionA' }), instructionNode({ name: 'instructionB' })],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+        // When we identify instruction data that matches no discriminator.
+        const result = identifyInstructionData(root, hex('48656c6c6f'));
+        // Then we expect no result because the fallback is ambiguous.
+        expect(result).toBeUndefined();
+    });
 });
 
 describe('identifyEventData', () => {
@@ -209,7 +266,8 @@ describe('identifyEventData', () => {
         const result = identifyEventData(root, hex('01020304'));
         expect(result).toBeUndefined();
     });
-    test('it fails to identify events with no discriminator nodes', () => {
+    test('it identifies a single event without discriminators as a fallback', () => {
+        // Given a program with exactly one event that has no discriminator nodes.
         const root = rootNode(
             programNode({
                 events: [eventNode({ data: structTypeNode([]), name: 'myEvent' })],
@@ -217,8 +275,10 @@ describe('identifyEventData', () => {
                 publicKey: '1111',
             }),
         );
+        // When we identify event data that matches no discriminator.
         const result = identifyEventData(root, hex('01020304'));
-        expect(result).toBeUndefined();
+        // Then we expect the single event to be identified as the fallback.
+        expect(result).toStrictEqual([root, root.program, root.program.events[0]]);
     });
     test('it does not identify events using instruction discriminators', () => {
         const root = rootNode(
@@ -259,5 +319,39 @@ describe('identifyEventData', () => {
         );
         const result = identifyEventData(root, hex('01022a000000'));
         expect(result).toStrictEqual([root, root.program, root.program.events[0]]);
+    });
+});
+
+describe('identifyData', () => {
+    test('it identifies via fallback single node without discriminator', () => {
+        // Given a program with one account without discriminator.
+        const root = rootNode(
+            programNode({
+                accounts: [accountNode({ name: 'myAccount' })],
+                instructions: [instructionNode({ name: 'myInstruction' })],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+        // When we identify only account node kind.
+        const result = identifyData(root, hex('01020304'), 'accountNode');
+        // Then we expect the single account to be identified as the fallback.
+        expect(result).toStrictEqual([root, root.program, root.program.accounts[0]]);
+    });
+
+    test('it does not identify via fallback when trying to identify multiple node kinds without discriminator', () => {
+        // Given a program with account and instruction without discriminators.
+        const root = rootNode(
+            programNode({
+                accounts: [accountNode({ name: 'accountWithoutDiscriminator' })],
+                instructions: [instructionNode({ name: 'instructionWithoutDiscriminator' })],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+        // When we identify with the default (all) kinds and no discriminator matches.
+        const result = identifyData(root, hex('01020304'));
+        // Then we expect no result because two candidates are ambiguous.
+        expect(result).toBeUndefined();
     });
 });

--- a/packages/dynamic-parsers/test/parsers.test.ts
+++ b/packages/dynamic-parsers/test/parsers.test.ts
@@ -24,7 +24,7 @@ import {
 import { AccountRole } from '@solana/instructions';
 import { describe, expect, test } from 'vitest';
 
-import { parseAccountData, parseEventData, parseInstruction, parseInstructionData } from '../src';
+import { parseAccountData, parseData, parseEventData, parseInstruction, parseInstructionData } from '../src';
 import { hex } from './_setup';
 
 describe('parseAccountData', () => {
@@ -59,6 +59,29 @@ describe('parseAccountData', () => {
         const result = parseAccountData(root, hex('090500416c6963652a'));
         expect(result).toStrictEqual({
             data: { age: 42, discriminator: 9, firstname: 'Alice' },
+            path: [root, root.program, root.program.accounts[0]],
+        });
+    });
+
+    test('it decodes a single account without discriminator', () => {
+        // Given a program with exactly one account without discriminator.
+        const root = rootNode(
+            programNode({
+                accounts: [
+                    accountNode({
+                        data: structTypeNode([structFieldTypeNode({ name: 'value', type: numberTypeNode('u32') })]),
+                        name: 'myAccount',
+                    }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+        // When we parse account data that matches no discriminator.
+        const result = parseAccountData(root, hex('2a000000'));
+        // Then we expect the single account to be decoded via the fallback.
+        expect(result).toStrictEqual({
+            data: { value: 42 },
             path: [root, root.program, root.program.accounts[0]],
         });
     });
@@ -179,6 +202,37 @@ describe('parseInstructionData', () => {
         // Then we expect no result.
         expect(result).toBeUndefined();
     });
+
+    test('it does not decode via fallback when an instruction with discriminator also exists', () => {
+        // Given a program with instruction with discriminator and instruction without discriminator.
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({
+                        arguments: [
+                            instructionArgumentNode({
+                                defaultValue: numberValueNode(9),
+                                name: 'discriminator',
+                                type: numberTypeNode('u8'),
+                            }),
+                        ],
+                        discriminators: [fieldDiscriminatorNode('discriminator')],
+                        name: 'instructionWithDiscriminator',
+                    }),
+                    instructionNode({
+                        arguments: [instructionArgumentNode({ name: 'message', type: stringTypeNode('utf8') })],
+                        name: 'instructionWithoutDiscriminator',
+                    }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+        // When we parse bytes whose leading byte (0x48) does not match the discriminator default (9).
+        const result = parseInstructionData(root, hex('48656c6c6f'));
+        // Then we expect no result because more than one instruction candidate exists.
+        expect(result).toBeUndefined();
+    });
 });
 
 describe('parseEventData', () => {
@@ -248,6 +302,29 @@ describe('parseEventData', () => {
             path: [root, root.program, root.program.events[0]],
         });
     });
+
+    test('it decodes a single event without discriminator', () => {
+        // Given a program with exactly one non-discriminated event.
+        const root = rootNode(
+            programNode({
+                events: [
+                    eventNode({
+                        data: structTypeNode([structFieldTypeNode({ name: 'value', type: numberTypeNode('u32') })]),
+                        name: 'myEvent',
+                    }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+        // When we parse event data that matches no discriminator.
+        const result = parseEventData(root, hex('2a000000'));
+        // Then we expect the event to be decoded via the fallback.
+        expect(result).toStrictEqual({
+            data: { value: 42 },
+            path: [root, root.program, root.program.events[0]],
+        });
+    });
 });
 
 describe('parseInstruction', () => {
@@ -283,5 +360,62 @@ describe('parseInstruction', () => {
             data: { message: 'Hello' },
             path: [root, root.program, root.program.instructions[0]],
         });
+    });
+});
+
+describe('parseData', () => {
+    test('it decodes via fallback a single node without discriminator', () => {
+        // Given a program with one account without discriminator.
+        const root = rootNode(
+            programNode({
+                accounts: [
+                    accountNode({
+                        data: structTypeNode([structFieldTypeNode({ name: 'value', type: numberTypeNode('u32') })]),
+                        name: 'myAccount',
+                    }),
+                ],
+                instructions: [
+                    instructionNode({
+                        arguments: [instructionArgumentNode({ name: 'message', type: stringTypeNode('utf8') })],
+                        name: 'myInstruction',
+                    }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+        // When we parse only the account node kind and no discriminator matches.
+        const result = parseData(root, hex('2a000000'), 'accountNode');
+        // Then we expect the single account to be decoded via the fallback.
+        expect(result).toStrictEqual({
+            data: { value: 42 },
+            path: [root, root.program, root.program.accounts[0]],
+        });
+    });
+
+    test('it does not decode via fallback when trying to parse multiple node kinds without discriminator', () => {
+        // Given a program with account and instruction without discriminators.
+        const root = rootNode(
+            programNode({
+                accounts: [
+                    accountNode({
+                        data: structTypeNode([structFieldTypeNode({ name: 'value', type: numberTypeNode('u32') })]),
+                        name: 'accountWithoutDiscriminator',
+                    }),
+                ],
+                instructions: [
+                    instructionNode({
+                        arguments: [instructionArgumentNode({ name: 'message', type: stringTypeNode('utf8') })],
+                        name: 'instructionWithoutDiscriminator',
+                    }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+        // When we parse with the default (all) kinds and no discriminator matches.
+        const result = parseData(root, hex('2a000000'));
+        // Then we expect no result because two candidates are ambiguous.
+        expect(result).toBeUndefined();
     });
 });

--- a/packages/dynamic-parsers/test/parsers.test.ts
+++ b/packages/dynamic-parsers/test/parsers.test.ts
@@ -8,6 +8,7 @@ import {
     fieldDiscriminatorNode,
     fixedSizeTypeNode,
     hiddenPrefixTypeNode,
+    instructionAccountNode,
     instructionArgumentNode,
     instructionNode,
     numberTypeNode,
@@ -20,9 +21,10 @@ import {
     structTypeNode,
     tupleTypeNode,
 } from '@codama/nodes';
+import { AccountRole } from '@solana/instructions';
 import { describe, expect, test } from 'vitest';
 
-import { parseAccountData, parseEventData, parseInstructionData } from '../src';
+import { parseAccountData, parseEventData, parseInstruction, parseInstructionData } from '../src';
 import { hex } from './_setup';
 
 describe('parseAccountData', () => {
@@ -97,6 +99,86 @@ describe('parseInstructionData', () => {
             path: [root, root.program, root.program.instructions[0]],
         });
     });
+
+    test('it decodes a single instruction without discriminator', () => {
+        // Given a program with exactly one instruction that has no discriminator (Memo-shaped).
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({
+                        arguments: [instructionArgumentNode({ name: 'message', type: stringTypeNode('utf8') })],
+                        name: 'memo',
+                    }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+
+        // When we parse instruction data that has no discriminator selector ("Hello" as UTF-8).
+        const result = parseInstructionData(root, hex('48656c6c6f'));
+
+        // Then we expect instruction to be decoded.
+        expect(result).toStrictEqual({
+            data: { message: 'Hello' },
+            path: [root, root.program, root.program.instructions[0]],
+        });
+    });
+
+    test('it does not fall back to direct decode when the program has more than one instruction', () => {
+        // Given a program with two instructions without discriminator.
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({
+                        arguments: [instructionArgumentNode({ name: 'message', type: stringTypeNode('utf8') })],
+                        name: 'instructionA',
+                    }),
+                    instructionNode({
+                        arguments: [instructionArgumentNode({ name: 'message', type: stringTypeNode('utf8') })],
+                        name: 'instructionB',
+                    }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+
+        // When we parse instruction data that matches no discriminator.
+        const result = parseInstructionData(root, hex('48656c6c6f'));
+
+        // Then we expect no result.
+        expect(result).toBeUndefined();
+    });
+
+    test('it returns undefined for a single instruction with a discriminator that does not match', () => {
+        // Given a program with one instruction that declares a discriminator field.
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({
+                        arguments: [
+                            instructionArgumentNode({
+                                defaultValue: numberValueNode(42),
+                                name: 'discriminator',
+                                type: numberTypeNode('u8'),
+                            }),
+                        ],
+                        discriminators: [fieldDiscriminatorNode('discriminator')],
+                        name: 'myInstruction',
+                    }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+
+        // When we parse bytes whose leading byte (0x07) does not match the discriminator default (42).
+        const result = parseInstructionData(root, hex('07'));
+
+        // Then we expect no result.
+        expect(result).toBeUndefined();
+    });
 });
 
 describe('parseEventData', () => {
@@ -164,6 +246,42 @@ describe('parseEventData', () => {
         expect(result).toStrictEqual({
             data: [42],
             path: [root, root.program, root.program.events[0]],
+        });
+    });
+});
+
+describe('parseInstruction', () => {
+    test('it parses a single instruction without discriminator', () => {
+        // Given a Memo-shaped program: one instruction without discriminator with a single signer account.
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({
+                        accounts: [instructionAccountNode({ isSigner: true, isWritable: false, name: 'signer' })],
+                        arguments: [instructionArgumentNode({ name: 'message', type: stringTypeNode('utf8') })],
+                        name: 'memo',
+                    }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+
+        // And a concrete instruction carrying "Hello" as UTF-8 data and one account meta.
+        const instruction = {
+            accounts: [{ address: '1111', role: AccountRole.READONLY_SIGNER }],
+            data: hex('48656c6c6f'),
+            programAddress: 'myProgramAddress',
+        } as unknown as Parameters<typeof parseInstruction>[1];
+
+        // When we parse the instruction.
+        const result = parseInstruction(root, instruction);
+
+        // Then we expect the decoded data, the instruction path, and the account meta with its node name.
+        expect(result).toStrictEqual({
+            accounts: [{ address: '1111', name: 'signer', role: AccountRole.READONLY_SIGNER }],
+            data: { message: 'Hello' },
+            path: [root, root.program, root.program.instructions[0]],
         });
     });
 });


### PR DESCRIPTION
## Summary

`parseInstruction` / `parseInstructionData` returns `undefined` for single-instruction programs that declare no discriminator, e.g. [SPL Memo v4](https://explorer.solana.com/address/Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH/idl) `Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH`. Its instruction data is just a UTF-8 string without instruction selector.

Current ix identification is discriminator-based, so parsing fails when discriminator doesn't exist.

## What changed

- Updated `identifyData` to fall back fallback to identify data for single node kind without discriminator.
- Added tests.