### PR TITLE
feat(dynamic-address-resolution): refactor pda-seed-value visitor

### DIFF
--- a/.changeset/icy-zebras-fly.md
+++ b/.changeset/icy-zebras-fly.md
@@ -1,0 +1,6 @@
+---
+'@codama/dynamic-address-resolution': patch
+---
+
+Refactor internals of pda-seed-value visitor.
+Extract the constant-seed part of `createPdaSeedValueVisitor` into a standalone visitor. The pda-seed-value visitor now extends the constant-pda-seed with variable-seed handling (visitAccountValue / visitArgumentValue) on top. `resolveStandalonePda` method was simplified.

--- a/packages/dynamic-address-resolution/src/resolvers/resolve-constant-pda-seed-value.ts
+++ b/packages/dynamic-address-resolution/src/resolvers/resolve-constant-pda-seed-value.ts
@@ -1,0 +1,20 @@
+import type { ReadonlyUint8Array } from '@solana/codecs';
+import type { ProgramIdValueNode, ValueNode } from 'codama';
+import { visitOrElse } from 'codama';
+
+import {
+    type ConstantPdaSeedValueVisitorContext,
+    createConstantPdaSeedValueVisitor,
+    unexpectedConstantPdaSeedNodeFallback,
+} from '../visitors';
+
+/**
+ * Resolves a constant PDA seed value to raw bytes. Facade over `createConstantPdaSeedValueVisitor`.
+ */
+export async function resolveConstantPdaSeedValue(
+    node: ProgramIdValueNode | ValueNode,
+    ctx: ConstantPdaSeedValueVisitorContext,
+): Promise<ReadonlyUint8Array> {
+    const visitor = createConstantPdaSeedValueVisitor(ctx);
+    return await visitOrElse(node, visitor, unexpectedConstantPdaSeedNodeFallback);
+}

--- a/packages/dynamic-address-resolution/src/resolvers/resolve-standalone-pda.ts
+++ b/packages/dynamic-address-resolution/src/resolvers/resolve-standalone-pda.ts
@@ -9,25 +9,14 @@ import {
 import type { Address, ProgramDerivedAddress } from '@solana/addresses';
 import { getProgramDerivedAddress } from '@solana/addresses';
 import type { ReadonlyUint8Array } from '@solana/codecs';
-import type { InstructionNode, PdaNode, RegisteredPdaSeedNode, RootNode, VariablePdaSeedNode } from 'codama';
-import { camelCase, isNode, visitOrElse } from 'codama';
+import type { PdaNode, RegisteredPdaSeedNode, RootNode, VariablePdaSeedNode } from 'codama';
+import { camelCase, isNode } from 'codama';
 
 import { toAddress } from '../shared/address';
 import { getMemoizedUtf8Encoder } from '../shared/codecs';
 import { formatValueType, getMaybeNodeKind } from '../shared/util';
 import { createCodecInputTransformer } from '../visitors/codec-input-transformer';
-import { createPdaSeedValueVisitor, PDA_SEED_VALUE_SUPPORTED_NODE_KINDS } from '../visitors/pda-seed-value';
-
-/**
- * Minimal InstructionNode stub to satisfy constant PDA seeds requirements.
- * Constant seeds only use programIdValue / publicKeyValue / bytesValue / stringValue, none of which reference instruction arguments or accounts
- */
-const STANDALONE_IX_NODE: InstructionNode = {
-    accounts: [],
-    arguments: [],
-    kind: 'instructionNode',
-    name: '__standalone__' as InstructionNode['name'],
-};
+import { resolveConstantPdaSeedValue } from './resolve-constant-pda-seed-value';
 
 /**
  * Derives a PDA from a standalone `PdaNode` and user-supplied seed values,
@@ -42,7 +31,7 @@ export async function resolveStandalonePda(
     const seedValues = await Promise.all(
         pdaNode.seeds.map(async (seedNode): Promise<ReadonlyUint8Array> => {
             if (seedNode.kind === 'constantPdaSeedNode') {
-                return await resolveStandaloneConstantSeed(root, programAddress, seedNode);
+                return await resolveStandaloneConstantSeed(programAddress, seedNode);
             }
             if (seedNode.kind === 'variablePdaSeedNode') {
                 return await resolveStandaloneVariableSeed(root, seedNode, seedInputs);
@@ -57,7 +46,6 @@ export async function resolveStandalonePda(
 }
 
 function resolveStandaloneConstantSeed(
-    root: RootNode,
     programAddress: Address,
     seedNode: RegisteredPdaSeedNode,
 ): Promise<ReadonlyUint8Array> {
@@ -68,22 +56,7 @@ function resolveStandaloneConstantSeed(
             node: seedNode,
         });
     }
-    const visitor = createPdaSeedValueVisitor({
-        accountsInput: undefined,
-        argumentsInput: undefined,
-        ixNode: STANDALONE_IX_NODE,
-        programId: programAddress,
-        resolutionPath: [],
-        resolversInput: undefined,
-        root,
-    });
-    return visitOrElse(seedNode.value, visitor, node => {
-        throw new CodamaError(CODAMA_ERROR__UNEXPECTED_NODE_KIND, {
-            expectedKinds: Array.from(PDA_SEED_VALUE_SUPPORTED_NODE_KINDS),
-            kind: node.kind,
-            node,
-        });
-    });
+    return resolveConstantPdaSeedValue(seedNode.value, { programId: programAddress });
 }
 
 function resolveStandaloneVariableSeed(

--- a/packages/dynamic-address-resolution/src/visitors/index.ts
+++ b/packages/dynamic-address-resolution/src/visitors/index.ts
@@ -1,6 +1,14 @@
 export { createAccountDefaultValueVisitor } from './account-default-value';
 export { createConditionNodeValueVisitor } from './condition-node-value';
 export { createDefaultValueEncoderVisitor, DEFAULT_VALUE_ENCODER_SUPPORTED_NODE_KINDS } from './default-value-encoder';
-export { createPdaSeedValueVisitor, PDA_SEED_VALUE_SUPPORTED_NODE_KINDS } from './pda-seed-value';
+export {
+    createPdaSeedValueVisitor,
+    createConstantPdaSeedValueVisitor,
+    unexpectedConstantPdaSeedNodeFallback,
+    PDA_SEED_VALUE_SUPPORTED_NODE_KINDS,
+    CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS,
+    type ConstantPdaSeedValueVisitorContext,
+    type PdaSeedValueVisitorContext,
+} from './pda-seed-value';
 export { createValueNodeVisitor } from './value-node-value';
 export { createCodecInputTransformer, createCodecInputTransformerVisitor } from './codec-input-transformer';

--- a/packages/dynamic-address-resolution/src/visitors/pda-seed-value.ts
+++ b/packages/dynamic-address-resolution/src/visitors/pda-seed-value.ts
@@ -58,10 +58,12 @@ type PdaSeedValueSupportedNodeKind = (typeof PDA_SEED_VALUE_SUPPORTED_NODE_KINDS
 
 export type ConstantPdaSeedValueVisitorContext = {
     programId: Address;
-    seedTypeNode?: TypeNode;
 };
 
-export type PdaSeedValueVisitorContext = BaseResolutionContext & ConstantPdaSeedValueVisitorContext;
+export type PdaSeedValueVisitorContext = BaseResolutionContext &
+    ConstantPdaSeedValueVisitorContext & {
+        seedTypeNode?: TypeNode;
+    };
 
 /**
  * Visitor for resolving PdaSeedValueNode value to raw bytes.
@@ -77,7 +79,7 @@ export function createPdaSeedValueVisitor(
     const accountsInput = ctx.accountsInput ?? {};
     const argumentsInput = ctx.argumentsInput ?? {};
 
-    const base = createConstantPdaSeedValueVisitor({ programId, seedTypeNode });
+    const base = createConstantPdaSeedValueVisitor({ programId });
 
     const visitor: Visitor<Promise<ReadonlyUint8Array>, PdaSeedValueSupportedNodeKind> = extendVisitor(base, {
         visitAccountValue: async (node: AccountValueNode) => {

--- a/packages/dynamic-address-resolution/src/visitors/pda-seed-value.ts
+++ b/packages/dynamic-address-resolution/src/visitors/pda-seed-value.ts
@@ -9,22 +9,25 @@ import {
 } from '@codama/errors';
 import type { Address } from '@solana/addresses';
 import type { ReadonlyUint8Array } from '@solana/codecs';
-import type {
-    AccountValueNode,
-    ArgumentValueNode,
-    BooleanValueNode,
-    BytesValueNode,
+import {
+    type AccountValueNode,
+    type ArgumentValueNode,
+    type BooleanValueNode,
+    type BytesValueNode,
     ConstantValueNode,
+    extendVisitor,
+    isNode,
+    Node,
     NoneValueNode,
     NumberValueNode,
-    ProgramIdValueNode,
-    PublicKeyValueNode,
-    SomeValueNode,
-    StringValueNode,
-    TypeNode,
-    Visitor,
+    type ProgramIdValueNode,
+    type PublicKeyValueNode,
+    type SomeValueNode,
+    type StringValueNode,
+    type TypeNode,
+    type Visitor,
+    visitOrElse,
 } from 'codama';
-import { isNode, visitOrElse } from 'codama';
 
 import { resolveAccountValueNodeAddress } from '../resolvers/resolve-account-value-node-address';
 import type { BaseResolutionContext } from '../resolvers/types';
@@ -33,9 +36,7 @@ import { getCodecFromBytesEncoding } from '../shared/bytes-encoding';
 import { getMemoizedAddressEncoder, getMemoizedBooleanEncoder, getMemoizedUtf8Codec } from '../shared/codecs';
 import { createCodecInputTransformer } from './codec-input-transformer';
 
-export const PDA_SEED_VALUE_SUPPORTED_NODE_KINDS = [
-    'accountValueNode',
-    'argumentValueNode',
+export const CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS = [
     'booleanValueNode',
     'bytesValueNode',
     'constantValueNode',
@@ -47,12 +48,20 @@ export const PDA_SEED_VALUE_SUPPORTED_NODE_KINDS = [
     'stringValueNode',
 ] as const;
 
+export const PDA_SEED_VALUE_SUPPORTED_NODE_KINDS = [
+    ...CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS,
+    'accountValueNode',
+    'argumentValueNode',
+] as const;
+
 type PdaSeedValueSupportedNodeKind = (typeof PDA_SEED_VALUE_SUPPORTED_NODE_KINDS)[number];
 
-type PdaSeedValueVisitorContext = BaseResolutionContext & {
+export type ConstantPdaSeedValueVisitorContext = {
     programId: Address;
     seedTypeNode?: TypeNode;
 };
+
+export type PdaSeedValueVisitorContext = BaseResolutionContext & ConstantPdaSeedValueVisitorContext;
 
 /**
  * Visitor for resolving PdaSeedValueNode value to raw bytes.
@@ -68,7 +77,9 @@ export function createPdaSeedValueVisitor(
     const accountsInput = ctx.accountsInput ?? {};
     const argumentsInput = ctx.argumentsInput ?? {};
 
-    return {
+    const base = createConstantPdaSeedValueVisitor({ programId, seedTypeNode });
+
+    const visitor: Visitor<Promise<ReadonlyUint8Array>, PdaSeedValueSupportedNodeKind> = extendVisitor(base, {
         visitAccountValue: async (node: AccountValueNode) => {
             const resolvedAddress = await resolveAccountValueNodeAddress(node, {
                 accountsInput,
@@ -121,6 +132,44 @@ export function createPdaSeedValueVisitor(
             return await Promise.resolve(codec.encode(transformedInput));
         },
 
+        // Override base recursion so wrapped account/argument values reach the extended handlers.
+        visitConstantValue: async node => await visitOrElse(node.value, visitor, unexpectedPdaSeedNodeFallback),
+
+        visitSomeValue: async node => await visitOrElse(node.value, visitor, unexpectedPdaSeedNodeFallback),
+    });
+
+    return visitor;
+}
+
+export const unexpectedPdaSeedNodeFallback = (node: Node): never => {
+    throw new CodamaError(CODAMA_ERROR__UNEXPECTED_NODE_KIND, {
+        expectedKinds: [...PDA_SEED_VALUE_SUPPORTED_NODE_KINDS],
+        kind: node.kind,
+        node,
+    });
+};
+
+/**
+ * Base PDA seed value visitor that handles constant seed kinds only
+ * (boolean / bytes / constant / none / number / programId / publicKey / some / string).
+ * The account/argument handlers throw by default and are meant to be extended if needed (e.g. for variable seeds).
+ */
+export function createConstantPdaSeedValueVisitor(
+    ctx: ConstantPdaSeedValueVisitorContext,
+): Visitor<Promise<ReadonlyUint8Array>, PdaSeedValueSupportedNodeKind> {
+    const { programId } = ctx;
+
+    const visitor: Visitor<Promise<ReadonlyUint8Array>, PdaSeedValueSupportedNodeKind> = {
+        // Throws error by default since constant seeds should not depend on accounts.
+        visitAccountValue: async (node: AccountValueNode) => {
+            return await Promise.resolve(unexpectedConstantPdaSeedNodeFallback(node));
+        },
+
+        // Throws error by default since constant seeds should not depend on arguments.
+        visitArgumentValue: async (node: ArgumentValueNode) => {
+            return await Promise.resolve(unexpectedConstantPdaSeedNodeFallback(node));
+        },
+
         visitBooleanValue: async (node: BooleanValueNode) =>
             await Promise.resolve(getMemoizedBooleanEncoder().encode(node.boolean)),
 
@@ -130,14 +179,7 @@ export function createPdaSeedValueVisitor(
         },
 
         visitConstantValue: async (node: ConstantValueNode) => {
-            const innerVisitor = createPdaSeedValueVisitor(ctx);
-            return await visitOrElse(node.value, innerVisitor, innerNode => {
-                throw new CodamaError(CODAMA_ERROR__UNEXPECTED_NODE_KIND, {
-                    expectedKinds: [...PDA_SEED_VALUE_SUPPORTED_NODE_KINDS],
-                    kind: innerNode.kind,
-                    node: innerNode,
-                });
-            });
+            return await visitOrElse(node.value, visitor, unexpectedConstantPdaSeedNodeFallback);
         },
 
         visitNoneValue: async (_node: NoneValueNode) => await Promise.resolve(new Uint8Array(0)),
@@ -161,17 +203,20 @@ export function createPdaSeedValueVisitor(
         },
 
         visitSomeValue: async (node: SomeValueNode) => {
-            const innerVisitor = createPdaSeedValueVisitor(ctx);
-            return await visitOrElse(node.value, innerVisitor, innerNode => {
-                throw new CodamaError(CODAMA_ERROR__UNEXPECTED_NODE_KIND, {
-                    expectedKinds: [...PDA_SEED_VALUE_SUPPORTED_NODE_KINDS],
-                    kind: innerNode.kind,
-                    node: innerNode,
-                });
-            });
+            return await visitOrElse(node.value, visitor, unexpectedConstantPdaSeedNodeFallback);
         },
 
         visitStringValue: async (node: StringValueNode) =>
             await Promise.resolve(getMemoizedUtf8Codec().encode(node.string)),
     };
+
+    return visitor;
 }
+
+export const unexpectedConstantPdaSeedNodeFallback = (node: Node) => {
+    throw new CodamaError(CODAMA_ERROR__UNEXPECTED_NODE_KIND, {
+        expectedKinds: [...CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS],
+        kind: node.kind,
+        node,
+    });
+};

--- a/packages/dynamic-address-resolution/test/resolvers/resolve-constant-pda-seed-value.test.ts
+++ b/packages/dynamic-address-resolution/test/resolvers/resolve-constant-pda-seed-value.test.ts
@@ -1,0 +1,65 @@
+import { address, getAddressEncoder } from '@solana/addresses';
+import { getUtf8Codec } from '@solana/codecs';
+import {
+    constantValueNode,
+    mapValueNode,
+    noneValueNode,
+    numberValueNode,
+    programIdValueNode,
+    programNode,
+    rootNode,
+    someValueNode,
+    stringTypeNode,
+    stringValueNode,
+} from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { resolveConstantPdaSeedValue } from '../../src/resolvers/resolve-constant-pda-seed-value';
+import { CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS } from '../../src/visitors';
+
+const PROGRAM_PUBLIC_KEY = '11111111111111111111111111111111';
+const ctx = {
+    programId: address(PROGRAM_PUBLIC_KEY),
+    root: rootNode(programNode({ name: 'test', publicKey: PROGRAM_PUBLIC_KEY })),
+};
+
+describe('resolveConstantPdaSeedValue', () => {
+    test('should dispatch to the correct visitor method (stringValueNode)', async () => {
+        const result = await resolveConstantPdaSeedValue(stringValueNode('hello'), ctx);
+        expect(result).toEqual(getUtf8Codec().encode('hello'));
+    });
+
+    test('should dispatch programIdValueNode and encode ctx programId', async () => {
+        const result = await resolveConstantPdaSeedValue(programIdValueNode(), ctx);
+        expect(result).toEqual(getAddressEncoder().encode(ctx.programId));
+    });
+
+    test('should dispatch numberValueNode as a u8 byte', async () => {
+        const result = await resolveConstantPdaSeedValue(numberValueNode(42), ctx);
+        expect(result).toEqual(new Uint8Array([42]));
+    });
+
+    test('should dispatch someValueNode and recurse into the wrapped value', async () => {
+        const result = await resolveConstantPdaSeedValue(someValueNode(stringValueNode('hi')), ctx);
+        expect(result).toEqual(getUtf8Codec().encode('hi'));
+    });
+
+    test('should dispatch constantValueNode and recurse into the wrapped value', async () => {
+        const result = await resolveConstantPdaSeedValue(
+            constantValueNode(stringTypeNode('utf8'), stringValueNode('hi')),
+            ctx,
+        );
+        expect(result).toEqual(getUtf8Codec().encode('hi'));
+    });
+
+    test('should dispatch noneValueNode as zero bytes', async () => {
+        const result = await resolveConstantPdaSeedValue(noneValueNode(), ctx);
+        expect(result).toEqual(new Uint8Array(0));
+    });
+
+    test('should throw UNEXPECTED_NODE_KIND for unsupported value node kind', async () => {
+        await expect(resolveConstantPdaSeedValue(mapValueNode([]), ctx)).rejects.toThrow(
+            `Expected node of kind [${CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS.join(',')}], got [mapValueNode]`,
+        );
+    });
+});

--- a/packages/dynamic-address-resolution/test/resolvers/resolve-standalone-pda.test.ts
+++ b/packages/dynamic-address-resolution/test/resolvers/resolve-standalone-pda.test.ts
@@ -1,0 +1,119 @@
+import { address, getAddressEncoder, getProgramDerivedAddress } from '@solana/addresses';
+import { getU32Encoder, getUtf8Codec } from '@solana/codecs';
+import {
+    constantPdaSeedNode,
+    mapValueNode,
+    numberTypeNode,
+    numberValueNode,
+    pdaNode,
+    programIdValueNode,
+    programNode,
+    publicKeyTypeNode,
+    publicKeyValueNode,
+    remainderOptionTypeNode,
+    rootNode,
+    stringTypeNode,
+    stringValueNode,
+    variablePdaSeedNode,
+} from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { resolveStandalonePda } from '../../src/resolvers/resolve-standalone-pda';
+import { generateAddress } from '../test-utils';
+
+const PROGRAM_ADDRESS = address('11111111111111111111111111111111');
+
+function makeRoot() {
+    return rootNode(programNode({ name: 'test', publicKey: PROGRAM_ADDRESS }));
+}
+
+describe('resolveStandalonePda', () => {
+    test('should derive PDA from mixed constant seeds', async () => {
+        const extraKey = await generateAddress();
+        const pda = pdaNode({
+            name: 'mixed',
+            seeds: [
+                constantPdaSeedNode(stringTypeNode('utf8'), stringValueNode('prefix')),
+                constantPdaSeedNode(publicKeyTypeNode(), programIdValueNode()),
+                constantPdaSeedNode(numberTypeNode('u8'), numberValueNode(7)),
+                constantPdaSeedNode(publicKeyTypeNode(), publicKeyValueNode(extraKey)),
+            ],
+        });
+
+        const expected = await getProgramDerivedAddress({
+            programAddress: PROGRAM_ADDRESS,
+            seeds: [
+                getUtf8Codec().encode('prefix'),
+                getAddressEncoder().encode(PROGRAM_ADDRESS),
+                new Uint8Array([7]),
+                getAddressEncoder().encode(extraKey),
+            ],
+        });
+
+        const result = await resolveStandalonePda(makeRoot(), pda);
+        expect(result).toEqual(expected);
+    });
+
+    test('should derive PDA from variable string seed', async () => {
+        const pda = pdaNode({
+            name: 'test',
+            seeds: [variablePdaSeedNode('label', stringTypeNode('utf8'))],
+        });
+
+        const expected = await getProgramDerivedAddress({
+            programAddress: PROGRAM_ADDRESS,
+            seeds: [getUtf8Codec().encode('hello')],
+        });
+
+        const result = await resolveStandalonePda(makeRoot(), pda, { label: 'hello' });
+        expect(result).toEqual(expected);
+    });
+
+    test('should derive PDA from variable number seed', async () => {
+        const pda = pdaNode({
+            name: 'test',
+            seeds: [variablePdaSeedNode('count', numberTypeNode('u32'))],
+        });
+
+        const expected = await getProgramDerivedAddress({
+            programAddress: PROGRAM_ADDRESS,
+            seeds: [getU32Encoder().encode(123_456)],
+        });
+
+        const result = await resolveStandalonePda(makeRoot(), pda, { count: 123_456 });
+        expect(result).toEqual(expected);
+    });
+
+    test('should encode optional remainderOptionTypeNode seed as zero bytes when input is missing', async () => {
+        const pda = pdaNode({
+            name: 'optional',
+            seeds: [variablePdaSeedNode('maybe', remainderOptionTypeNode(stringTypeNode('utf8')))],
+        });
+
+        const expected = await getProgramDerivedAddress({
+            programAddress: PROGRAM_ADDRESS,
+            seeds: [new Uint8Array(0)],
+        });
+
+        const result = await resolveStandalonePda(makeRoot(), pda);
+        expect(result).toEqual(expected);
+    });
+
+    test('should throw UNEXPECTED_NODE_KIND for unsupported constant seed value kind', async () => {
+        const pda = pdaNode({
+            name: 'bad',
+            seeds: [constantPdaSeedNode(numberTypeNode('u8'), mapValueNode([])) as never],
+        });
+
+        await expect(resolveStandalonePda(makeRoot(), pda)).rejects.toThrow(/mapValueNode/);
+    });
+
+    test('should throw ARGUMENT_MISSING when a required variable seed input is omitted', async () => {
+        const pda = pdaNode({
+            name: 'requiresInput',
+            seeds: [variablePdaSeedNode('owner', publicKeyTypeNode())],
+        });
+
+        await expect(resolveStandalonePda(makeRoot(), pda)).rejects.toThrow(/owner/);
+    });
+});

--- a/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/accountValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/accountValueNode.test.ts
@@ -1,0 +1,14 @@
+import { accountValueNode } from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS } from '../../../src/visitors/pda-seed-value';
+import { makeConstantVisitor } from './constant-pda-seed-value-test-utils';
+
+describe('constant-pda-seed-value: visitAccountValue', () => {
+    test('should throw UNEXPECTED_NODE_KIND — accounts are not resolvable in a constant context', async () => {
+        const visitor = makeConstantVisitor();
+        await expect(visitor.visitAccountValue(accountValueNode('anything'))).rejects.toThrow(
+            `Expected node of kind [${CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS.join(',')}], got [accountValueNode]`,
+        );
+    });
+});

--- a/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/argumentValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/argumentValueNode.test.ts
@@ -1,0 +1,14 @@
+import { argumentValueNode } from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS } from '../../../src/visitors/pda-seed-value';
+import { makeConstantVisitor } from './constant-pda-seed-value-test-utils';
+
+describe('constant-pda-seed-value: visitArgumentValue', () => {
+    test('should throw UNEXPECTED_NODE_KIND — arguments are not resolvable in a constant context', async () => {
+        const visitor = makeConstantVisitor();
+        await expect(visitor.visitArgumentValue(argumentValueNode('anything'))).rejects.toThrow(
+            `Expected node of kind [${CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS.join(',')}], got [argumentValueNode]`,
+        );
+    });
+});

--- a/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/booleanValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/booleanValueNode.test.ts
@@ -1,0 +1,17 @@
+import { getBooleanCodec } from '@solana/codecs';
+import { booleanValueNode } from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { makeConstantVisitor } from './constant-pda-seed-value-test-utils';
+
+describe('constant-pda-seed-value: visitBooleanValue', () => {
+    test('should encode true', async () => {
+        const result = await makeConstantVisitor().visitBooleanValue(booleanValueNode(true));
+        expect(result).toEqual(getBooleanCodec().encode(true));
+    });
+
+    test('should encode false', async () => {
+        const result = await makeConstantVisitor().visitBooleanValue(booleanValueNode(false));
+        expect(result).toEqual(getBooleanCodec().encode(false));
+    });
+});

--- a/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/bytesValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/bytesValueNode.test.ts
@@ -1,0 +1,26 @@
+import { getBase16Codec, getBase58Codec, getUtf8Codec } from '@solana/codecs';
+import { bytesValueNode } from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { generateAddress } from '../../test-utils';
+import { makeConstantVisitor } from './constant-pda-seed-value-test-utils';
+
+describe('constant-pda-seed-value: visitBytesValue', () => {
+    test('should encode base16 data', async () => {
+        const hex = '48656c6c6f';
+        const result = await makeConstantVisitor().visitBytesValue(bytesValueNode('base16', hex));
+        expect(result).toEqual(getBase16Codec().encode(hex));
+    });
+
+    test('should encode base58 data', async () => {
+        const b58 = await generateAddress();
+        const result = await makeConstantVisitor().visitBytesValue(bytesValueNode('base58', b58));
+        expect(result).toEqual(getBase58Codec().encode(b58));
+    });
+
+    test('should encode utf8 data', async () => {
+        const text = 'Hello';
+        const result = await makeConstantVisitor().visitBytesValue(bytesValueNode('utf8', text));
+        expect(result).toEqual(getUtf8Codec().encode(text));
+    });
+});

--- a/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/constant-pda-seed-value-test-utils.ts
+++ b/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/constant-pda-seed-value-test-utils.ts
@@ -1,0 +1,12 @@
+import { address } from '@solana/addresses';
+
+import { createConstantPdaSeedValueVisitor } from '../../../src/visitors/pda-seed-value';
+
+const PROGRAM_PUBLIC_KEY = '11111111111111111111111111111111';
+
+export function makeConstantVisitor(overrides?: Partial<Parameters<typeof createConstantPdaSeedValueVisitor>[0]>) {
+    return createConstantPdaSeedValueVisitor({
+        programId: address(PROGRAM_PUBLIC_KEY),
+        ...overrides,
+    });
+}

--- a/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/constantValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/constantValueNode.test.ts
@@ -1,0 +1,30 @@
+import { getUtf8Codec } from '@solana/codecs';
+import { constantValueNode, mapValueNode, numberTypeNode, stringTypeNode, stringValueNode } from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS } from '../../../src/visitors/pda-seed-value';
+import { makeConstantVisitor } from './constant-pda-seed-value-test-utils';
+
+describe('constant-pda-seed-value: visitConstantValue', () => {
+    test('should delegate to inner stringValueNode', async () => {
+        const node = constantValueNode(stringTypeNode('utf8'), stringValueNode('Hello world'));
+        const result = await makeConstantVisitor().visitConstantValue(node);
+        expect(result).toEqual(getUtf8Codec().encode('Hello world'));
+    });
+
+    test('should recurse through nested constantValueNodes', async () => {
+        const node = constantValueNode(
+            stringTypeNode('utf8'),
+            constantValueNode(stringTypeNode('utf8'), stringValueNode('Nested hello world')),
+        );
+        const result = await makeConstantVisitor().visitConstantValue(node);
+        expect(result).toEqual(getUtf8Codec().encode('Nested hello world'));
+    });
+
+    test('should throw for unsupported inner node kind via fallback', async () => {
+        const node = constantValueNode(numberTypeNode('u8'), mapValueNode([]));
+        await expect(makeConstantVisitor().visitConstantValue(node)).rejects.toThrow(
+            `Expected node of kind [${CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS.join(',')}], got [mapValueNode]`,
+        );
+    });
+});

--- a/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/noneValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/noneValueNode.test.ts
@@ -1,0 +1,11 @@
+import { noneValueNode } from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { makeConstantVisitor } from './constant-pda-seed-value-test-utils';
+
+describe('constant-pda-seed-value: visitNoneValue', () => {
+    test('should return empty Uint8Array', async () => {
+        const result = await makeConstantVisitor().visitNoneValue(noneValueNode());
+        expect(result).toEqual(new Uint8Array(0));
+    });
+});

--- a/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/numberValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/numberValueNode.test.ts
@@ -1,0 +1,15 @@
+import { numberValueNode } from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { makeConstantVisitor } from './constant-pda-seed-value-test-utils';
+
+describe('constant-pda-seed-value: visitNumberValue', () => {
+    test('should encode valid u8', async () => {
+        const result = await makeConstantVisitor().visitNumberValue(numberValueNode(1));
+        expect(result).toEqual(new Uint8Array([1]));
+    });
+
+    test('should throw for value out of u8 range', async () => {
+        await expect(makeConstantVisitor().visitNumberValue(numberValueNode(256))).rejects.toThrow(/out of range/);
+    });
+});

--- a/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/programIdValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/programIdValueNode.test.ts
@@ -1,0 +1,16 @@
+import { getAddressEncoder } from '@solana/addresses';
+import { programIdValueNode } from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { generateAddress } from '../../test-utils';
+import { makeConstantVisitor } from './constant-pda-seed-value-test-utils';
+
+describe('constant-pda-seed-value: visitProgramIdValue', () => {
+    test('should encode the context programId as 32-byte address', async () => {
+        const randomAddress = await generateAddress();
+        const result = await makeConstantVisitor({ programId: randomAddress }).visitProgramIdValue(
+            programIdValueNode(),
+        );
+        expect(result).toEqual(getAddressEncoder().encode(randomAddress));
+    });
+});

--- a/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/publicKeyValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/publicKeyValueNode.test.ts
@@ -1,0 +1,20 @@
+import { address, getAddressEncoder } from '@solana/addresses';
+import { publicKeyValueNode } from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { generateAddress } from '../../test-utils';
+import { makeConstantVisitor } from './constant-pda-seed-value-test-utils';
+
+describe('constant-pda-seed-value: visitPublicKeyValue', () => {
+    test('should encode the provided public key as 32-byte address', async () => {
+        const randomAddress = await generateAddress();
+        const result = await makeConstantVisitor().visitPublicKeyValue(publicKeyValueNode(randomAddress));
+        expect(result).toEqual(getAddressEncoder().encode(address(randomAddress)));
+    });
+
+    test('should throw for invalid public key', async () => {
+        await expect(makeConstantVisitor().visitPublicKeyValue(publicKeyValueNode('not-a-key'))).rejects.toThrow(
+            /Cannot convert value to Address/,
+        );
+    });
+});

--- a/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/someValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/someValueNode.test.ts
@@ -1,0 +1,20 @@
+import { mapValueNode, numberValueNode, someValueNode } from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS } from '../../../src/visitors/pda-seed-value';
+import { makeConstantVisitor } from './constant-pda-seed-value-test-utils';
+
+describe('constant-pda-seed-value: visitSomeValue', () => {
+    test('should delegate to inner numberValueNode', async () => {
+        const node = someValueNode(numberValueNode(42));
+        const result = await makeConstantVisitor().visitSomeValue(node);
+        expect(result).toEqual(new Uint8Array([42]));
+    });
+
+    test('should throw for unsupported inner node kind', async () => {
+        const node = someValueNode(mapValueNode([]));
+        await expect(makeConstantVisitor().visitSomeValue(node)).rejects.toThrow(
+            `Expected node of kind [${CONSTANT_PDA_SEED_VALUE_SUPPORTED_NODE_KINDS.join(',')}], got [mapValueNode]`,
+        );
+    });
+});

--- a/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/stringValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/constant-pda-seed-value/stringValueNode.test.ts
@@ -1,0 +1,17 @@
+import { getUtf8Codec } from '@solana/codecs';
+import { stringValueNode } from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { makeConstantVisitor } from './constant-pda-seed-value-test-utils';
+
+describe('constant-pda-seed-value: visitStringValue', () => {
+    test('should encode non-empty string as UTF-8 bytes', async () => {
+        const result = await makeConstantVisitor().visitStringValue(stringValueNode('hello'));
+        expect(result).toEqual(getUtf8Codec().encode('hello'));
+    });
+
+    test('should encode empty string as empty bytes', async () => {
+        const result = await makeConstantVisitor().visitStringValue(stringValueNode(''));
+        expect(result).toEqual(getUtf8Codec().encode(''));
+    });
+});

--- a/packages/dynamic-address-resolution/test/visitors/pda-seed-value/constantValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/pda-seed-value/constantValueNode.test.ts
@@ -1,5 +1,14 @@
 import { getUtf8Codec } from '@solana/codecs';
-import { constantValueNode, mapValueNode, numberTypeNode, stringTypeNode, stringValueNode } from 'codama';
+import {
+    argumentValueNode,
+    constantValueNode,
+    instructionArgumentNode,
+    instructionNode,
+    mapValueNode,
+    numberTypeNode,
+    stringTypeNode,
+    stringValueNode,
+} from 'codama';
 import { describe, expect, test } from 'vitest';
 
 import { PDA_SEED_VALUE_SUPPORTED_NODE_KINDS } from '../../../src/visitors/pda-seed-value';
@@ -26,5 +35,19 @@ describe('pda-seed-value: visitConstantValue', () => {
         await expect(makeVisitor().visitConstantValue(node)).rejects.toThrow(
             `Expected node of kind [${PDA_SEED_VALUE_SUPPORTED_NODE_KINDS.join(',')}], got [mapValueNode]`,
         );
+    });
+
+    test('constantValueNode wrapping argumentValueNode resolves the argument', async () => {
+        const visitor = makeVisitor({
+            argumentsInput: { title: 'hello' },
+            ixNode: instructionNode({
+                arguments: [instructionArgumentNode({ name: 'title', type: stringTypeNode('utf8') })],
+                name: 'testInstruction',
+            }),
+        });
+        // @ts-expect-error Deliberate constraint violation for testing extended recursion through constantValueNode
+        const node = constantValueNode(stringTypeNode('utf8'), argumentValueNode('title'));
+        const result = await visitor.visitConstantValue(node);
+        expect(result).toEqual(getUtf8Codec().encode('hello'));
     });
 });

--- a/packages/dynamic-address-resolution/test/visitors/pda-seed-value/constantValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/pda-seed-value/constantValueNode.test.ts
@@ -37,7 +37,7 @@ describe('pda-seed-value: visitConstantValue', () => {
         );
     });
 
-    test('constantValueNode wrapping argumentValueNode resolves the argument', async () => {
+    test('should resolve the argument when wrapping an argumentValueNode', async () => {
         const visitor = makeVisitor({
             argumentsInput: { title: 'hello' },
             ixNode: instructionNode({

--- a/packages/dynamic-address-resolution/test/visitors/pda-seed-value/someValueNode.test.ts
+++ b/packages/dynamic-address-resolution/test/visitors/pda-seed-value/someValueNode.test.ts
@@ -1,10 +1,15 @@
+import { getUtf8Codec } from '@solana/codecs';
 import {
+    argumentValueNode,
     constantValueNode,
+    instructionArgumentNode,
+    instructionNode,
     mapValueNode,
     numberValueNode,
     publicKeyTypeNode,
     publicKeyValueNode,
     someValueNode,
+    stringTypeNode,
 } from 'codama';
 import { describe, expect, test } from 'vitest';
 
@@ -30,5 +35,19 @@ describe('pda-seed-value: visitSomeValue', () => {
         await expect(makeVisitor().visitSomeValue(node)).rejects.toThrow(
             'Cannot convert value to Address: ["invalid-key"].',
         );
+    });
+
+    test('someValueNode wrapping argumentValueNode resolves the argument', async () => {
+        const visitor = makeVisitor({
+            argumentsInput: { title: 'hello' },
+            ixNode: instructionNode({
+                arguments: [instructionArgumentNode({ name: 'title', type: stringTypeNode('utf8') })],
+                name: 'testInstruction',
+            }),
+        });
+        // @ts-expect-error Deliberate constraint violation for testing extended recursion through someValueNode.
+        const node = someValueNode(argumentValueNode('title'));
+        const result = await visitor.visitSomeValue(node);
+        expect(result).toEqual(getUtf8Codec().encode('hello'));
     });
 });


### PR DESCRIPTION
### Summary

This is [4] PR for dynamic-client refactoring. It refactors internals of pda-seed-value visitor (the public API stays unchanged).
Extract the constant-seed part of `createPdaSeedValueVisitor` into a standalone visitor to simplify `resolveStandalonePda` method. The pda-seed-value visitor now extends the constant-pda-seed with variable-seed handling (`visitAccountValue` / `visitArgumentValue`) on top.

###  Change

- Added `createConstantPdaSeedValueVisitor` for the 9 constant value-node kinds (boolean / bytes / constant / none / number / programId / publicKey / some / string).
- Added `resolveConstantPdaSeedValue` resolver (internal) — facade over the visitor.
- Refactored `createPdaSeedValueVisitor` to extend the constant base via `extendVisitor` core helper, keeping only the `visitAccountValue`, `visitArgumentValue` overrides for variable seeds.
- Updated `resolveStandalonePda` to use `resolveConstantPdaSeedValue` directly. Drops the STANDALONE_IX_NODE stub and the manual visitOrElse dispatch.
- Added tests.