### PR TITLE
Validate its own generated schemas

### DIFF
--- a/.changeset/fix-validator-nested-defined-type-link.md
+++ b/.changeset/fix-validator-nested-defined-type-link.md
@@ -1,0 +1,5 @@
+---
+'@codama/validators': patch
+---
+
+Fix `getValidationItemsVisitor` throwing `Expected node of kind [definedTypeLinkNode]` on any nested `definedTypeLinkNode` (a struct field, argument, array element, or PDA seed), and recording `ValidationItem` paths that omitted the node itself. The visitor now composes `recordNodeStackVisitor` outermost, like every other visitor, so the current node is on the stack when validation runs.

--- a/packages/validators/src/getValidationItemsVisitor.ts
+++ b/packages/validators/src/getValidationItemsVisitor.ts
@@ -23,8 +23,6 @@ export function getValidationItemsVisitor(): Visitor<readonly ValidationItem[]> 
             () => [] as readonly ValidationItem[],
             (_, items) => items.flat(),
         ),
-        v => recordLinkablesOnFirstVisitVisitor(v, linkables),
-        v => recordNodeStackVisitor(v, stack),
         v =>
             extendVisitor(v, {
                 visitAccount(node, { next }) {
@@ -243,5 +241,11 @@ export function getValidationItemsVisitor(): Visitor<readonly ValidationItem[]> 
                     return [...items, ...next(node)];
                 },
             }),
+        // Pipe stages run outermost-first, i.e. in reverse of their listing here:
+        //   pipe(init, g, h, i) => i(h(g(init)))   -- i is the outer layer, runs first
+        // so these record the node (onto the stack, and into linkables) BEFORE the
+        // extendVisitor logic above runs and reads that state to validate the node.
+        v => recordNodeStackVisitor(v, stack),
+        v => recordLinkablesOnFirstVisitVisitor(v, linkables),
     );
 }

--- a/packages/validators/test/getValidationItemsVisitor.test.ts
+++ b/packages/validators/test/getValidationItemsVisitor.test.ts
@@ -109,6 +109,12 @@ test('it reports a nested defined type link that points at a missing type', () =
 
     // Then the missing link is reported as an error.
     expect(items).toEqual([
-        validationItem('error', 'Pointing to a missing defined type named "missing"', link, [node, foo, struct, field, link]),
+        validationItem('error', 'Pointing to a missing defined type named "missing"', link, [
+            node,
+            foo,
+            struct,
+            field,
+            link,
+        ]),
     ]);
 });

--- a/packages/validators/test/getValidationItemsVisitor.test.ts
+++ b/packages/validators/test/getValidationItemsVisitor.test.ts
@@ -1,4 +1,13 @@
-import { programNode, publicKeyTypeNode, structFieldTypeNode, structTypeNode, tupleTypeNode } from '@codama/nodes';
+import {
+    definedTypeLinkNode,
+    definedTypeNode,
+    numberTypeNode,
+    programNode,
+    publicKeyTypeNode,
+    structFieldTypeNode,
+    structTypeNode,
+    tupleTypeNode,
+} from '@codama/nodes';
 import { visit } from '@codama/visitors-core';
 import { expect, test } from 'vitest';
 
@@ -49,5 +58,57 @@ test('it validates nested nodes', () => {
     expect(items).toEqual([
         validationItem('warn', 'Tuple has no items.', tupleNode, [node]),
         validationItem('error', 'Struct field name "owner" is not unique.', structNode.fields[0], [node]),
+    ]);
+});
+
+test('it validates a defined type link nested within a struct field', () => {
+    // Given a program whose defined type links to another through a struct field.
+    const node = programNode({
+        accounts: [],
+        definedTypes: [
+            definedTypeNode({
+                name: 'foo',
+                type: structTypeNode([structFieldTypeNode({ name: 'bar', type: definedTypeLinkNode('baz') })]),
+            }),
+            definedTypeNode({ name: 'baz', type: numberTypeNode('u64') }),
+        ],
+        errors: [],
+        instructions: [],
+        name: 'test',
+        origin: 'anchor',
+        publicKey: '11111111111111111111111111111111',
+        version: '1.0.0',
+    });
+
+    // When we get the validation items using a visitor.
+    const items = visit(node, getValidationItemsVisitor());
+
+    // Then we expect no validation errors.
+    expect(items).toEqual([]);
+});
+
+test('it reports a nested defined type link that points at a missing type', () => {
+    // Given a program whose defined type field links to a type that does not exist.
+    const link = definedTypeLinkNode('missing');
+    const field = structFieldTypeNode({ name: 'bar', type: link });
+    const struct = structTypeNode([field]);
+    const foo = definedTypeNode({ name: 'foo', type: struct });
+    const node = programNode({
+        accounts: [],
+        definedTypes: [foo],
+        errors: [],
+        instructions: [],
+        name: 'test',
+        origin: 'anchor',
+        publicKey: '11111111111111111111111111111111',
+        version: '1.0.0',
+    });
+
+    // When we get the validation items using a visitor.
+    const items = visit(node, getValidationItemsVisitor());
+
+    // Then the missing link is reported as an error.
+    expect(items).toEqual([
+        validationItem('error', 'Pointing to a missing defined type named "missing"', link, [node, foo, struct, field, link]),
     ]);
 });

--- a/packages/validators/test/getValidationItemsVisitor.test.ts
+++ b/packages/validators/test/getValidationItemsVisitor.test.ts
@@ -32,10 +32,10 @@ test('it validates program nodes', () => {
 
     // Then we expect the following validation errors.
     expect(items).toEqual([
-        validationItem('error', 'Program has no name.', node, []),
-        validationItem('error', 'Program has no public key.', node, []),
-        validationItem('warn', 'Program has no version.', node, []),
-        validationItem('info', 'Program has no origin.', node, []),
+        validationItem('error', 'Program has no name.', node, [node]),
+        validationItem('error', 'Program has no public key.', node, [node]),
+        validationItem('warn', 'Program has no version.', node, [node]),
+        validationItem('info', 'Program has no origin.', node, [node]),
     ]);
 });
 
@@ -56,8 +56,8 @@ test('it validates nested nodes', () => {
     const tupleNode = node.items[0];
     const structNode = node.items[1];
     expect(items).toEqual([
-        validationItem('warn', 'Tuple has no items.', tupleNode, [node]),
-        validationItem('error', 'Struct field name "owner" is not unique.', structNode.fields[0], [node]),
+        validationItem('warn', 'Tuple has no items.', tupleNode, [node, tupleNode]),
+        validationItem('error', 'Struct field name "owner" is not unique.', structNode.fields[0], [node, structNode]),
     ]);
 });
 


### PR DESCRIPTION
## Summary and Context

I spent most of my day chasing a validation issue for my own project and decided to look at how codama validation works. 

`getValidationItemsVisitor` throws `CodamaError: Expected node of kind [definedTypeLinkNode], got [...]` on any IDL where a `definedTypeLinkNode` sits below the top of the tree: under a struct field, an instruction argument, an array element, or a PDA seed. That is most real programs, and six of this repo's own committed test IDLs hit it, including `example-idl.json`, `system-program-idl.json`, `token-idl.json`, and `token-2022-idl.json`.

The root cause is a single ordering issue in how the visitor threads its `NodeStack`, and the same issue silently corrupted every recorded `ValidationItem.path`. The fix restores the invariant the other eleven `recordNodeStackVisitor` consumers already follow.

**Disclosure**: I traced the issue, hacked the fix and used LLM to polish.

## The invariant

When a visitor threads a context through the tree (here, the `NodeStack` of ancestors), it has to commit the current node into that context **as it enters the node, before anything reads it.** Two readers run on arrival: the node's own logic, and, further down, its children. So the node must be on the stack for its *own* resolution, as well as its children's.

## What went wrong

This visitor was the only one to run its per-node logic before committing the node to the stack, so the validation ran in the gap between "arrived at the node" and "recorded the node." (In pipe terms it applied `extendVisitor` after `recordNodeStackVisitor`; `getByteSizeVisitor`, `setInstructionAccountDefaultValuesVisitor`, and the nine others do the reverse.)

That one gap produced two symptoms:

1. **The crash.** `visitDefinedTypeLink` calls `linkables.has(stack.getPath(node.kind))`. `getPath(kind)` asserts the top of the stack is `kind`; the link node wasn't committed yet, so the top was its parent, giving `Expected node of kind [definedTypeLinkNode], got [structFieldTypeNode]` (or `arrayTypeNode`, or `variablePdaSeedNode`: always exactly the link's parent).

2. **Off-by-one paths.** Every `validationItem(..., stack)` snapshotted the stack at that same pre-commit moment, so each `ValidationItem.path` omitted the node it points at, contradicting the documented contract ("the path of nodes that led to the node above, including the node itself").

## Regression

The crash isn't original to the file. Tracing the link check:

| commit | check | crashes? |
|---|---|---|
| #7 (Add validators package) | `linkables.has(node, stack)`, passes `node` explicitly | no |
| #270 (Use NodePath in LinkableDictionary) | `linkables.has(stack.getPath())`, no assertion | no |
| **#275 (Refactor NodeStack and NodePath)** | `linkables.has(stack.getPath(node.kind))`, asserts stack top | **yes** |

#275 made `getPath(kind)` assert the stack's top kind and switched this call to pass `node.kind`. That assertion holds under the standard composition (node already committed), which this visitor happened not to have, so the call began throwing. The off-by-one paths are older, dating to the original composition, but stayed invisible until #275's assertion surfaced the underlying staleness.

## The fix

Commit the node before the per-node logic runs, matching every other visitor: `recordNodeStackVisitor` and `recordLinkablesOnFirstVisitVisitor` now wrap the validation logic instead of the reverse. `stack.getPath(node.kind)` resolves, and recorded paths satisfy the contract. The change is a two-line reordering of the pipe.

## Tests

- Two regression tests build the smallest crashing shape from the node constructors (a defined type whose struct field links to another). Both throw before the fix. One asserts a resolvable link validates cleanly; the other asserts a *missing* link is reported as an error (`Pointing to a missing defined type named "missing"`), so the fix restores the validator's ability to catch a broken link, not just stop the crash.
- The two existing tests asserted the off-by-one paths (`[]` for the program node, `[node]` for the nested items); they are corrected to the documented behavior (`[node]`, `[node, tupleNode]`, `[node, structNode]`).

## Verification against the repo's own corpus

Running the validator over every committed rootNode IDL in `packages/dynamic-client/test/programs/idls/`: before the fix, 6 of 12 throw; after, all 12 validate.

## Suggestion: guard our own output in CI

Since six committed IDLs crashed the validator, a small guard would catch this class of regression early: a test that runs `getValidationItemsVisitor` over the repo's own fixture IDLs and asserts it doesn't throw. Happy to add it in this PR or a follow-up, wherever you'd prefer it to live.
