### PR TITLE
feat(cli): add additionalIdls config option

### DIFF
--- a/.changeset/plutohan-additional-idls.md
+++ b/.changeset/plutohan-additional-idls.md
@@ -1,0 +1,5 @@
+---
+'@codama/cli': minor
+---
+
+Add an `additionalIdls` config option to generate clients for multiple programs in an Anchor workspace from a single `codama.json`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -71,6 +71,7 @@ Here are the available options for the `run` command:
 The Codama configuration file defines an object containing the following fields:
 
 - `idl` (string): The path to the IDL file. This can be a Codama IDL or an Anchor IDL which will be automatically converted to a Codama IDL.
+- `additionalIdls` (array): An array of paths to additional Anchor IDLs. Their programs are included alongside the main IDL's program (as `additionalPrograms`), so a single config can generate clients for multiple programs in an Anchor workspace.
     ```json
     {
         "idl": "path/to/idl"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -71,7 +71,7 @@ Here are the available options for the `run` command:
 The Codama configuration file defines an object containing the following fields:
 
 - `idl` (string): The path to the IDL file. This can be a Codama IDL or an Anchor IDL which will be automatically converted to a Codama IDL.
-- `additionalIdls` (array): An array of paths to additional Anchor IDLs. Their programs are included alongside the main IDL's program (as `additionalPrograms`), so a single config can generate clients for multiple programs in an Anchor workspace.
+- `additionalIdls` (array): An array of paths to additional IDLs. Their programs are included alongside the main IDL's program (as `additionalPrograms`), so a single config can generate clients for multiple programs in an Anchor workspace.
     ```json
     {
         "idl": "path/to/idl"

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -6,6 +6,7 @@ import { ProgramOptions } from './programOptions';
 import { canRead, CliError, importModuleItem, logWarning } from './utils';
 
 export type Config = Readonly<{
+    additionalIdls?: readonly string[];
     idl?: string;
     scripts?: ScriptsConfig;
     before?: readonly VisitorConfig[];

--- a/packages/cli/src/parsedConfig.ts
+++ b/packages/cli/src/parsedConfig.ts
@@ -45,33 +45,25 @@ async function parseConfig(
     options: Pick<ProgramOptions, 'idl'>,
 ): Promise<ParsedConfig> {
     const idlPath = parseIdlPath(config, configPath, options);
-    const idlContent = await importModuleItem({ identifier: 'IDL', from: idlPath });
-    const rootNode = await mergeAdditionalIdls(idlContent, config.additionalIdls ?? [], configPath);
+    const additionalIdlPaths = (config.additionalIdls ?? []).map(idl => resolveConfigPath(idl, configPath));
+
+    // Load and convert the main IDL and every additional IDL the same way, in parallel.
+    const idls = await Promise.all([
+        loadIdl(idlPath, 'IDL'),
+        ...additionalIdlPaths.map(path => loadIdl(path, 'additional IDL')),
+    ]);
+
+    const [mainIdl] = idls;
+    const rootNode = mergeRootNodes(idls.map(idl => idl.rootNode));
     const scripts = parseScripts(config.scripts ?? {}, configPath);
     const visitors = (config.before ?? []).map((v, i) => parseVisitorConfig(v, configPath, i, null));
 
-    return { configPath, idlContent, idlPath, rootNode, scripts, before: visitors };
+    return { configPath, idlContent: mainIdl.content, idlPath, rootNode, scripts, before: visitors };
 }
 
-async function mergeAdditionalIdls(
-    idlContent: unknown,
-    additionalIdls: readonly string[],
-    configPath: string | null,
-): Promise<RootNode> {
-    // Convert the main IDL and every additional IDL to a root node in parallel,
-    // keeping the main root node first.
-    const rootNodes = await Promise.all([
-        getRootNodeFromIdl(idlContent),
-        ...additionalIdls.map(async additionalIdl => {
-            const additionalIdlPath = resolveConfigPath(additionalIdl, configPath);
-            const additionalIdlContent = await importModuleItem({
-                identifier: 'additional IDL',
-                from: additionalIdlPath,
-            });
-            return await getRootNodeFromIdl(additionalIdlContent);
-        }),
-    ]);
-    return mergeRootNodes(rootNodes);
+async function loadIdl(from: string, identifier: string): Promise<{ content: unknown; rootNode: RootNode }> {
+    const content = await importModuleItem({ identifier, from });
+    return { content, rootNode: await getRootNodeFromIdl(content) };
 }
 
 function mergeRootNodes(rootNodes: readonly RootNode[]): RootNode {

--- a/packages/cli/src/parsedConfig.ts
+++ b/packages/cli/src/parsedConfig.ts
@@ -1,4 +1,4 @@
-import type { RootNode } from '@codama/nodes';
+import { getAllPrograms, type RootNode,rootNode } from '@codama/nodes';
 import { Command } from 'commander';
 
 import { Config, getConfig, ScriptName, ScriptsConfig, VisitorConfig, VisitorPath } from './config';
@@ -46,11 +46,32 @@ async function parseConfig(
 ): Promise<ParsedConfig> {
     const idlPath = parseIdlPath(config, configPath, options);
     const idlContent = await importModuleItem({ identifier: 'IDL', from: idlPath });
-    const rootNode = await getRootNodeFromIdl(idlContent);
+    const mainRootNode = await getRootNodeFromIdl(idlContent);
+    const rootNode = await mergeAdditionalIdls(mainRootNode, config.additionalIdls ?? [], configPath);
     const scripts = parseScripts(config.scripts ?? {}, configPath);
     const visitors = (config.before ?? []).map((v, i) => parseVisitorConfig(v, configPath, i, null));
 
     return { configPath, idlContent, idlPath, rootNode, scripts, before: visitors };
+}
+
+async function mergeAdditionalIdls(
+    mainRootNode: RootNode,
+    additionalIdls: readonly string[],
+    configPath: string | null,
+): Promise<RootNode> {
+    if (additionalIdls.length === 0) {
+        return mainRootNode;
+    }
+
+    const additionalPrograms = [...mainRootNode.additionalPrograms];
+    for (const additionalIdl of additionalIdls) {
+        const additionalIdlPath = resolveConfigPath(additionalIdl, configPath);
+        const additionalIdlContent = await importModuleItem({ identifier: 'additional IDL', from: additionalIdlPath });
+        const additionalRootNode = await getRootNodeFromIdl(additionalIdlContent);
+        additionalPrograms.push(...getAllPrograms(additionalRootNode));
+    }
+
+    return rootNode(mainRootNode.program, additionalPrograms);
 }
 
 function parseIdlPath(

--- a/packages/cli/src/parsedConfig.ts
+++ b/packages/cli/src/parsedConfig.ts
@@ -1,4 +1,4 @@
-import { getAllPrograms, type RootNode,rootNode } from '@codama/nodes';
+import { getAllPrograms, type RootNode } from '@codama/nodes';
 import { Command } from 'commander';
 
 import { Config, getConfig, ScriptName, ScriptsConfig, VisitorConfig, VisitorPath } from './config';
@@ -71,7 +71,8 @@ async function mergeAdditionalIdls(
         additionalPrograms.push(...getAllPrograms(additionalRootNode));
     }
 
-    return rootNode(mainRootNode.program, additionalPrograms);
+    // Preserve the main root node's other fields (e.g. `standard`, `version`).
+    return { ...mainRootNode, additionalPrograms };
 }
 
 function parseIdlPath(

--- a/packages/cli/src/parsedConfig.ts
+++ b/packages/cli/src/parsedConfig.ts
@@ -46,8 +46,7 @@ async function parseConfig(
 ): Promise<ParsedConfig> {
     const idlPath = parseIdlPath(config, configPath, options);
     const idlContent = await importModuleItem({ identifier: 'IDL', from: idlPath });
-    const mainRootNode = await getRootNodeFromIdl(idlContent);
-    const rootNode = await mergeAdditionalIdls(mainRootNode, config.additionalIdls ?? [], configPath);
+    const rootNode = await mergeAdditionalIdls(idlContent, config.additionalIdls ?? [], configPath);
     const scripts = parseScripts(config.scripts ?? {}, configPath);
     const visitors = (config.before ?? []).map((v, i) => parseVisitorConfig(v, configPath, i, null));
 
@@ -55,24 +54,33 @@ async function parseConfig(
 }
 
 async function mergeAdditionalIdls(
-    mainRootNode: RootNode,
+    idlContent: unknown,
     additionalIdls: readonly string[],
     configPath: string | null,
 ): Promise<RootNode> {
-    if (additionalIdls.length === 0) {
-        return mainRootNode;
-    }
+    // Convert the main IDL and every additional IDL to a root node in parallel,
+    // keeping the main root node first.
+    const rootNodes = await Promise.all([
+        getRootNodeFromIdl(idlContent),
+        ...additionalIdls.map(async additionalIdl => {
+            const additionalIdlPath = resolveConfigPath(additionalIdl, configPath);
+            const additionalIdlContent = await importModuleItem({
+                identifier: 'additional IDL',
+                from: additionalIdlPath,
+            });
+            return await getRootNodeFromIdl(additionalIdlContent);
+        }),
+    ]);
+    return mergeRootNodes(rootNodes);
+}
 
-    const additionalPrograms = [...mainRootNode.additionalPrograms];
-    for (const additionalIdl of additionalIdls) {
-        const additionalIdlPath = resolveConfigPath(additionalIdl, configPath);
-        const additionalIdlContent = await importModuleItem({ identifier: 'additional IDL', from: additionalIdlPath });
-        const additionalRootNode = await getRootNodeFromIdl(additionalIdlContent);
-        additionalPrograms.push(...getAllPrograms(additionalRootNode));
+function mergeRootNodes(rootNodes: readonly RootNode[]): RootNode {
+    const [head, ...tail] = rootNodes;
+    if (tail.length === 0) {
+        return head;
     }
-
     // Preserve the main root node's other fields (e.g. `standard`, `version`).
-    return { ...mainRootNode, additionalPrograms };
+    return { ...head, additionalPrograms: [...head.additionalPrograms, ...tail.flatMap(getAllPrograms)] };
 }
 
 function parseIdlPath(

--- a/packages/cli/test/parsedConfig.test.ts
+++ b/packages/cli/test/parsedConfig.test.ts
@@ -1,0 +1,65 @@
+import type { ProgramNode, RootNode } from '@codama/nodes';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { getConfig } from '../src/config';
+import { getParsedConfig } from '../src/parsedConfig';
+import { importModuleItem } from '../src/utils/import';
+import { getRootNodeFromIdl } from '../src/utils/nodes';
+
+vi.mock('../src/config', () => ({ getConfig: vi.fn() }));
+vi.mock('../src/utils/import', () => ({ importModuleItem: vi.fn() }));
+vi.mock('../src/utils/nodes', () => ({ getRootNodeFromIdl: vi.fn() }));
+
+const getConfigMock = vi.mocked(getConfig);
+const importModuleItemMock = vi.mocked(importModuleItem);
+const getRootNodeFromIdlMock = vi.mocked(getRootNodeFromIdl);
+
+function programNode(name: string): ProgramNode {
+    return {
+        accounts: [],
+        constants: [],
+        definedTypes: [],
+        errors: [],
+        instructions: [],
+        kind: 'programNode',
+        name,
+        pdas: [],
+    } as unknown as ProgramNode;
+}
+
+function rootNodeWith(name: string): RootNode {
+    return {
+        additionalPrograms: [],
+        kind: 'rootNode',
+        program: programNode(name),
+        standard: 'codama',
+        version: '1.0.0',
+    } as unknown as RootNode;
+}
+
+beforeEach(() => {
+    vi.resetAllMocks();
+    importModuleItemMock.mockResolvedValue({});
+});
+
+test('merges additionalIdls programs into the root node additionalPrograms', async () => {
+    getConfigMock.mockResolvedValue([{ additionalIdls: ['a.json', 'b.json'], idl: 'main.json' }, '/root/codama.json']);
+    getRootNodeFromIdlMock
+        .mockResolvedValueOnce(rootNodeWith('main'))
+        .mockResolvedValueOnce(rootNodeWith('a'))
+        .mockResolvedValueOnce(rootNodeWith('b'));
+
+    const parsed = await getParsedConfig({});
+
+    expect(parsed.rootNode.program.name).toBe('main');
+    expect(parsed.rootNode.additionalPrograms.map(p => p.name)).toEqual(['a', 'b']);
+});
+
+test('leaves the root node unchanged when no additionalIdls are provided', async () => {
+    getConfigMock.mockResolvedValue([{ idl: 'main.json' }, '/root/codama.json']);
+    getRootNodeFromIdlMock.mockResolvedValue(rootNodeWith('main'));
+
+    const parsed = await getParsedConfig({});
+
+    expect(parsed.rootNode.additionalPrograms).toEqual([]);
+});

--- a/packages/cli/test/parsedConfig.test.ts
+++ b/packages/cli/test/parsedConfig.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
 test('merges additionalIdls programs into the root node additionalPrograms', async () => {
     getConfigMock.mockResolvedValue([{ additionalIdls: ['a.json', 'b.json'], idl: 'main.json' }, '/root/codama.json']);
     getRootNodeFromIdlMock
-        .mockResolvedValueOnce(rootNodeWith('main'))
+        .mockResolvedValueOnce({ ...rootNodeWith('main'), version: '9.9.9' } as RootNode)
         .mockResolvedValueOnce(rootNodeWith('a'))
         .mockResolvedValueOnce(rootNodeWith('b'));
 
@@ -53,6 +53,9 @@ test('merges additionalIdls programs into the root node additionalPrograms', asy
 
     expect(parsed.rootNode.program.name).toBe('main');
     expect(parsed.rootNode.additionalPrograms.map(p => p.name)).toEqual(['a', 'b']);
+    // The main root node's other fields are preserved by the merge.
+    expect(parsed.rootNode.standard).toBe('codama');
+    expect(parsed.rootNode.version).toBe('9.9.9');
 });
 
 test('leaves the root node unchanged when no additionalIdls are provided', async () => {

--- a/packages/cli/test/parsedConfig.test.ts
+++ b/packages/cli/test/parsedConfig.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
 test('merges additionalIdls programs into the root node additionalPrograms', async () => {
     getConfigMock.mockResolvedValue([{ additionalIdls: ['a.json', 'b.json'], idl: 'main.json' }, '/root/codama.json']);
     getRootNodeFromIdlMock
-        .mockResolvedValueOnce({ ...rootNodeWith('main'), version: '9.9.9' } as RootNode)
+        .mockResolvedValueOnce({ ...rootNodeWith('main'), version: '9.9.9' } as unknown as RootNode)
         .mockResolvedValueOnce(rootNodeWith('a'))
         .mockResolvedValueOnce(rootNodeWith('b'));
 

--- a/packages/cli/test/parsedConfig.test.ts
+++ b/packages/cli/test/parsedConfig.test.ts
@@ -1,4 +1,5 @@
-import type { ProgramNode, RootNode } from '@codama/nodes';
+import type { RootNode } from '@codama/nodes';
+import { programNode, rootNode } from '@codama/nodes';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { getConfig } from '../src/config';
@@ -14,27 +15,8 @@ const getConfigMock = vi.mocked(getConfig);
 const importModuleItemMock = vi.mocked(importModuleItem);
 const getRootNodeFromIdlMock = vi.mocked(getRootNodeFromIdl);
 
-function programNode(name: string): ProgramNode {
-    return {
-        accounts: [],
-        constants: [],
-        definedTypes: [],
-        errors: [],
-        instructions: [],
-        kind: 'programNode',
-        name,
-        pdas: [],
-    } as unknown as ProgramNode;
-}
-
 function rootNodeWith(name: string): RootNode {
-    return {
-        additionalPrograms: [],
-        kind: 'rootNode',
-        program: programNode(name),
-        standard: 'codama',
-        version: '1.0.0',
-    } as unknown as RootNode;
+    return rootNode(programNode({ name, publicKey: '11111111111111111111111111111111' }));
 }
 
 beforeEach(() => {


### PR DESCRIPTION
Closes #983.

Implements the `additionalIdls` approach from your comment @lorisleiva: the config can list additional Anchor IDLs, and their programs get merged into the root node's `additionalPrograms`, so one `codama.json` generates clients for every program in an Anchor workspace.

Includes a README entry, a test, and a changeset.
