### PR TITLE
Integrate @codama/spec@1.8.0

### DIFF
--- a/.changeset/plugin-nodes.md
+++ b/.changeset/plugin-nodes.md
@@ -1,0 +1,5 @@
+---
+'@codama/nodes': minor
+---
+
+Integrate `@codama/spec@1.8.0`, adding the `pluginNode` to the node meta-model. A `pluginNode` attaches named, plugin-specific data to a node: it carries a `name` that uniquely identifies the plugin and an optional opaque `payload`. The payload is typed by the new `json` type expression, which renders as `unknown` in TypeScript. `instructionNode` gains an optional `plugins` field holding an array of `pluginNode`. All changes are additive and optional.

--- a/packages/node-types/src/generated/InstructionNode.ts
+++ b/packages/node-types/src/generated/InstructionNode.ts
@@ -7,6 +7,7 @@ import type { InstructionArgumentNode } from './InstructionArgumentNode';
 import type { InstructionByteDeltaNode } from './InstructionByteDeltaNode';
 import type { InstructionRemainingAccountsNode } from './InstructionRemainingAccountsNode';
 import type { InstructionStatusNode } from './InstructionStatusNode';
+import type { PluginNode } from './PluginNode';
 import type { ProvidedNode } from './ProvidedNode';
 import type { OptionalAccountStrategy } from './shared/optionalAccountStrategy';
 
@@ -26,6 +27,7 @@ export interface InstructionNode<
     TStatus extends InstructionStatusNode | undefined = InstructionStatusNode | undefined,
     TProvides extends Array<ProvidedNode> | undefined = Array<ProvidedNode> | undefined,
     TDisplay extends InstructionDisplayNode | undefined = InstructionDisplayNode | undefined,
+    TPlugins extends Array<PluginNode> | undefined = Array<PluginNode> | undefined,
 > {
     readonly kind: 'instructionNode';
 
@@ -64,4 +66,6 @@ export interface InstructionNode<
     readonly provides?: TProvides;
     /** Display metadata describing how the instruction is presented. */
     readonly display?: TDisplay;
+    /** Namespaced plugins with custom structured data. */
+    readonly plugins?: TPlugins;
 }

--- a/packages/node-types/src/generated/Node.ts
+++ b/packages/node-types/src/generated/Node.ts
@@ -16,6 +16,7 @@ import type { InstructionStatusNode } from './InstructionStatusNode';
 import type { RegisteredLinkNode } from './linkNodes/RegisteredLinkNode';
 import type { PdaNode } from './PdaNode';
 import type { RegisteredPdaSeedNode } from './pdaSeedNodes/RegisteredPdaSeedNode';
+import type { PluginNode } from './PluginNode';
 import type { ProgramNode } from './ProgramNode';
 import type { ProvidedNode } from './ProvidedNode';
 import type { RootNode } from './RootNode';
@@ -37,6 +38,7 @@ export type Node =
     | InstructionRemainingAccountsNode
     | InstructionStatusNode
     | PdaNode
+    | PluginNode
     | ProgramNode
     | ProvidedNode
     | RegisteredContextualValueNode

--- a/packages/node-types/src/generated/PluginNode.ts
+++ b/packages/node-types/src/generated/PluginNode.ts
@@ -1,0 +1,15 @@
+import type { CamelCaseString } from '../brands';
+
+/**
+ * Attaches named, plugin-specific data to a node.
+ * A plugin is uniquely identified by its `name`; the optional `payload` carries arbitrary, consumer-defined data that only the matching plugin knows how to interpret. Codama itself treats the payload as opaque.
+ */
+export interface PluginNode {
+    readonly kind: 'pluginNode';
+
+    // Data.
+    /** The unique name identifying the plugin this data belongs to. */
+    readonly name: CamelCaseString;
+    /** Arbitrary, plugin-specific data. Its shape is defined by the plugin, not by Codama, and is carried through the graph verbatim. */
+    readonly payload?: unknown;
+}

--- a/packages/node-types/src/generated/index.ts
+++ b/packages/node-types/src/generated/index.ts
@@ -13,6 +13,7 @@ export * from './InstructionRemainingAccountsValue';
 export * from './InstructionStatusNode';
 export * from './Node';
 export * from './PdaNode';
+export * from './PluginNode';
 export * from './ProgramNode';
 export * from './ProvidedNode';
 export * from './RootNode';

--- a/packages/node-types/src/generated/shared/codamaVersion.ts
+++ b/packages/node-types/src/generated/shared/codamaVersion.ts
@@ -3,4 +3,4 @@
  * version of the spec at generation time; documents conforming to this
  * version of the spec carry this exact string.
  */
-export type CodamaVersion = '1.7.0';
+export type CodamaVersion = '1.8.0';

--- a/packages/nodes/src/generated/InstructionNode.ts
+++ b/packages/nodes/src/generated/InstructionNode.ts
@@ -7,6 +7,7 @@ import type {
     InstructionNode,
     InstructionRemainingAccountsNode,
     InstructionStatusNode,
+    PluginNode,
     ProvidedNode,
 } from '@codama/node-types';
 import { camelCase, DocsInput, parseDocs } from '../shared';
@@ -24,6 +25,7 @@ export type InstructionNodeInput<
     TStatus extends InstructionStatusNode | undefined = InstructionStatusNode | undefined,
     TProvides extends Array<ProvidedNode> | undefined = Array<ProvidedNode> | undefined,
     TDisplay extends InstructionDisplayNode | undefined = InstructionDisplayNode | undefined,
+    TPlugins extends Array<PluginNode> | undefined = Array<PluginNode> | undefined,
 > = Omit<
     Partial<
         InstructionNode<
@@ -36,7 +38,8 @@ export type InstructionNodeInput<
             TSubInstructions,
             TStatus,
             TProvides,
-            TDisplay
+            TDisplay,
+            TPlugins
         >
     >,
     'docs' | 'kind' | 'name'
@@ -57,6 +60,7 @@ export function instructionNode<
     const TStatus extends InstructionStatusNode | undefined = undefined,
     const TProvides extends Array<ProvidedNode> | undefined = undefined,
     const TDisplay extends InstructionDisplayNode | undefined = undefined,
+    const TPlugins extends Array<PluginNode> | undefined = undefined,
 >(
     input: InstructionNodeInput<
         TAccounts,
@@ -68,7 +72,8 @@ export function instructionNode<
         TSubInstructions,
         TStatus,
         TProvides,
-        TDisplay
+        TDisplay,
+        TPlugins
     >,
 ): InstructionNode<
     TAccounts,
@@ -80,7 +85,8 @@ export function instructionNode<
     TSubInstructions,
     TStatus,
     TProvides,
-    TDisplay
+    TDisplay,
+    TPlugins
 > {
     const parsedDocs = parseDocs(input.docs);
     return Object.freeze({
@@ -102,5 +108,6 @@ export function instructionNode<
         ...(input.subInstructions !== undefined && { subInstructions: input.subInstructions }),
         ...(input.provides !== undefined && { provides: input.provides }),
         ...(input.display !== undefined && { display: input.display }),
+        ...(input.plugins !== undefined && { plugins: input.plugins }),
     });
 }

--- a/packages/nodes/src/generated/PluginNode.ts
+++ b/packages/nodes/src/generated/PluginNode.ts
@@ -1,0 +1,16 @@
+import type { PluginNode } from '@codama/node-types';
+import { camelCase } from '../shared';
+
+/**
+ * Attaches named, plugin-specific data to a node.
+ * A plugin is uniquely identified by its `name`; the optional `payload` carries arbitrary, consumer-defined data that only the matching plugin knows how to interpret. Codama itself treats the payload as opaque.
+ */
+export function pluginNode(name: string, payload?: unknown): PluginNode {
+    return Object.freeze({
+        kind: 'pluginNode',
+
+        // Data.
+        name: camelCase(name),
+        ...(payload !== undefined && { payload }),
+    });
+}

--- a/packages/nodes/src/generated/codamaVersion.ts
+++ b/packages/nodes/src/generated/codamaVersion.ts
@@ -8,4 +8,4 @@ import type { CodamaVersion } from '@codama/node-types';
  * that need to compare an IDL document's `version` against the spec
  * shape `@codama/nodes` understands.
  */
-export const CODAMA_VERSION: CodamaVersion = '1.7.0';
+export const CODAMA_VERSION: CodamaVersion = '1.8.0';

--- a/packages/nodes/src/generated/index.ts
+++ b/packages/nodes/src/generated/index.ts
@@ -14,6 +14,7 @@ export * from './InstructionRemainingAccountsValue';
 export * from './InstructionStatusNode';
 export * from './nodeKinds';
 export * from './PdaNode';
+export * from './PluginNode';
 export * from './ProgramNode';
 export * from './ProvidedNode';
 export * from './RootNode';

--- a/packages/nodes/src/generated/nodeKinds.ts
+++ b/packages/nodes/src/generated/nodeKinds.ts
@@ -21,6 +21,7 @@ export const REGISTERED_NODE_KINDS = [
     'instructionRemainingAccountsNode' as const,
     'instructionStatusNode' as const,
     'pdaNode' as const,
+    'pluginNode' as const,
     'programNode' as const,
     'providedNode' as const,
     'rootNode' as const,

--- a/packages/spec-generators/package.json
+++ b/packages/spec-generators/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@codama/fragments": "workspace:*",
-        "@codama/spec": "1.7.0"
+        "@codama/spec": "1.8.0"
     },
     "devDependencies": {
         "@types/node": "^25",

--- a/packages/spec-generators/src/nodeTypes/fragments/typeExpr.ts
+++ b/packages/spec-generators/src/nodeTypes/fragments/typeExpr.ts
@@ -14,6 +14,8 @@ export function getTypeExprFragment(expr: TypeExpr): Fragment {
             return fragment`number`;
         case 'boolean':
             return fragment`boolean`;
+        case 'json':
+            return fragment`unknown`;
         case 'literal':
             return fragment`${literalToTs(expr.value)}`;
         case 'literalUnion':

--- a/packages/spec-generators/src/nodes/config.ts
+++ b/packages/spec-generators/src/nodes/config.ts
@@ -102,6 +102,7 @@ export const NODE_CONFIGS: ReadonlyMap<string, NodeConstructorConfig> = new Map<
     ],
     ['instructionRemainingAccountsNode', { positionalArgs: ['value'] }],
     ['instructionStatusNode', { positionalArgs: ['lifecycle', 'message'] }],
+    ['pluginNode', { positionalArgs: ['name', 'payload'] }],
     [
         'programNode',
         {

--- a/packages/spec-generators/src/nodes/fragments/typeExpr.ts
+++ b/packages/spec-generators/src/nodes/fragments/typeExpr.ts
@@ -26,6 +26,8 @@ export function getTypeExprFragment(expr: TypeExpr): Fragment {
             return fragment`number`;
         case 'boolean':
             return fragment`boolean`;
+        case 'json':
+            return fragment`unknown`;
         case 'literal':
             return fragment`${literalToTs(expr.value)}`;
         case 'literalUnion':

--- a/packages/spec-generators/src/shared/defaults.ts
+++ b/packages/spec-generators/src/shared/defaults.ts
@@ -39,6 +39,7 @@ export const GENERIC_PARAM_ORDER: ReadonlyMap<string, readonly string[]> = new M
             'status',
             'provides',
             'display',
+            'plugins',
         ],
     ],
 ]);

--- a/packages/spec-generators/src/visitorsCore/options.ts
+++ b/packages/spec-generators/src/visitorsCore/options.ts
@@ -62,6 +62,7 @@ export const MERGE_VISITOR_WALK_ORDER: ReadonlyMap<string, readonly string[]> = 
             'subInstructions',
             'provides',
             'display',
+            'plugins',
         ],
     ],
     ['arrayTypeNode', ['count', 'item']],
@@ -101,6 +102,7 @@ export const IDENTITY_VISITOR_WALK_ORDER: ReadonlyMap<string, readonly string[]>
             'subInstructions',
             'provides',
             'display',
+            'plugins',
         ],
     ],
 ]);

--- a/packages/visitors-core/src/generated/identityVisitor.ts
+++ b/packages/visitors-core/src/generated/identityVisitor.ts
@@ -749,6 +749,9 @@ export function identityVisitor<TNodeKind extends NodeKind = NodeKind>(
                     ? node.provides.map(visit(this)).filter(removeNullAndAssertIsNodeFilter('providedNode'))
                     : undefined,
                 display,
+                plugins: node.plugins
+                    ? node.plugins.map(visit(this)).filter(removeNullAndAssertIsNodeFilter('pluginNode'))
+                    : undefined,
             });
         };
     }

--- a/packages/visitors-core/src/generated/mergeVisitor.ts
+++ b/packages/visitors-core/src/generated/mergeVisitor.ts
@@ -415,6 +415,7 @@ export function mergeVisitor<TReturn, TNodeKind extends NodeKind = NodeKind>(
                 ...(node.subInstructions ?? []).flatMap(visit(this)),
                 ...(node.provides ?? []).flatMap(visit(this)),
                 ...(node.display ? visit(this)(node.display) : []),
+                ...(node.plugins ?? []).flatMap(visit(this)),
             ]);
         };
     }

--- a/packages/visitors-core/src/generated/nodeTestPaths.ts
+++ b/packages/visitors-core/src/generated/nodeTestPaths.ts
@@ -68,6 +68,7 @@ export const NODE_TEST_PATHS: Readonly<Record<NodeKind, string>> = {
     pdaNode: 'PdaNode',
     pdaSeedValueNode: 'contextualValueNodes/PdaSeedValueNode',
     pdaValueNode: 'contextualValueNodes/PdaValueNode',
+    pluginNode: 'PluginNode',
     postOffsetTypeNode: 'typeNodes/PostOffsetTypeNode',
     prefixedCountNode: 'countNodes/PrefixedCountNode',
     preOffsetTypeNode: 'typeNodes/PreOffsetTypeNode',

--- a/packages/visitors-core/test/nodes/PluginNode.test.ts
+++ b/packages/visitors-core/test/nodes/PluginNode.test.ts
@@ -1,0 +1,27 @@
+import { pluginNode } from '@codama/nodes';
+import { test } from 'vitest';
+
+import {
+    expectDebugStringVisitor,
+    expectDeleteNodesVisitor,
+    expectIdentityVisitor,
+    expectMergeVisitorCount,
+} from './_setup';
+
+const node = pluginNode('anchor', { version: '0.30.0' });
+
+test('mergeVisitor', () => {
+    expectMergeVisitorCount(node, 1);
+});
+
+test('identityVisitor', () => {
+    expectIdentityVisitor(node);
+});
+
+test('deleteNodesVisitor', () => {
+    expectDeleteNodesVisitor(node, '[pluginNode]', null);
+});
+
+test('debugStringVisitor', () => {
+    expectDebugStringVisitor(node, `pluginNode [anchor]`);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,8 +328,8 @@ importers:
         specifier: workspace:*
         version: link:../fragments
       '@codama/spec':
-        specifier: 1.7.0
-        version: 1.7.0
+        specifier: 1.8.0
+        version: 1.8.0
     devDependencies:
       '@types/node':
         specifier: ^25
@@ -619,8 +619,8 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@codama/spec@1.7.0':
-    resolution: {integrity: sha512-qZsS8IfycSdeyq+1XXQWnYMpY1box8ZJm9b/sgh9YOOaZCSll/zMoq8Iw0pdFkGzzUi2LFGNgC1IJeNtLbH4HQ==}
+  '@codama/spec@1.8.0':
+    resolution: {integrity: sha512-vHuEs0KzCWfpgjALrVywb3WgMfc08PWwIx6yUaB6g5pckv8shcrDBQJA2vyNKfc8BRYdX6fwogLhytpDgyyJ0Q==}
     engines: {node: '>=22.12.0'}
 
   '@esbuild/aix-ppc64@0.27.0':
@@ -4842,7 +4842,7 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@codama/spec@1.7.0': {}
+  '@codama/spec@1.8.0': {}
 
   '@esbuild/aix-ppc64@0.27.0':
     optional: true


### PR DESCRIPTION
This PR integrates `@codama/spec@1.8.0`, threading the new `pluginNode` and `json` type expression through the TypeScript reference implementation. The node-types, nodes, and visitors-core packages are regenerated: `pluginNode` gains its interface and `pluginNode(name, payload?)` factory, `instructionNode` gains an optional `plugins` array, and the `json` type expression renders as `unknown`. A `PluginNode` visitor test fixture is added to satisfy the coverage gate. All changes are additive and optional.