### PR TITLE
Search additional programs when identifying and parsing data

### DIFF
--- a/.changeset/tidy-melons-search.md
+++ b/.changeset/tidy-melons-search.md
@@ -1,0 +1,5 @@
+---
+'@codama/dynamic-parsers': minor
+---
+
+Search additional programs when identifying and parsing data. `parseInstruction` now uses the instruction's `programAddress` to restrict the search to the matching program, falling back to all programs when none matches. All `identify*` and `parse*` functions accept an optional `programAddress` option.

--- a/.changeset/tidy-melons-search.md
+++ b/.changeset/tidy-melons-search.md
@@ -2,4 +2,4 @@
 '@codama/dynamic-parsers': minor
 ---
 
-Search additional programs when identifying and parsing data. `parseInstruction` now uses the instruction's `programAddress` to restrict the search to the matching program, falling back to all programs when none matches. All `identify*` and `parse*` functions accept an optional `programAddress` option.
+Search additional programs when identifying and parsing data. `parseInstruction` now uses the instruction's `programAddress` to restrict the search to the matching program, and identifies nothing when no program of the root matches that address. All `identify*` and `parse*` functions accept an optional `programAddress` option.

--- a/packages/dynamic-parsers/README.md
+++ b/packages/dynamic-parsers/README.md
@@ -88,6 +88,16 @@ if (parsedData) {
 }
 ```
 
+Note that it uses the instruction's `programAddress` to restrict the search to the matching program — including any of the root node's `additionalPrograms` — falling back to all programs when none matches.
+
+## Program selection
+
+All functions above search the root node's main program as well as its `additionalPrograms`, in that order. Additionally, they all accept an optional `programAddress` option that restricts the search to the programs matching that address, if any.
+
+```ts
+const parsedData = parseInstructionData(rootNode, bytes, { programAddress: address });
+```
+
 ### `identifyAccountData`
 
 This function tries to match the provided bytes to an account node, returning a `NodePath<AccountNode>` object if the identification was successful, or `undefined` otherwise. It is used by the `parseAccountData` function under the hood.

--- a/packages/dynamic-parsers/README.md
+++ b/packages/dynamic-parsers/README.md
@@ -88,15 +88,17 @@ if (parsedData) {
 }
 ```
 
-Note that it uses the instruction's `programAddress` to restrict the search to the matching program — including any of the root node's `additionalPrograms` — falling back to all programs when none matches.
+Note that it uses the instruction's `programAddress` to restrict the search to the matching program — including any of the root node's `additionalPrograms`. When no program of the root matches that address, nothing is parsed: matching an unknown program against another program's candidates would confidently misattribute the data, which matters when the result is displayed to end users (e.g. clear signing).
 
 ## Program selection
 
-All functions above search the root node's main program as well as its `additionalPrograms`, in that order. Additionally, they all accept an optional `programAddress` option that restricts the search to the programs matching that address, if any.
+All functions above search the root node's main program as well as its `additionalPrograms`, in that order. Additionally, they all accept an optional `programAddress` option that restricts the search to the programs matching that address. When no program matches, nothing is identified.
 
 ```ts
 const parsedData = parseInstructionData(rootNode, bytes, { programAddress: address });
 ```
+
+The single-non-discriminated-candidate fallback follows the same selection when a `programAddress` is provided. Without one, it stays conservative and only applies to the main program, since bytes alone cannot tell which program a discriminator-less candidate belongs to.
 
 ### `identifyAccountData`
 

--- a/packages/dynamic-parsers/src/identify.ts
+++ b/packages/dynamic-parsers/src/identify.ts
@@ -2,6 +2,7 @@ import { CodecAndValueVisitors, getCodecAndValueVisitors, ReadonlyUint8Array } f
 import {
     AccountNode,
     EventNode,
+    getAllPrograms,
     GetNodeFromKind,
     InstructionNode,
     isNodeFilter,
@@ -25,31 +26,43 @@ import { matchDiscriminators } from './discriminators';
 
 type IdentifiableNodeKind = 'accountNode' | 'eventNode' | 'instructionNode';
 
+export type IdentifyDataOptions = {
+    /**
+     * When provided, restricts the search to the programs matching this address,
+     * if any. When no program matches the address, all programs are searched.
+     */
+    programAddress?: string;
+};
+
 export function identifyAccountData(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
+    options: IdentifyDataOptions = {},
 ): NodePath<AccountNode> | undefined {
-    return identifyData(root, bytes, 'accountNode');
+    return identifyData(root, bytes, 'accountNode', options);
 }
 
 export function identifyEventData(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
+    options: IdentifyDataOptions = {},
 ): NodePath<EventNode> | undefined {
-    return identifyData(root, bytes, 'eventNode');
+    return identifyData(root, bytes, 'eventNode', options);
 }
 
 export function identifyInstructionData(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
+    options: IdentifyDataOptions = {},
 ): NodePath<InstructionNode> | undefined {
-    return identifyData(root, bytes, 'instructionNode');
+    return identifyData(root, bytes, 'instructionNode', options);
 }
 
 export function identifyData<TKind extends IdentifiableNodeKind>(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
     kind?: TKind | TKind[],
+    options: IdentifyDataOptions = {},
 ): NodePath<GetNodeFromKind<TKind>> | undefined {
     const kinds = kind ?? (['accountNode', 'instructionNode', 'eventNode'] as TKind[]);
 
@@ -58,25 +71,32 @@ export function identifyData<TKind extends IdentifiableNodeKind>(
     visit(root, getRecordLinkablesVisitor(linkables));
 
     const codecAndValueVisitors = getCodecAndValueVisitors(linkables, { stack });
-    const visitor = getByteIdentificationVisitor(kinds, bytes, codecAndValueVisitors, { stack });
+    const visitor = getByteIdentificationVisitor(kinds, bytes, codecAndValueVisitors, {
+        programAddress: options.programAddress,
+        stack,
+    });
 
     const identified = visit(root, visitor);
     if (identified) return identified;
 
     // Fallback: When Node of given kind doesn't have a discriminator and is single then we can identify it.
     // Example: `Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH` program with single instruction omits a discriminator.
-    const candidates = getNodeCandidates(root.program, kinds);
-    if (candidates.length !== 1 || candidates[0].discriminators?.length) return undefined;
-    return [root, root.program, candidates[0]] as unknown as NodePath<GetNodeFromKind<TKind>>;
+    for (const program of getCandidatePrograms(root, options.programAddress)) {
+        const candidates = getNodeCandidates(program, kinds);
+        if (candidates.length !== 1 || candidates[0].discriminators?.length) continue;
+        return [root, program, candidates[0]] as unknown as NodePath<GetNodeFromKind<TKind>>;
+    }
+    return undefined;
 }
 
 export function getByteIdentificationVisitor<TKind extends IdentifiableNodeKind>(
     kind: TKind | TKind[],
     bytes: ReadonlyUint8Array | Uint8Array,
     codecAndValueVisitors: CodecAndValueVisitors,
-    options: { stack?: NodeStack } = {},
+    options: IdentifyDataOptions & { stack?: NodeStack } = {},
 ) {
     const stack = options.stack ?? new NodeStack();
+    const programAddress = options.programAddress;
 
     return pipe(
         {
@@ -109,7 +129,10 @@ export function getByteIdentificationVisitor<TKind extends IdentifiableNodeKind>
                 }
             },
             visitRoot(node) {
-                return visit(node.program, this);
+                for (const program of getCandidatePrograms(node, programAddress)) {
+                    const result = visit(program, this);
+                    if (result) return result;
+                }
             },
         } as Visitor<
             NodePath<GetNodeFromKind<TKind>> | undefined,
@@ -117,6 +140,13 @@ export function getByteIdentificationVisitor<TKind extends IdentifiableNodeKind>
         >,
         v => recordNodeStackVisitor(v, stack),
     );
+}
+
+function getCandidatePrograms(root: RootNode, programAddress?: string): ProgramNode[] {
+    const programs = getAllPrograms(root);
+    if (programAddress === undefined) return programs;
+    const matches = programs.filter(program => program.publicKey === programAddress);
+    return matches.length > 0 ? matches : programs;
 }
 
 function getNodeCandidates(

--- a/packages/dynamic-parsers/src/identify.ts
+++ b/packages/dynamic-parsers/src/identify.ts
@@ -28,8 +28,12 @@ type IdentifiableNodeKind = 'accountNode' | 'eventNode' | 'instructionNode';
 
 export type IdentifyDataOptions = {
     /**
-     * When provided, restricts the search to the programs matching this address,
-     * if any. When no program matches the address, all programs are searched.
+     * When provided, restricts the search to the programs matching this address.
+     * When no program matches the address, nothing is identified: bytes can
+     * legitimately match several programs of the same root (e.g. a token
+     * instruction and an ATA instruction sharing a one-byte discriminator), so
+     * matching a program we know nothing about against another program's
+     * candidates would confidently misattribute the data.
      */
     programAddress?: string;
 };
@@ -81,7 +85,12 @@ export function identifyData<TKind extends IdentifiableNodeKind>(
 
     // Fallback: When Node of given kind doesn't have a discriminator and is single then we can identify it.
     // Example: `Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH` program with single instruction omits a discriminator.
-    for (const program of getCandidatePrograms(root, options.programAddress)) {
+    // Without a program address the fallback stays conservative (main program only): bytes alone
+    // cannot tell which program a discriminator-less candidate belongs to.
+    const fallbackPrograms = options.programAddress
+        ? getCandidatePrograms(root, options.programAddress)
+        : [root.program];
+    for (const program of fallbackPrograms) {
         const candidates = getNodeCandidates(program, kinds);
         if (candidates.length !== 1 || candidates[0].discriminators?.length) continue;
         return [root, program, candidates[0]] as unknown as NodePath<GetNodeFromKind<TKind>>;
@@ -145,8 +154,7 @@ export function getByteIdentificationVisitor<TKind extends IdentifiableNodeKind>
 function getCandidatePrograms(root: RootNode, programAddress?: string): ProgramNode[] {
     const programs = getAllPrograms(root);
     if (programAddress === undefined) return programs;
-    const matches = programs.filter(program => program.publicKey === programAddress);
-    return matches.length > 0 ? matches : programs;
+    return programs.filter(program => program.publicKey === programAddress);
 }
 
 function getNodeCandidates(

--- a/packages/dynamic-parsers/src/parsers.ts
+++ b/packages/dynamic-parsers/src/parsers.ts
@@ -9,7 +9,7 @@ import type {
     InstructionWithData,
 } from '@solana/instructions';
 
-import { identifyData } from './identify';
+import { identifyData, IdentifyDataOptions } from './identify';
 
 type ParsableNode = AccountNode | EventNode | InstructionNode;
 type ParsableNodeKind = ParsableNode['kind'];
@@ -22,30 +22,39 @@ export type ParsedData<TNode extends ParsableNode> = {
 export function parseAccountData(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
+    options: IdentifyDataOptions = {},
 ): ParsedData<AccountNode> | undefined {
-    return parseData(root, bytes, 'accountNode');
+    return parseData(root, bytes, 'accountNode', options);
 }
 
 export function parseEventData(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
+    options: IdentifyDataOptions = {},
 ): ParsedData<EventNode> | undefined {
-    return parseData(root, bytes, 'eventNode');
+    return parseData(root, bytes, 'eventNode', options);
 }
 
 export function parseInstructionData(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
+    options: IdentifyDataOptions = {},
 ): ParsedData<InstructionNode> | undefined {
-    return parseData(root, bytes, 'instructionNode');
+    return parseData(root, bytes, 'instructionNode', options);
 }
 
 export function parseData<TKind extends ParsableNodeKind>(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
     kind?: TKind | TKind[],
+    options: IdentifyDataOptions = {},
 ): ParsedData<GetNodeFromKind<TKind>> | undefined {
-    const path = identifyData<TKind>(root, bytes, kind ?? (['accountNode', 'instructionNode', 'eventNode'] as TKind[]));
+    const path = identifyData<TKind>(
+        root,
+        bytes,
+        kind ?? (['accountNode', 'instructionNode', 'eventNode'] as TKind[]),
+        options,
+    );
     if (!path) return undefined;
     const codec = getNodeCodec(path as NodePath<ParsableNode>);
     const data = codec.decode(bytes);
@@ -68,7 +77,7 @@ export function parseInstruction(
         InstructionWithAccounts<readonly (AccountLookupMeta | AccountMeta)[]> &
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInstruction | undefined {
-    const parsedData = parseInstructionData(root, instruction.data);
+    const parsedData = parseInstructionData(root, instruction.data, { programAddress: instruction.programAddress });
     if (!parsedData) return undefined;
     const instructionNode = getLastNodeFromPath(parsedData.path);
     const accounts: ParsedInstructionAccounts = (instructionNode.accounts ?? []).flatMap((account, index) => {

--- a/packages/dynamic-parsers/src/parsers.ts
+++ b/packages/dynamic-parsers/src/parsers.ts
@@ -9,7 +9,7 @@ import type {
     InstructionWithData,
 } from '@solana/instructions';
 
-import { identifyData } from './identify';
+import { identifyData, IdentifyDataOptions } from './identify';
 
 type ParsableNode = AccountNode | EventNode | InstructionNode;
 type ParsableNodeKind = ParsableNode['kind'];
@@ -22,30 +22,39 @@ export type ParsedData<TNode extends ParsableNode> = {
 export function parseAccountData(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
+    options: IdentifyDataOptions = {},
 ): ParsedData<AccountNode> | undefined {
-    return parseData(root, bytes, 'accountNode');
+    return parseData(root, bytes, 'accountNode', options);
 }
 
 export function parseEventData(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
+    options: IdentifyDataOptions = {},
 ): ParsedData<EventNode> | undefined {
-    return parseData(root, bytes, 'eventNode');
+    return parseData(root, bytes, 'eventNode', options);
 }
 
 export function parseInstructionData(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
+    options: IdentifyDataOptions = {},
 ): ParsedData<InstructionNode> | undefined {
-    return parseData(root, bytes, 'instructionNode');
+    return parseData(root, bytes, 'instructionNode', options);
 }
 
 export function parseData<TKind extends ParsableNodeKind>(
     root: RootNode,
     bytes: ReadonlyUint8Array | Uint8Array,
     kind?: TKind | TKind[],
+    options: IdentifyDataOptions = {},
 ): ParsedData<GetNodeFromKind<TKind>> | undefined {
-    const path = identifyData<TKind>(root, bytes, kind ?? (['accountNode', 'instructionNode', 'eventNode'] as TKind[]));
+    const path = identifyData<TKind>(
+        root,
+        bytes,
+        kind ?? (['accountNode', 'instructionNode', 'eventNode'] as TKind[]),
+        options,
+    );
     if (!path) return undefined;
     const codec = getNodeCodec(path as NodePath<ParsableNode>);
     const data = codec.decode(bytes);
@@ -68,7 +77,7 @@ export function parseInstruction(
         InstructionWithAccounts<readonly (AccountLookupMeta | AccountMeta)[]> &
         InstructionWithData<ReadonlyUint8Array>,
 ): ParsedInstruction | undefined {
-    const parsedData = parseInstructionData(root, instruction.data);
+    const parsedData = parseInstructionData(root, instruction.data, { programAddress: instruction.programAddress });
     if (!parsedData) return undefined;
     const instructionNode = getLastNodeFromPath(parsedData.path);
     const accounts: ParsedInstructionAccounts = instructionNode.accounts.flatMap((account, index) => {

--- a/packages/dynamic-parsers/test/identify.test.ts
+++ b/packages/dynamic-parsers/test/identify.test.ts
@@ -73,16 +73,16 @@ describe('identifyAccountData', () => {
         const result = identifyAccountData(root, hex('ff010203'));
         expect(result).toStrictEqual([root, root.program, root.program.accounts[0]]);
     });
-    test('it does not identify accounts in additional programs', () => {
+    test('it identifies accounts in additional programs', () => {
         const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [
             programNode({
                 accounts: [accountNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myAccount' })],
-                name: 'myProgram',
-                publicKey: '1111',
+                name: 'myAdditionalProgram',
+                publicKey: '2222',
             }),
         ]);
         const result = identifyAccountData(root, hex('01020304'));
-        expect(result).toBeUndefined();
+        expect(result).toStrictEqual([root, root.additionalPrograms[0], root.additionalPrograms[0].accounts[0]]);
     });
     test('it does not identify accounts using instruction discriminators', () => {
         const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [
@@ -156,16 +156,100 @@ describe('identifyInstructionData', () => {
         const result = identifyInstructionData(root, hex('ff010203'));
         expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
     });
-    test('it does not identify instructions in additional programs', () => {
+    test('it identifies instructions in additional programs', () => {
         const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [
+            programNode({
+                instructions: [instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myInstruction' })],
+                name: 'myAdditionalProgram',
+                publicKey: '2222',
+            }),
+        ]);
+        const result = identifyInstructionData(root, hex('01020304'));
+        expect(result).toStrictEqual([root, root.additionalPrograms[0], root.additionalPrograms[0].instructions[0]]);
+    });
+    test('it identifies instructions in the main program before additional programs', () => {
+        // Given a main program and an additional program whose instructions both match the data.
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'mainInstruction' }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+            [
+                programNode({
+                    instructions: [
+                        instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'additionalInstruction' }),
+                    ],
+                    name: 'myAdditionalProgram',
+                    publicKey: '2222',
+                }),
+            ],
+        );
+        // When we identify the data without a program address.
+        const result = identifyInstructionData(root, hex('01020304'));
+        // Then we expect the main program's instruction to win.
+        expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
+    });
+    test('it restricts the search to programs matching the provided program address', () => {
+        // Given a main program and an additional program whose instructions both match the data.
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'mainInstruction' }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+            [
+                programNode({
+                    instructions: [
+                        instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'additionalInstruction' }),
+                    ],
+                    name: 'myAdditionalProgram',
+                    publicKey: '2222',
+                }),
+            ],
+        );
+        // When we identify the data using the additional program's address.
+        const result = identifyInstructionData(root, hex('01020304'), { programAddress: '2222' });
+        // Then we expect the additional program's instruction, not the main program's.
+        expect(result).toStrictEqual([root, root.additionalPrograms[0], root.additionalPrograms[0].instructions[0]]);
+    });
+    test('it searches all programs when no program matches the provided program address', () => {
+        const root = rootNode(
             programNode({
                 instructions: [instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myInstruction' })],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
-        ]);
-        const result = identifyInstructionData(root, hex('01020304'));
-        expect(result).toBeUndefined();
+        );
+        const result = identifyInstructionData(root, hex('01020304'), { programAddress: '9999' });
+        expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
+    });
+    test('it identifies a single non-discriminated instruction in an additional program as a fallback', () => {
+        // Given an additional program with exactly one non-discriminated instruction.
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'mainInstruction' }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+            [
+                programNode({
+                    instructions: [instructionNode({ name: 'additionalInstruction' })],
+                    name: 'myAdditionalProgram',
+                    publicKey: '2222',
+                }),
+            ],
+        );
+        // When we identify non-matching data using the additional program's address.
+        const result = identifyInstructionData(root, hex('0102030405'), { programAddress: '2222' });
+        // Then we expect the additional program's instruction to be identified as the fallback.
+        expect(result).toStrictEqual([root, root.additionalPrograms[0], root.additionalPrograms[0].instructions[0]]);
     });
     test('it does not identify instructions using account discriminators', () => {
         const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [

--- a/packages/dynamic-parsers/test/identify.test.ts
+++ b/packages/dynamic-parsers/test/identify.test.ts
@@ -72,16 +72,16 @@ describe('identifyAccountData', () => {
         const result = identifyAccountData(root, hex('ff010203'));
         expect(result).toStrictEqual([root, root.program, accountA]);
     });
-    test('it does not identify accounts in additional programs', () => {
+    test('it identifies accounts in additional programs', () => {
         const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [
             programNode({
                 accounts: [accountNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myAccount' })],
-                name: 'myProgram',
-                publicKey: '1111',
+                name: 'myAdditionalProgram',
+                publicKey: '2222',
             }),
         ]);
         const result = identifyAccountData(root, hex('01020304'));
-        expect(result).toBeUndefined();
+        expect(result).toStrictEqual([root, root.additionalPrograms[0], root.additionalPrograms[0].accounts[0]]);
     });
     test('it does not identify accounts using instruction discriminators', () => {
         const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [
@@ -156,16 +156,100 @@ describe('identifyInstructionData', () => {
         const result = identifyInstructionData(root, hex('ff010203'));
         expect(result).toStrictEqual([root, root.program, instructionA]);
     });
-    test('it does not identify instructions in additional programs', () => {
+    test('it identifies instructions in additional programs', () => {
         const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [
+            programNode({
+                instructions: [instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myInstruction' })],
+                name: 'myAdditionalProgram',
+                publicKey: '2222',
+            }),
+        ]);
+        const result = identifyInstructionData(root, hex('01020304'));
+        expect(result).toStrictEqual([root, root.additionalPrograms[0], root.additionalPrograms[0].instructions[0]]);
+    });
+    test('it identifies instructions in the main program before additional programs', () => {
+        // Given a main program and an additional program whose instructions both match the data.
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'mainInstruction' }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+            [
+                programNode({
+                    instructions: [
+                        instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'additionalInstruction' }),
+                    ],
+                    name: 'myAdditionalProgram',
+                    publicKey: '2222',
+                }),
+            ],
+        );
+        // When we identify the data without a program address.
+        const result = identifyInstructionData(root, hex('01020304'));
+        // Then we expect the main program's instruction to win.
+        expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
+    });
+    test('it restricts the search to programs matching the provided program address', () => {
+        // Given a main program and an additional program whose instructions both match the data.
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'mainInstruction' }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+            [
+                programNode({
+                    instructions: [
+                        instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'additionalInstruction' }),
+                    ],
+                    name: 'myAdditionalProgram',
+                    publicKey: '2222',
+                }),
+            ],
+        );
+        // When we identify the data using the additional program's address.
+        const result = identifyInstructionData(root, hex('01020304'), { programAddress: '2222' });
+        // Then we expect the additional program's instruction, not the main program's.
+        expect(result).toStrictEqual([root, root.additionalPrograms[0], root.additionalPrograms[0].instructions[0]]);
+    });
+    test('it searches all programs when no program matches the provided program address', () => {
+        const root = rootNode(
             programNode({
                 instructions: [instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myInstruction' })],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
-        ]);
-        const result = identifyInstructionData(root, hex('01020304'));
-        expect(result).toBeUndefined();
+        );
+        const result = identifyInstructionData(root, hex('01020304'), { programAddress: '9999' });
+        expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
+    });
+    test('it identifies a single non-discriminated instruction in an additional program as a fallback', () => {
+        // Given an additional program with exactly one non-discriminated instruction.
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'mainInstruction' }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+            [
+                programNode({
+                    instructions: [instructionNode({ name: 'additionalInstruction' })],
+                    name: 'myAdditionalProgram',
+                    publicKey: '2222',
+                }),
+            ],
+        );
+        // When we identify non-matching data using the additional program's address.
+        const result = identifyInstructionData(root, hex('0102030405'), { programAddress: '2222' });
+        // Then we expect the additional program's instruction to be identified as the fallback.
+        expect(result).toStrictEqual([root, root.additionalPrograms[0], root.additionalPrograms[0].instructions[0]]);
     });
     test('it does not identify instructions using account discriminators', () => {
         const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [

--- a/packages/dynamic-parsers/test/identify.test.ts
+++ b/packages/dynamic-parsers/test/identify.test.ts
@@ -73,15 +73,15 @@ describe('identifyAccountData', () => {
         expect(result).toStrictEqual([root, root.program, accountA]);
     });
     test('it identifies accounts in additional programs', () => {
-        const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [
-            programNode({
-                accounts: [accountNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myAccount' })],
-                name: 'myAdditionalProgram',
-                publicKey: '2222',
-            }),
-        ]);
+        const additionalAccount = accountNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myAccount' });
+        const additionalProgram = programNode({
+            accounts: [additionalAccount],
+            name: 'myAdditionalProgram',
+            publicKey: '2222',
+        });
+        const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [additionalProgram]);
         const result = identifyAccountData(root, hex('01020304'));
-        expect(result).toStrictEqual([root, root.additionalPrograms[0], root.additionalPrograms[0].accounts[0]]);
+        expect(result).toStrictEqual([root, additionalProgram, additionalAccount]);
     });
     test('it does not identify accounts using instruction discriminators', () => {
         const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [
@@ -157,43 +157,50 @@ describe('identifyInstructionData', () => {
         expect(result).toStrictEqual([root, root.program, instructionA]);
     });
     test('it identifies instructions in additional programs', () => {
-        const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [
+        const additionalInstruction = instructionNode({
+            discriminators: [sizeDiscriminatorNode(4)],
+            name: 'myInstruction',
+        });
+        const additionalProgram = programNode({
+            instructions: [additionalInstruction],
+            name: 'myAdditionalProgram',
+            publicKey: '2222',
+        });
+        const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [additionalProgram]);
+        const result = identifyInstructionData(root, hex('01020304'));
+        expect(result).toStrictEqual([root, additionalProgram, additionalInstruction]);
+    });
+    test('it identifies instructions in the main program before additional programs', () => {
+        // Given a main program and an additional program whose instructions both match the data.
+        const mainInstruction = instructionNode({
+            discriminators: [sizeDiscriminatorNode(4)],
+            name: 'mainInstruction',
+        });
+        const root = rootNode(programNode({ instructions: [mainInstruction], name: 'myProgram', publicKey: '1111' }), [
             programNode({
-                instructions: [instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myInstruction' })],
+                instructions: [
+                    instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'additionalInstruction' }),
+                ],
                 name: 'myAdditionalProgram',
                 publicKey: '2222',
             }),
         ]);
-        const result = identifyInstructionData(root, hex('01020304'));
-        expect(result).toStrictEqual([root, root.additionalPrograms[0], root.additionalPrograms[0].instructions[0]]);
-    });
-    test('it identifies instructions in the main program before additional programs', () => {
-        // Given a main program and an additional program whose instructions both match the data.
-        const root = rootNode(
-            programNode({
-                instructions: [
-                    instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'mainInstruction' }),
-                ],
-                name: 'myProgram',
-                publicKey: '1111',
-            }),
-            [
-                programNode({
-                    instructions: [
-                        instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'additionalInstruction' }),
-                    ],
-                    name: 'myAdditionalProgram',
-                    publicKey: '2222',
-                }),
-            ],
-        );
         // When we identify the data without a program address.
         const result = identifyInstructionData(root, hex('01020304'));
         // Then we expect the main program's instruction to win.
-        expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
+        expect(result).toStrictEqual([root, root.program, mainInstruction]);
     });
     test('it restricts the search to programs matching the provided program address', () => {
         // Given a main program and an additional program whose instructions both match the data.
+        const additionalInstruction = instructionNode({
+            discriminators: [sizeDiscriminatorNode(4)],
+            name: 'additionalInstruction',
+        });
+        const additionalProgram = programNode({
+            instructions: [additionalInstruction],
+            name: 'myAdditionalProgram',
+            publicKey: '2222',
+        });
         const root = rootNode(
             programNode({
                 instructions: [
@@ -202,22 +209,14 @@ describe('identifyInstructionData', () => {
                 name: 'myProgram',
                 publicKey: '1111',
             }),
-            [
-                programNode({
-                    instructions: [
-                        instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'additionalInstruction' }),
-                    ],
-                    name: 'myAdditionalProgram',
-                    publicKey: '2222',
-                }),
-            ],
+            [additionalProgram],
         );
         // When we identify the data using the additional program's address.
         const result = identifyInstructionData(root, hex('01020304'), { programAddress: '2222' });
         // Then we expect the additional program's instruction, not the main program's.
-        expect(result).toStrictEqual([root, root.additionalPrograms[0], root.additionalPrograms[0].instructions[0]]);
+        expect(result).toStrictEqual([root, additionalProgram, additionalInstruction]);
     });
-    test('it searches all programs when no program matches the provided program address', () => {
+    test('it identifies nothing when no program matches the provided program address', () => {
         const root = rootNode(
             programNode({
                 instructions: [instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myInstruction' })],
@@ -226,10 +225,17 @@ describe('identifyInstructionData', () => {
             }),
         );
         const result = identifyInstructionData(root, hex('01020304'), { programAddress: '9999' });
-        expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
+        expect(result).toBeUndefined();
     });
-    test('it identifies a single non-discriminated instruction in an additional program as a fallback', () => {
-        // Given an additional program with exactly one non-discriminated instruction.
+    test('it does not apply the fallback to additional programs without a program address', () => {
+        // Given a main program with a discriminated instruction and an additional
+        // program with a single non-discriminated instruction.
+        const additionalInstruction = instructionNode({ name: 'additionalInstruction' });
+        const additionalProgram = programNode({
+            instructions: [additionalInstruction],
+            name: 'myAdditionalProgram',
+            publicKey: '2222',
+        });
         const root = rootNode(
             programNode({
                 instructions: [
@@ -238,18 +244,40 @@ describe('identifyInstructionData', () => {
                 name: 'myProgram',
                 publicKey: '1111',
             }),
-            [
-                programNode({
-                    instructions: [instructionNode({ name: 'additionalInstruction' })],
-                    name: 'myAdditionalProgram',
-                    publicKey: '2222',
-                }),
-            ],
+            [additionalProgram],
+        );
+        // When we identify non-matching data without a program address, the fallback
+        // stays conservative and nothing is identified.
+        expect(identifyInstructionData(root, hex('0102030405'))).toBeUndefined();
+        // But scoping to the additional program identifies its single candidate.
+        expect(identifyInstructionData(root, hex('0102030405'), { programAddress: '2222' })).toStrictEqual([
+            root,
+            additionalProgram,
+            additionalInstruction,
+        ]);
+    });
+    test('it identifies a single non-discriminated instruction in an additional program as a fallback', () => {
+        // Given an additional program with exactly one non-discriminated instruction.
+        const additionalInstruction = instructionNode({ name: 'additionalInstruction' });
+        const additionalProgram = programNode({
+            instructions: [additionalInstruction],
+            name: 'myAdditionalProgram',
+            publicKey: '2222',
+        });
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'mainInstruction' }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+            [additionalProgram],
         );
         // When we identify non-matching data using the additional program's address.
         const result = identifyInstructionData(root, hex('0102030405'), { programAddress: '2222' });
         // Then we expect the additional program's instruction to be identified as the fallback.
-        expect(result).toStrictEqual([root, root.additionalPrograms[0], root.additionalPrograms[0].instructions[0]]);
+        expect(result).toStrictEqual([root, additionalProgram, additionalInstruction]);
     });
     test('it does not identify instructions using account discriminators', () => {
         const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [

--- a/packages/dynamic-parsers/test/parsers.test.ts
+++ b/packages/dynamic-parsers/test/parsers.test.ts
@@ -361,6 +361,71 @@ describe('parseInstruction', () => {
             path: [root, root.program, root.program.instructions[0]],
         });
     });
+
+    test('it parses an instruction from an additional program using the program address', () => {
+        // Given a token-shaped main program and an ATA-shaped additional program whose
+        // instructions share the same one-byte field discriminator.
+        const discriminator = (defaultValue: number) =>
+            instructionArgumentNode({
+                defaultValue: numberValueNode(defaultValue),
+                name: 'discriminator',
+                type: numberTypeNode('u8'),
+            });
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({
+                        accounts: [instructionAccountNode({ isSigner: false, isWritable: true, name: 'account' })],
+                        arguments: [discriminator(1)],
+                        discriminators: [fieldDiscriminatorNode('discriminator')],
+                        name: 'initializeAccount',
+                    }),
+                ],
+                name: 'token',
+                publicKey: '1111',
+            }),
+            [
+                programNode({
+                    instructions: [
+                        instructionNode({
+                            accounts: [
+                                instructionAccountNode({ isSigner: true, isWritable: true, name: 'payer' }),
+                                instructionAccountNode({ isSigner: false, isWritable: true, name: 'ata' }),
+                            ],
+                            arguments: [discriminator(1)],
+                            discriminators: [fieldDiscriminatorNode('discriminator')],
+                            name: 'createAssociatedTokenIdempotent',
+                        }),
+                    ],
+                    name: 'associatedToken',
+                    publicKey: '2222',
+                }),
+            ],
+        );
+
+        // And a concrete instruction targeting the additional program's address.
+        const instruction = {
+            accounts: [
+                { address: 'payer111', role: AccountRole.WRITABLE_SIGNER },
+                { address: 'ata11111', role: AccountRole.WRITABLE },
+            ],
+            data: hex('01'),
+            programAddress: '2222',
+        } as unknown as Parameters<typeof parseInstruction>[1];
+
+        // When we parse the instruction.
+        const result = parseInstruction(root, instruction);
+
+        // Then we expect the additional program's instruction, not the main program's.
+        expect(result).toStrictEqual({
+            accounts: [
+                { address: 'payer111', name: 'payer', role: AccountRole.WRITABLE_SIGNER },
+                { address: 'ata11111', name: 'ata', role: AccountRole.WRITABLE },
+            ],
+            data: { discriminator: 1 },
+            path: [root, root.additionalPrograms[0], root.additionalPrograms[0].instructions[0]],
+        });
+    });
 });
 
 describe('parseData', () => {

--- a/packages/dynamic-parsers/test/parsers.test.ts
+++ b/packages/dynamic-parsers/test/parsers.test.ts
@@ -350,6 +350,71 @@ describe('parseInstruction', () => {
             path: [root, root.program, memoInstruction],
         });
     });
+
+    test('it parses an instruction from an additional program using the program address', () => {
+        // Given a token-shaped main program and an ATA-shaped additional program whose
+        // instructions share the same one-byte field discriminator.
+        const discriminator = (defaultValue: number) =>
+            instructionArgumentNode({
+                defaultValue: numberValueNode(defaultValue),
+                name: 'discriminator',
+                type: numberTypeNode('u8'),
+            });
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({
+                        accounts: [instructionAccountNode({ isSigner: false, isWritable: true, name: 'account' })],
+                        arguments: [discriminator(1)],
+                        discriminators: [fieldDiscriminatorNode('discriminator')],
+                        name: 'initializeAccount',
+                    }),
+                ],
+                name: 'token',
+                publicKey: '1111',
+            }),
+            [
+                programNode({
+                    instructions: [
+                        instructionNode({
+                            accounts: [
+                                instructionAccountNode({ isSigner: true, isWritable: true, name: 'payer' }),
+                                instructionAccountNode({ isSigner: false, isWritable: true, name: 'ata' }),
+                            ],
+                            arguments: [discriminator(1)],
+                            discriminators: [fieldDiscriminatorNode('discriminator')],
+                            name: 'createAssociatedTokenIdempotent',
+                        }),
+                    ],
+                    name: 'associatedToken',
+                    publicKey: '2222',
+                }),
+            ],
+        );
+
+        // And a concrete instruction targeting the additional program's address.
+        const instruction = {
+            accounts: [
+                { address: 'payer111', role: AccountRole.WRITABLE_SIGNER },
+                { address: 'ata11111', role: AccountRole.WRITABLE },
+            ],
+            data: hex('01'),
+            programAddress: '2222',
+        } as unknown as Parameters<typeof parseInstruction>[1];
+
+        // When we parse the instruction.
+        const result = parseInstruction(root, instruction);
+
+        // Then we expect the additional program's instruction, not the main program's.
+        expect(result).toStrictEqual({
+            accounts: [
+                { address: 'payer111', name: 'payer', role: AccountRole.WRITABLE_SIGNER },
+                { address: 'ata11111', name: 'ata', role: AccountRole.WRITABLE },
+            ],
+            data: { discriminator: 1 },
+            path: [root, root.additionalPrograms[0], root.additionalPrograms[0].instructions[0]],
+        });
+    });
 });
 
 describe('parseData', () => {

--- a/packages/dynamic-parsers/test/parsers.test.ts
+++ b/packages/dynamic-parsers/test/parsers.test.ts
@@ -337,7 +337,7 @@ describe('parseInstruction', () => {
         const instruction = {
             accounts: [{ address: '1111', role: AccountRole.READONLY_SIGNER }],
             data: hex('48656c6c6f'),
-            programAddress: 'myProgramAddress',
+            programAddress: '1111',
         } as unknown as Parameters<typeof parseInstruction>[1];
 
         // When we parse the instruction.
@@ -360,6 +360,20 @@ describe('parseInstruction', () => {
                 name: 'discriminator',
                 type: numberTypeNode('u8'),
             });
+        const additionalInstruction = instructionNode({
+            accounts: [
+                instructionAccountNode({ isSigner: true, isWritable: true, name: 'payer' }),
+                instructionAccountNode({ isSigner: false, isWritable: true, name: 'ata' }),
+            ],
+            arguments: [discriminator(1)],
+            discriminators: [fieldDiscriminatorNode('discriminator')],
+            name: 'createAssociatedTokenIdempotent',
+        });
+        const additionalProgram = programNode({
+            instructions: [additionalInstruction],
+            name: 'associatedToken',
+            publicKey: '2222',
+        });
         const root = rootNode(
             programNode({
                 instructions: [
@@ -373,23 +387,7 @@ describe('parseInstruction', () => {
                 name: 'token',
                 publicKey: '1111',
             }),
-            [
-                programNode({
-                    instructions: [
-                        instructionNode({
-                            accounts: [
-                                instructionAccountNode({ isSigner: true, isWritable: true, name: 'payer' }),
-                                instructionAccountNode({ isSigner: false, isWritable: true, name: 'ata' }),
-                            ],
-                            arguments: [discriminator(1)],
-                            discriminators: [fieldDiscriminatorNode('discriminator')],
-                            name: 'createAssociatedTokenIdempotent',
-                        }),
-                    ],
-                    name: 'associatedToken',
-                    publicKey: '2222',
-                }),
-            ],
+            [additionalProgram],
         );
 
         // And a concrete instruction targeting the additional program's address.
@@ -412,8 +410,28 @@ describe('parseInstruction', () => {
                 { address: 'ata11111', name: 'ata', role: AccountRole.WRITABLE },
             ],
             data: { discriminator: 1 },
-            path: [root, root.additionalPrograms[0], root.additionalPrograms[0].instructions[0]],
+            path: [root, additionalProgram, additionalInstruction],
         });
+    });
+    test('it does not parse an instruction whose program is not part of the root', () => {
+        const root = rootNode(
+            programNode({
+                instructions: [
+                    instructionNode({
+                        arguments: [instructionArgumentNode({ name: 'value', type: numberTypeNode('u8') })],
+                        name: 'myInstruction',
+                    }),
+                ],
+                name: 'myProgram',
+                publicKey: '1111',
+            }),
+        );
+        const result = parseInstruction(root, {
+            accounts: [],
+            data: hex('01'),
+            programAddress: '9999',
+        } as unknown as Parameters<typeof parseInstruction>[1]);
+        expect(result).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
Fixes #553.

`identifyData` only visited the root node's main program, so instructions living in `additionalPrograms` (e.g. the ATA program embedded in the token IDLs) could never be identified and were misparsed against the main program's discriminators.

- The identification visitor now searches the main program first, then each additional program.
- `parseInstruction` passes the instruction's `programAddress` down, restricting the search to programs matching that address. When no program matches, all programs are searched, which keeps the existing behavior for roots whose program IDs are placeholders.
- The single-non-discriminated-node fallback applies the same program selection.
- All `identify*`/`parse*` functions accept an optional `programAddress` option.

With this, an ATA `createAssociatedTokenIdempotent` carried in a token IDL's additional programs parses through the ATA program instead of colliding with the token program's `initializeAccount` on the shared one-byte discriminator.