### PR TITLE
Omit empty node arrays and type array attributes as optional

### DIFF
--- a/.changeset/big-pens-make.md
+++ b/.changeset/big-pens-make.md
@@ -1,0 +1,10 @@
+---
+'@codama/node-types': minor
+'@codama/nodes': minor
+---
+
+Omit empty array attributes from nodes, and default absent arrays to `[]` on read.
+
+Every node array attribute — whether previously required (e.g. `programNode.accounts`, `instructionNode.arguments`, `structTypeNode.fields`) or optional (e.g. `instructionNode.discriminators`) — is now omitted from the node when empty, and defaults to `[]` when absent. An absent array and an empty array are semantically identical, so this keeps encoded IDLs small (they are often uploaded on-chain) and makes adding or omitting an array attribute non-breaking. Reading remains backwards-compatible: IDLs that still serialise empty arrays continue to parse, and every visitor and accessor normalises an absent array to `[]`.
+
+**Breaking type change.** While runtime reads stay backwards-compatible, this is a breaking change at the type level for external consumers such as renderers and community packages. Array attributes are now typed as optional on the node interfaces (e.g. `ProgramNode.accounts` is now `readonly accounts?: AccountNode[]`), so any code that reads an array attribute without guarding — e.g. `program.accounts.map(…)` — must now coalesce with `?? []` (`(program.accounts ?? []).map(…)`). Type-parameter constraints also widen from `Array<T>` to `Array<T> | undefined`, so indexing into these types (e.g. `InstructionNode['arguments'][number]`) must be rewritten as `NonNullable<InstructionNode['arguments']>[number]`. Consumers should expect compile errors on the first unguarded array read after upgrading and add `?? []` guards accordingly.

--- a/packages/dynamic-address-resolution/src/codegen/collect-pda-nodes.ts
+++ b/packages/dynamic-address-resolution/src/codegen/collect-pda-nodes.ts
@@ -10,8 +10,8 @@ export function collectPdaNodesFromIdl(idl: RootNode): Map<string, PdaNode> {
         pdas.set(pda.name, pda);
     }
 
-    for (const ix of idl.program.instructions) {
-        for (const acc of ix.accounts) {
+    for (const ix of idl.program.instructions ?? []) {
+        for (const acc of ix.accounts ?? []) {
             if (!acc.defaultValue || acc.defaultValue.kind !== 'pdaValueNode') continue;
             const pdaDef = acc.defaultValue.pda;
             if (!pdaDef || pdaDef.kind !== 'pdaNode') continue;

--- a/packages/dynamic-address-resolution/src/codegen/collect-resolver-names.ts
+++ b/packages/dynamic-address-resolution/src/codegen/collect-resolver-names.ts
@@ -6,10 +6,10 @@ import type { InstructionInputValueNode, InstructionNode } from 'codama';
 export function collectResolverNames(ix: InstructionNode): Set<string> {
     const names = new Set<string>();
 
-    for (const acc of ix.accounts) {
+    for (const acc of ix.accounts ?? []) {
         extractResolverNodeName(acc.defaultValue, names);
     }
-    for (const arg of ix.arguments) {
+    for (const arg of ix.arguments ?? []) {
         extractResolverNodeName(arg.defaultValue, names);
     }
 

--- a/packages/dynamic-address-resolution/src/codegen/generate-resolution-input-types.ts
+++ b/packages/dynamic-address-resolution/src/codegen/generate-resolution-input-types.ts
@@ -30,9 +30,9 @@ export const RESOLVER_FN_DECLARATION =
  */
 export function generateResolutionInputTypes(idl: RootNode): string {
     const definedTypes = idl.program.definedTypes ?? [];
-    const hasAnyResolvers = idl.program.instructions.some(ix => getResolutionRefs(ix).hasResolvers);
+    const hasAnyResolvers = (idl.program.instructions ?? []).some(ix => getResolutionRefs(ix).hasResolvers);
     let output = hasAnyResolvers ? RESOLVER_FN_DECLARATION : '';
-    for (const ix of idl.program.instructions) {
+    for (const ix of idl.program.instructions ?? []) {
         output += generateTypeBlockForInstruction(ix, definedTypes);
     }
     return output;
@@ -43,7 +43,7 @@ function generateTypeBlockForInstruction(ix: InstructionNode, definedTypes: Defi
     let output = '';
 
     if (refs.argsRef) {
-        const args = ix.arguments.filter(arg => arg.defaultValueStrategy !== 'omitted');
+        const args = (ix.arguments ?? []).filter(arg => arg.defaultValueStrategy !== 'omitted');
         const remainingAccountArgs = (ix.remainingAccounts ?? []).filter(ra => ra.value.kind === 'argumentValueNode');
         output += `export type ${refs.argsRef} = {\n`;
         for (const arg of args) {
@@ -59,9 +59,9 @@ function generateTypeBlockForInstruction(ix: InstructionNode, definedTypes: Defi
         output += '};\n\n';
     }
 
-    if (ix.accounts.length > 0) {
+    if ((ix.accounts ?? []).length > 0) {
         output += `export type ${refs.accountsRef} = {\n`;
-        for (const acc of ix.accounts) {
+        for (const acc of ix.accounts ?? []) {
             const omittable = isAccountAutoResolvable(acc) ? '?' : '';
             const type = acc.isOptional ? 'Address | null' : 'Address';
             output += `    ${acc.name}${omittable}: ${type};\n`;

--- a/packages/dynamic-address-resolution/src/codegen/get-resolution-refs.ts
+++ b/packages/dynamic-address-resolution/src/codegen/get-resolution-refs.ts
@@ -38,7 +38,7 @@ export type ResolutionRefs = {
 export function getResolutionRefs(ix: InstructionNode): ResolutionRefs {
     const typeName = pascalCase(ix.name);
 
-    const args = ix.arguments.filter(arg => arg.defaultValueStrategy !== 'omitted');
+    const args = (ix.arguments ?? []).filter(arg => arg.defaultValueStrategy !== 'omitted');
     const remainingAccountArgs = (ix.remainingAccounts ?? []).filter(ra => ra.value.kind === 'argumentValueNode');
     const hasArgs = args.length > 0 || remainingAccountArgs.length > 0;
     const hasRequiredArgs = args.some(arg => !OPTIONAL_NODE_KINDS.includes(arg.type.kind));

--- a/packages/dynamic-address-resolution/src/resolvers/resolve-account-value-node-address.ts
+++ b/packages/dynamic-address-resolution/src/resolvers/resolve-account-value-node-address.ts
@@ -33,7 +33,7 @@ export async function resolveAccountValueNodeAddress<
     }
 
     // Find the referenced account in the instruction.
-    const referencedIxAccountNode = ixNode.accounts.find(acc => acc.name === node.name);
+    const referencedIxAccountNode = (ixNode.accounts ?? []).find(acc => acc.name === node.name);
     if (!referencedIxAccountNode) {
         throw new CodamaError(CODAMA_ERROR__DYNAMIC_CLIENT__NODE_REFERENCE_NOT_FOUND, {
             instructionName: ixNode.name,

--- a/packages/dynamic-address-resolution/src/resolvers/resolve-pda-address.ts
+++ b/packages/dynamic-address-resolution/src/resolvers/resolve-pda-address.ts
@@ -50,11 +50,11 @@ export async function resolvePDAAddress<
         });
     }
 
-    const pdaNode = resolvePdaNode(pdaValueNode, root.program.pdas);
+    const pdaNode = resolvePdaNode(pdaValueNode, root.program.pdas ?? []);
     const programId = address(pdaNode.programId || root.program.publicKey);
 
     const seedValues = await Promise.all(
-        pdaNode.seeds.map(async seedNode => {
+        (pdaNode.seeds ?? []).map(async seedNode => {
             if (seedNode.kind === 'constantPdaSeedNode') {
                 return await resolveConstantPdaSeed({
                     accountsInput,
@@ -69,7 +69,7 @@ export async function resolvePDAAddress<
             }
 
             if (seedNode.kind === 'variablePdaSeedNode') {
-                const variableSeedValueNodes = pdaValueNode.seeds;
+                const variableSeedValueNodes = pdaValueNode.seeds ?? [];
                 const seedName = seedNode.name;
                 const variableSeedValueNode = variableSeedValueNodes.find(node => node.name === seedName);
 

--- a/packages/dynamic-address-resolution/src/resolvers/resolve-standalone-pda.ts
+++ b/packages/dynamic-address-resolution/src/resolvers/resolve-standalone-pda.ts
@@ -29,7 +29,7 @@ export async function resolveStandalonePda(
 ): Promise<ProgramDerivedAddress> {
     const programAddress = toAddress(pdaNode.programId || root.program.publicKey);
     const seedValues = await Promise.all(
-        pdaNode.seeds.map(async (seedNode): Promise<ReadonlyUint8Array> => {
+        (pdaNode.seeds ?? []).map(async (seedNode): Promise<ReadonlyUint8Array> => {
             if (seedNode.kind === 'constantPdaSeedNode') {
                 return await resolveStandaloneConstantSeed(programAddress, seedNode);
             }

--- a/packages/dynamic-address-resolution/src/visitors/codec-input-transformer.ts
+++ b/packages/dynamic-address-resolution/src/visitors/codec-input-transformer.ts
@@ -113,7 +113,7 @@ export function createCodecInputTransformerVisitor(
         },
 
         visitDefinedTypeLink(node) {
-            const definedType = root.program.definedTypes.find(dt => dt.name === node.name);
+            const definedType = (root.program.definedTypes ?? []).find(dt => dt.name === node.name);
             if (!definedType) {
                 throw new CodamaError(CODAMA_ERROR__LINKED_NODE_NOT_FOUND, {
                     kind: 'definedTypeLinkNode',
@@ -145,10 +145,10 @@ export function createCodecInputTransformerVisitor(
 
                 const { __kind, ...rest } = input;
                 const kindObj = { __kind: pascalCase(String(__kind)) };
-                const variantNode = node.variants.find(v => v.name === __kind);
+                const variantNode = (node.variants ?? []).find(v => v.name === __kind);
 
                 if (!variantNode) {
-                    const availableVariants = node.variants.map(v => v.name).join(', ');
+                    const availableVariants = (node.variants ?? []).map(v => v.name).join(', ');
                     throw new CodamaError(CODAMA_ERROR__DYNAMIC_CLIENT__UNEXPECTED_ARGUMENT_TYPE, {
                         actualType: `variant '${String(__kind)}'`,
                         expectedType: `one of [${availableVariants}]`,
@@ -289,7 +289,7 @@ export function createCodecInputTransformerVisitor(
         },
 
         visitStructType(node) {
-            const fieldTransformers = node.fields.map(field => {
+            const fieldTransformers = (node.fields ?? []).map(field => {
                 const transform = visitOrElse(field, visitor, unexpectedNodeFallback);
                 return { name: field.name, transform };
             });
@@ -312,7 +312,7 @@ export function createCodecInputTransformerVisitor(
         },
 
         visitTupleType(node) {
-            const itemTransforms = node.items.map(item => visitOrElse(item, visitor, unexpectedNodeFallback));
+            const itemTransforms = (node.items ?? []).map(item => visitOrElse(item, visitor, unexpectedNodeFallback));
             return (input: unknown) => {
                 if (!Array.isArray(input)) {
                     throw new CodamaError(CODAMA_ERROR__DYNAMIC_CLIENT__UNEXPECTED_ARGUMENT_TYPE, {

--- a/packages/dynamic-address-resolution/src/visitors/pda-seed-value.ts
+++ b/packages/dynamic-address-resolution/src/visitors/pda-seed-value.ts
@@ -102,7 +102,7 @@ export function createPdaSeedValueVisitor(
         },
 
         visitArgumentValue: async (node: ArgumentValueNode) => {
-            const ixArgumentNode = ixNode.arguments.find(arg => arg.name === node.name);
+            const ixArgumentNode = (ixNode.arguments ?? []).find(arg => arg.name === node.name);
             if (!ixArgumentNode) {
                 throw new CodamaError(CODAMA_ERROR__DYNAMIC_CLIENT__NODE_REFERENCE_NOT_FOUND, {
                     instructionName: ixNode.name,

--- a/packages/dynamic-address-resolution/src/visitors/value-node-value.ts
+++ b/packages/dynamic-address-resolution/src/visitors/value-node-value.ts
@@ -51,7 +51,7 @@ export function createValueNodeVisitor(): Visitor<ResolvedValue, ValueNodeSuppor
     const visitor: Visitor<ResolvedValue, ValueNodeSupportedNodeKind> = {
         visitArrayValue: (node: ArrayValueNode) => ({
             kind: node.kind,
-            value: node.items.map(item =>
+            value: (node.items ?? []).map(item =>
                 visitOrElse(item, visitor, n => {
                     throw new CodamaError(CODAMA_ERROR__UNEXPECTED_NODE_KIND, {
                         expectedKinds: [...VALUE_NODE_SUPPORTED_NODE_KINDS],
@@ -90,7 +90,7 @@ export function createValueNodeVisitor(): Visitor<ResolvedValue, ValueNodeSuppor
 
         visitMapValue: (node: MapValueNode) => ({
             kind: node.kind,
-            value: node.entries.map(entry => ({
+            value: (node.entries ?? []).map(entry => ({
                 key: visitOrElse(entry.key, visitor, n => {
                     throw new CodamaError(CODAMA_ERROR__UNEXPECTED_NODE_KIND, {
                         expectedKinds: [...VALUE_NODE_SUPPORTED_NODE_KINDS],
@@ -125,7 +125,7 @@ export function createValueNodeVisitor(): Visitor<ResolvedValue, ValueNodeSuppor
 
         visitSetValue: (node: SetValueNode) => ({
             kind: node.kind,
-            value: node.items.map(item =>
+            value: (node.items ?? []).map(item =>
                 visitOrElse(item, visitor, n => {
                     throw new CodamaError(CODAMA_ERROR__UNEXPECTED_NODE_KIND, {
                         expectedKinds: [...VALUE_NODE_SUPPORTED_NODE_KINDS],
@@ -154,7 +154,7 @@ export function createValueNodeVisitor(): Visitor<ResolvedValue, ValueNodeSuppor
         visitStructValue: (node: StructValueNode) => ({
             kind: node.kind,
             value: Object.fromEntries(
-                node.fields.map(field => [
+                (node.fields ?? []).map(field => [
                     field.name,
                     visitOrElse(field.value, visitor, n => {
                         throw new CodamaError(CODAMA_ERROR__UNEXPECTED_NODE_KIND, {
@@ -169,7 +169,7 @@ export function createValueNodeVisitor(): Visitor<ResolvedValue, ValueNodeSuppor
 
         visitTupleValue: (node: TupleValueNode) => ({
             kind: node.kind,
-            value: node.items.map(item =>
+            value: (node.items ?? []).map(item =>
                 visitOrElse(item, visitor, n => {
                     throw new CodamaError(CODAMA_ERROR__UNEXPECTED_NODE_KIND, {
                         expectedKinds: [...VALUE_NODE_SUPPORTED_NODE_KINDS],

--- a/packages/dynamic-address-resolution/test/resolvers/resolve-conditional.test.ts
+++ b/packages/dynamic-address-resolution/test/resolvers/resolve-conditional.test.ts
@@ -14,47 +14,45 @@ import { describe, expect, test } from 'vitest';
 
 import { resolveConditionalValueNodeCondition } from '../../src/resolvers/resolve-conditional';
 
+const sourceAccount = instructionAccountNode({
+    isSigner: false,
+    isWritable: true,
+    name: 'source',
+});
+const transferIx = instructionNode({
+    accounts: [
+        sourceAccount,
+        instructionAccountNode({
+            isSigner: false,
+            isWritable: true,
+            name: 'destination',
+        }),
+        instructionAccountNode({
+            defaultValue: identityValueNode(),
+            isSigner: 'either',
+            isWritable: false,
+            name: 'authority',
+        }),
+    ],
+    arguments: [
+        instructionArgumentNode({
+            name: 'amount',
+            type: numberTypeNode('u64'),
+        }),
+    ],
+    name: 'transfer',
+});
 const tokenRoot = rootNode(
     programNode({
-        instructions: [
-            instructionNode({
-                accounts: [
-                    instructionAccountNode({
-                        isSigner: false,
-                        isWritable: true,
-                        name: 'source',
-                    }),
-                    instructionAccountNode({
-                        isSigner: false,
-                        isWritable: true,
-                        name: 'destination',
-                    }),
-                    instructionAccountNode({
-                        defaultValue: identityValueNode(),
-                        isSigner: 'either',
-                        isWritable: false,
-                        name: 'authority',
-                    }),
-                ],
-                arguments: [
-                    instructionArgumentNode({
-                        name: 'amount',
-                        type: numberTypeNode('u64'),
-                    }),
-                ],
-                name: 'transfer',
-            }),
-        ],
+        instructions: [transferIx],
         name: 'splToken',
         publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
     }),
 );
 
-const transferIx = tokenRoot.program.instructions[0];
-
 describe('resolveConditionalValueNodeCondition: INVARIANT_VIOLATION', () => {
     test('should throw when conditionalValueNode has no value and no branches', async () => {
-        const ixAccountNode: InstructionAccountNode = transferIx.accounts[0];
+        const ixAccountNode: InstructionAccountNode = sourceAccount;
 
         const invalidConditional: ConditionalValueNode = {
             condition: { kind: 'accountValueNode', name: camelCase('source') },

--- a/packages/dynamic-client/src/cli/commands/generate-client-types/generate-client-types.ts
+++ b/packages/dynamic-client/src/cli/commands/generate-client-types/generate-client-types.ts
@@ -44,7 +44,7 @@ export type MethodBuilder<TAccounts, TSigners extends string[], TResolvers = Rec
     output += generateResolutionInputTypes(idl);
     output += generateSignerTypes(idl);
 
-    for (const ix of idl.program.instructions) {
+    for (const ix of idl.program.instructions ?? []) {
         const typeName = pascalCase(ix.name);
         const refs = getResolutionRefs(ix);
         const signerRef = getInstructionSignerRef(ix);
@@ -66,7 +66,7 @@ export type MethodBuilder<TAccounts, TSigners extends string[], TResolvers = Rec
  */
 export type ${programName}Methods = {\n`;
 
-    for (const ix of idl.program.instructions) {
+    for (const ix of idl.program.instructions ?? []) {
         const typeName = pascalCase(ix.name);
         output += `    ${ix.name}: ${typeName}Method;\n`;
     }

--- a/packages/dynamic-client/src/program-client/collect-pdas.ts
+++ b/packages/dynamic-client/src/program-client/collect-pdas.ts
@@ -10,12 +10,12 @@ import { isNode, type PdaNode, type RootNode } from 'codama';
 export function collectPdaNodes(root: RootNode): Map<string, PdaNode> {
     const pdas = new Map<string, PdaNode>();
 
-    for (const pda of root.program.pdas) {
+    for (const pda of root.program.pdas ?? []) {
         pdas.set(pda.name, pda);
     }
 
-    for (const ix of root.program.instructions) {
-        for (const acc of ix.accounts) {
+    for (const ix of root.program.instructions ?? []) {
+        for (const acc of ix.accounts ?? []) {
             if (!acc.defaultValue || !isNode(acc.defaultValue, 'pdaValueNode')) continue;
             if (!isNode(acc.defaultValue.pda, 'pdaNode')) continue;
             const pdaNode = acc.defaultValue.pda;

--- a/packages/dynamic-client/src/program-client/create-program-client.ts
+++ b/packages/dynamic-client/src/program-client/create-program-client.ts
@@ -75,7 +75,7 @@ export function createProgramClient<TClient = ProgramClient>(
     const programAddress = address(root.program.publicKey);
 
     const instructions = new Map<string, InstructionNode>();
-    for (const ix of root.program.instructions) {
+    for (const ix of root.program.instructions ?? []) {
         instructions.set(ix.name, ix);
     }
 

--- a/packages/dynamic-client/test/programs/anchor/tests/blog.test.ts
+++ b/packages/dynamic-client/test/programs/anchor/tests/blog.test.ts
@@ -362,7 +362,7 @@ describe('blog', () => {
     });
 
     function decodeAccount(name: string, pda: Address) {
-        const accountNode = programClient.root.program.accounts.find(a => a.name === name);
+        const accountNode = (programClient.root.program.accounts ?? []).find(a => a.name === name);
         if (!accountNode) throw new Error(`Account node "${name}" not found in IDL`);
 
         const codec = getNodeCodec([programClient.root, programClient.root.program, accountNode]);

--- a/packages/dynamic-client/test/programs/anchor/tests/example.test.ts
+++ b/packages/dynamic-client/test/programs/anchor/tests/example.test.ts
@@ -307,7 +307,7 @@ function decodeDataAccount1(
     root: RootNode,
     data: Uint8Array,
 ): { bump: number; input: bigint; optionalInput: string | null } {
-    const accountNode = root.program.accounts.find(a => a.name === 'dataAccount1');
+    const accountNode = (root.program.accounts ?? []).find(a => a.name === 'dataAccount1');
     if (!accountNode) {
         throw new Error('Could not find account node "dataAccount1" in IDL');
     }

--- a/packages/dynamic-client/test/programs/anchor/tests/nested-example-ix.test.ts
+++ b/packages/dynamic-client/test/programs/anchor/tests/nested-example-ix.test.ts
@@ -605,7 +605,7 @@ describe('anchor-example: nestedExampleIx', () => {
 });
 
 function decodeNestedExampleAccount(root: RootNode, data: Uint8Array) {
-    const accountNode = root.program.accounts.find(a => a.name === 'nestedExampleAccount');
+    const accountNode = (root.program.accounts ?? []).find(a => a.name === 'nestedExampleAccount');
     if (!accountNode) {
         throw new Error('Could not find account node "nestedExampleAccount" node in IDL');
     }

--- a/packages/dynamic-client/test/programs/collection-types/collection-types.test.ts
+++ b/packages/dynamic-client/test/programs/collection-types/collection-types.test.ts
@@ -8,7 +8,7 @@ import { createTestProgramClient, loadRoot, SvmTestContext } from '../test-utils
 const root = loadRoot('collection-types-idl.json');
 
 function decodeInstructionData(instructionName: string, data: ReadonlyUint8Array): unknown {
-    const ix = root.program.instructions.find(i => i.name === instructionName);
+    const ix = (root.program.instructions ?? []).find(i => i.name === instructionName);
     if (!ix) throw new Error(`Instruction ${instructionName} not found`);
 
     const codec = getNodeCodec([root, root.program, ix]);

--- a/packages/dynamic-codecs/src/codecs.ts
+++ b/packages/dynamic-codecs/src/codecs.ts
@@ -189,7 +189,7 @@ export function getNodeCodecVisitor(
             if (isScalarEnum(node)) {
                 return getEnumCodec(
                     Object.fromEntries(
-                        node.variants.flatMap((variant, index) => [
+                        (node.variants ?? []).flatMap((variant, index) => [
                             [variant.name, index],
                             [index, variant.name],
                         ]),
@@ -198,7 +198,9 @@ export function getNodeCodecVisitor(
                 ) as Codec<unknown>;
             }
             // Data enums are decoded as discriminated unions, e.g. `{ __kind: 'Move', x: 10, y: 20 }`.
-            const variants = node.variants.map(variant => [pascalCase(variant.name), visit(variant, this)] as const);
+            const variants = (node.variants ?? []).map(
+                variant => [pascalCase(variant.name), visit(variant, this)] as const,
+            );
             return getDiscriminatedUnionCodec(variants, { size }) as unknown as Codec<unknown>;
         },
         visitEvent(node) {
@@ -210,7 +212,7 @@ export function getNodeCodecVisitor(
         },
         visitHiddenPrefixType(node) {
             const type = visit(node.type, this);
-            const constants = node.prefix.map(constant => {
+            const constants = (node.prefix ?? []).map(constant => {
                 const constantCodec = visit(constant.type, this);
                 const constantValue = visit(constant.value, valueNodeVisitor);
                 return getConstantCodec(constantCodec.encode(constantValue));
@@ -219,7 +221,7 @@ export function getNodeCodecVisitor(
         },
         visitHiddenSuffixType(node) {
             const type = visit(node.type, this);
-            const constants = node.suffix.map(constant => {
+            const constants = (node.suffix ?? []).map(constant => {
                 const constantCodec = visit(constant.type, this);
                 const constantValue = visit(constant.value, valueNodeVisitor);
                 return getConstantCodec(constantCodec.encode(constantValue));
@@ -227,7 +229,7 @@ export function getNodeCodecVisitor(
             return getHiddenSuffixCodec(type, constants);
         },
         visitInstruction(node) {
-            return visit(structTypeNodeFromInstructionArgumentNodes(node.arguments), this);
+            return visit(structTypeNodeFromInstructionArgumentNodes(node.arguments ?? []), this);
         },
         visitInstructionArgument(node) {
             return visit(structFieldTypeNodeFromInstructionArgumentNode(node), this);
@@ -334,11 +336,11 @@ export function getNodeCodecVisitor(
             return visit(node.type, this);
         },
         visitStructType(node) {
-            const fields = node.fields.map(field => [field.name, visit(field, this)] as const);
+            const fields = (node.fields ?? []).map(field => [field.name, visit(field, this)] as const);
             return getStructCodec(fields) as Codec<unknown>;
         },
         visitTupleType(node) {
-            const items = node.items.map(item => visit(item, this));
+            const items = (node.items ?? []).map(item => visit(item, this));
             return getTupleCodec(items) as Codec<unknown>;
         },
         visitZeroableOptionType(node) {

--- a/packages/dynamic-codecs/src/values.ts
+++ b/packages/dynamic-codecs/src/values.ts
@@ -24,7 +24,7 @@ export function getValueNodeVisitor(
 
     const baseVisitor: Visitor<unknown, ValueNode['kind']> = {
         visitArrayValue(node) {
-            return node.items.map(item => visit(item, this));
+            return (node.items ?? []).map(item => visit(item, this));
         },
         visitBooleanValue(node) {
             return node.boolean;
@@ -42,7 +42,8 @@ export function getValueNodeVisitor(
         visitEnumValue(node) {
             const enumType = linkables.getOrThrow([...stack.getPath(node.kind), node.enum]).type;
             assertIsNode(enumType, 'enumTypeNode');
-            const variantIndex = enumType.variants.findIndex(variant => variant.name === node.variant);
+            const variants = enumType.variants ?? [];
+            const variantIndex = variants.findIndex(variant => variant.name === node.variant);
             if (variantIndex < 0) {
                 throw new CodamaError(CODAMA_ERROR__ENUM_VARIANT_NOT_FOUND, {
                     enum: node.enum,
@@ -50,7 +51,7 @@ export function getValueNodeVisitor(
                     variant: node.variant,
                 });
             }
-            const variant = enumType.variants[variantIndex];
+            const variant = variants[variantIndex];
             if (isScalarEnum(enumType)) return variantIndex;
             const kind = { __kind: pascalCase(node.variant) };
             if (isNode(variant, 'enumEmptyVariantTypeNode')) return kind;
@@ -76,7 +77,7 @@ export function getValueNodeVisitor(
         },
         visitMapValue(node) {
             return Object.fromEntries(
-                node.entries.map(entry => {
+                (node.entries ?? []).map(entry => {
                     const key = visit(entry.key, this);
                     const value = visit(entry.value, this);
                     return [key, value];
@@ -93,7 +94,7 @@ export function getValueNodeVisitor(
             return node.publicKey;
         },
         visitSetValue(node) {
-            return node.items.map(item => visit(item, this));
+            return (node.items ?? []).map(item => visit(item, this));
         },
         visitSomeValue(node) {
             const value = visit(node.value, this);
@@ -104,7 +105,7 @@ export function getValueNodeVisitor(
         },
         visitStructValue(node) {
             return Object.fromEntries(
-                node.fields.map(field => {
+                (node.fields ?? []).map(field => {
                     const name = field.name;
                     const value = visit(field.value, this);
                     return [name, value];
@@ -112,7 +113,7 @@ export function getValueNodeVisitor(
             );
         },
         visitTupleValue(node) {
-            return node.items.map(item => visit(item, this));
+            return (node.items ?? []).map(item => visit(item, this));
         },
     };
 

--- a/packages/dynamic-codecs/test/codecs/DefinedTypeLinkNode.test.ts
+++ b/packages/dynamic-codecs/test/codecs/DefinedTypeLinkNode.test.ts
@@ -13,19 +13,18 @@ import { hex } from '../_setup';
 
 test('it resolves the codec of defined type link nodes', () => {
     // Given an existing defined type and a LinkNode pointing to it.
+    const slotType = definedTypeNode({ name: 'slot', type: numberTypeNode('u64') });
+    const lastSlotType = definedTypeNode({ name: 'lastSlot', type: definedTypeLinkNode('slot') });
     const root = rootNode(
         programNode({
-            definedTypes: [
-                definedTypeNode({ name: 'slot', type: numberTypeNode('u64') }),
-                definedTypeNode({ name: 'lastSlot', type: definedTypeLinkNode('slot') }),
-            ],
+            definedTypes: [slotType, lastSlotType],
             name: 'myProgram',
             publicKey: '1111',
         }),
     );
 
     // When we get the codec for the defined type pointing to another defined type.
-    const codec = getNodeCodec([root, root.program, root.program.definedTypes[1]]);
+    const codec = getNodeCodec([root, root.program, lastSlotType]);
 
     // Then we expect the codec to match the linked defined type.
     expect(codec.encode(42)).toStrictEqual(hex('2a00000000000000'));
@@ -35,13 +34,12 @@ test('it resolves the codec of defined type link nodes', () => {
 test('it follows linked nodes using the correct paths', () => {
     // Given two link nodes designed so that the path would
     // fail if we did not save and restored linked paths.
+    const typeA = definedTypeNode({
+        name: 'typeA',
+        type: definedTypeLinkNode('typeB1', programLinkNode('programB')),
+    });
     const programA = programNode({
-        definedTypes: [
-            definedTypeNode({
-                name: 'typeA',
-                type: definedTypeLinkNode('typeB1', programLinkNode('programB')),
-            }),
-        ],
+        definedTypes: [typeA],
         name: 'programA',
         publicKey: '1111',
     });
@@ -56,7 +54,7 @@ test('it follows linked nodes using the correct paths', () => {
     const root = rootNode(programA, [programB]);
 
     // When we get the codec for the defined type in programA.
-    const codec = getNodeCodec([root, programA, programA.definedTypes[0]]);
+    const codec = getNodeCodec([root, programA, typeA]);
 
     // Then we expect the links in programB to be resolved correctly.
     expect(codec.encode(42)).toStrictEqual(hex('2a00000000000000'));

--- a/packages/dynamic-instructions/src/accounts/create-account-meta.ts
+++ b/packages/dynamic-instructions/src/accounts/create-account-meta.ts
@@ -47,7 +47,7 @@ export async function createAccountMeta<
 ): Promise<AccountMeta[]> {
     const programAddress = toAddress(root.program.publicKey);
     const resolvedAccounts = await Promise.all(
-        ixNode.accounts.map<Promise<ResolvedAccount>>(async ixAccountNode => {
+        (ixNode.accounts ?? []).map<Promise<ResolvedAccount>>(async ixAccountNode => {
             const finalAddress = await resolveInstructionAccountAddress<TAccounts, TArgs, TResolvers>({
                 accountsInput,
                 argumentsInput,

--- a/packages/dynamic-instructions/src/accounts/validate-accounts-input.ts
+++ b/packages/dynamic-instructions/src/accounts/validate-accounts-input.ts
@@ -17,7 +17,8 @@ import { createIxAccountsValidator } from '../validators';
  * Skips validation for instructions without accounts.
  */
 export function createAccountsInputValidator(ixNode: InstructionNode) {
-    const validator = ixNode.accounts.length ? createIxAccountsValidator(ixNode.accounts) : null;
+    const accounts = ixNode.accounts ?? [];
+    const validator = accounts.length ? createIxAccountsValidator(accounts) : null;
 
     return (accountsInput: AccountsInput = {}) => {
         if (!validator) return;

--- a/packages/dynamic-instructions/src/arguments/encode-instruction-arguments.ts
+++ b/packages/dynamic-instructions/src/arguments/encode-instruction-arguments.ts
@@ -31,7 +31,7 @@ export function encodeInstructionArguments<TArgs extends ArgumentsInput = Argume
     ix: InstructionNode,
     argumentsInput?: TArgs,
 ): ReadonlyUint8Array {
-    const chunks = ix.arguments.map(ixArgumentNode => {
+    const chunks = (ix.arguments ?? []).map(ixArgumentNode => {
         const input = argumentsInput?.[ixArgumentNode.name];
         const nodeCodec = getNodeCodec([root, root.program, ix, ixArgumentNode]);
         if (isOmittedArgument(ixArgumentNode)) {
@@ -48,7 +48,7 @@ export function encodeInstructionArguments<TArgs extends ArgumentsInput = Argume
 
 function encodeOmittedArgument(
     ix: InstructionNode,
-    ixArgumentNode: InstructionNode['arguments'][number],
+    ixArgumentNode: NonNullable<InstructionNode['arguments']>[number],
     nodeCodec: Codec<unknown>,
 ): ReadonlyUint8Array {
     const defaultValue = ixArgumentNode.defaultValue;
@@ -71,7 +71,7 @@ function encodeOmittedArgument(
 
 function encodeOptionalArgument(
     ix: InstructionNode,
-    ixArgumentNode: InstructionNode['arguments'][number],
+    ixArgumentNode: NonNullable<InstructionNode['arguments']>[number],
     nodeCodec: Codec<unknown>,
 ): ReadonlyUint8Array {
     try {
@@ -88,7 +88,7 @@ function encodeOptionalArgument(
 function encodeRequiredArgument(
     root: RootNode,
     ix: InstructionNode,
-    ixArgumentNode: InstructionNode['arguments'][number],
+    ixArgumentNode: NonNullable<InstructionNode['arguments']>[number],
     input: ArgumentsInput[string],
     nodeCodec: Codec<unknown>,
 ): ReadonlyUint8Array {

--- a/packages/dynamic-instructions/src/arguments/resolve-argument-from-custom-resolvers.ts
+++ b/packages/dynamic-instructions/src/arguments/resolve-argument-from-custom-resolvers.ts
@@ -28,7 +28,7 @@ export async function resolveArgumentDefaultsFromCustomResolvers<
 ): Promise<TArgs> {
     const resolvedArgumentsInput: Record<string, unknown> = { ...argumentsInput };
 
-    const allArguments = [...ixNode.arguments, ...(ixNode.extraArguments ?? [])];
+    const allArguments = [...(ixNode.arguments ?? []), ...(ixNode.extraArguments ?? [])];
     for (const argumentNode of allArguments) {
         if (resolvedArgumentsInput[argumentNode.name] !== undefined) continue;
         if (isOmittedArgument(argumentNode)) continue;

--- a/packages/dynamic-instructions/src/arguments/validate-arguments-input.ts
+++ b/packages/dynamic-instructions/src/arguments/validate-arguments-input.ts
@@ -16,9 +16,9 @@ import { isOmittedArgument } from './shared';
  * Optional validation allows undefined so custom resolvers will fill default values after validation.
  */
 export function createArgumentsInputValidator(root: RootNode, ixNode: InstructionNode) {
-    const requiredArguments = ixNode.arguments.filter(arg => arg?.defaultValueStrategy !== 'omitted');
+    const requiredArguments = (ixNode.arguments ?? []).filter(arg => arg?.defaultValueStrategy !== 'omitted');
     const validator = requiredArguments.length
-        ? createIxArgumentsValidator(ixNode.name, requiredArguments, root.program.definedTypes)
+        ? createIxArgumentsValidator(ixNode.name, requiredArguments, root.program.definedTypes ?? [])
         : null;
 
     return (argumentsInput: ArgumentsInput = {}) => {
@@ -80,7 +80,7 @@ function formatFailureValue(value: unknown): string {
  * Ensures that arguments with "omitted" defaultValueStrategy are not provided by the user (e.g. discriminator).
  */
 function validateOmittedArguments(ixNode: InstructionNode, argumentsInput: ArgumentsInput = {}) {
-    ixNode.arguments.filter(isOmittedArgument).forEach(ixArgumentNode => {
+    (ixNode.arguments ?? []).filter(isOmittedArgument).forEach(ixArgumentNode => {
         if (Object.hasOwn(argumentsInput, ixArgumentNode.name)) {
             throw new CodamaError(CODAMA_ERROR__DYNAMIC_CLIENT__FAILED_TO_VALIDATE_INPUT, {
                 message: 'Omitted argument must not be provided',

--- a/packages/dynamic-instructions/src/codegen/collect-either-signer-names.ts
+++ b/packages/dynamic-instructions/src/codegen/collect-either-signer-names.ts
@@ -4,5 +4,5 @@ import type { InstructionNode } from 'codama';
  * Collect the names of accounts on an instruction with `isSigner: 'either'`.
  */
 export function collectEitherSignerNames(ix: InstructionNode): string[] {
-    return ix.accounts.filter(acc => acc.isSigner === 'either').map(acc => acc.name);
+    return (ix.accounts ?? []).filter(acc => acc.isSigner === 'either').map(acc => acc.name);
 }

--- a/packages/dynamic-instructions/src/codegen/generate-instruction-builder.ts
+++ b/packages/dynamic-instructions/src/codegen/generate-instruction-builder.ts
@@ -17,7 +17,7 @@ export function generateInstructionBuildersMap(idl: RootNode): string {
  */
 export type ${programName}InstructionBuilders = {\n`;
 
-    for (const ix of idl.program.instructions) {
+    for (const ix of idl.program.instructions ?? []) {
         const refs = getResolutionRefs(ix);
         const signerRef = getInstructionSignerRef(ix);
         const argsGeneric = refs.argsRef ?? 'Record<string, never>';

--- a/packages/dynamic-instructions/src/codegen/generate-signer-types.ts
+++ b/packages/dynamic-instructions/src/codegen/generate-signer-types.ts
@@ -7,7 +7,7 @@ import { collectEitherSignerNames } from './collect-either-signer-names';
  */
 export function generateSignerTypes(idl: RootNode): string {
     let output = '';
-    for (const ix of idl.program.instructions) {
+    for (const ix of idl.program.instructions ?? []) {
         output += generateSignersTypeBlock(ix);
     }
     return output;

--- a/packages/dynamic-instructions/src/display/build-display-context.ts
+++ b/packages/dynamic-instructions/src/display/build-display-context.ts
@@ -72,7 +72,7 @@ function createAccountDataResolver(
     const instruction = getLastNodeFromPath(parsedInstruction.path);
     return (accountName, bytes) => {
         const target = camelCase(accountName);
-        const instructionAccount = instruction.accounts.find(account => account.name === target);
+        const instructionAccount = (instruction.accounts ?? []).find(account => account.name === target);
         if (!instructionAccount?.accountLink) return null;
 
         const linkPath = [...parsedInstruction.path, instructionAccount.accountLink] as NodePath<AccountLinkNode>;

--- a/packages/dynamic-instructions/src/display/format-argument-value.ts
+++ b/packages/dynamic-instructions/src/display/format-argument-value.ts
@@ -65,7 +65,7 @@ function formatEnumValue(enumType: EnumTypeNode, value: unknown): string {
     if (decodedName === null) return rawValue(value);
 
     // Scalar enums decode to the variant name as-is; data enum `__kind` is the PascalCase form.
-    const variant = enumType.variants.find(candidate =>
+    const variant = (enumType.variants ?? []).find(candidate =>
         isScalarEnum(enumType) ? candidate.name === decodedName : pascalCase(candidate.name) === decodedName,
     );
     if (!variant) return rawValue(value);

--- a/packages/dynamic-instructions/src/display/interpolate-intent.ts
+++ b/packages/dynamic-instructions/src/display/interpolate-intent.ts
@@ -43,7 +43,7 @@ async function resolvePlaceholder(root: string, name: string, displayContext: Di
     const { data, path } = displayContext.parsedInstruction;
     if (root === 'data') {
         const instruction = getLastNodeFromPath(path);
-        const argument = instruction.arguments.find(arg => arg.name === name);
+        const argument = (instruction.arguments ?? []).find(arg => arg.name === name);
         const decodedData = data as Record<string, unknown>;
         if (!argument || !(name in decodedData)) return null;
         const ownerPath = [...path, argument];

--- a/packages/dynamic-instructions/src/display/list-fallback.ts
+++ b/packages/dynamic-instructions/src/display/list-fallback.ts
@@ -25,7 +25,7 @@ import type { DisplayContext, DisplayField } from './types';
 export async function listFallback(displayContext: DisplayContext): Promise<DisplayField[]> {
     const instruction = getLastNodeFromPath(displayContext.parsedInstruction.path);
     const argumentFieldGroups = await Promise.all(
-        instruction.arguments.map(argument => argumentFields(argument, displayContext)),
+        (instruction.arguments ?? []).map(argument => argumentFields(argument, displayContext)),
     );
     return [...argumentFieldGroups.flat(), ...accountFields(displayContext)];
 }
@@ -63,7 +63,9 @@ async function flattenedFields(
     prefix: string | undefined,
     displayContext: DisplayContext,
 ): Promise<DisplayField[]> {
-    const visibleFields = struct.fields.filter(field => !isSkipped(field.display?.skip, field.name, displayContext));
+    const visibleFields = (struct.fields ?? []).filter(
+        field => !isSkipped(field.display?.skip, field.name, displayContext),
+    );
     return await Promise.all(
         visibleFields.map(async field => {
             const label = `${prefix ?? ''}${field.display?.label ?? titleCase(field.name)}`;
@@ -81,7 +83,7 @@ async function flattenedFields(
 /** Produces the display fields for the instruction's accounts. */
 function accountFields(displayContext: DisplayContext): DisplayField[] {
     const instruction = getLastNodeFromPath(displayContext.parsedInstruction.path);
-    return instruction.accounts.flatMap(account => {
+    return (instruction.accounts ?? []).flatMap(account => {
         if (isSkipped(account.display?.skip, account.name, displayContext)) return [];
         const address = displayContext.parsedInstruction.accounts.find(a => a.name === account.name)?.address;
         if (!address) return [];

--- a/packages/dynamic-instructions/src/display/resolve-consumed-members.ts
+++ b/packages/dynamic-instructions/src/display/resolve-consumed-members.ts
@@ -53,7 +53,7 @@ function collectInjectedKeys(displayContext: BaseDisplayContext): Set<string> {
     const keys = new Set<string>();
     const instructionPath = displayContext.parsedInstruction.path;
     const instruction = getLastNodeFromPath(instructionPath);
-    instruction.arguments.forEach(argument => {
+    (instruction.arguments ?? []).forEach(argument => {
         collectMemberInjectedKeys(
             argument.type,
             argument.display?.flatten ?? false,
@@ -85,7 +85,7 @@ function collectMemberInjectedKeys(
         addInjectedKey(resolved.type.display.decimals, keys);
         addInjectedKey(resolved.type.display.unit, keys);
     } else if (flatten && isNode(resolved.type, 'structTypeNode')) {
-        resolved.type.fields.forEach(field => {
+        (resolved.type.fields ?? []).forEach(field => {
             collectMemberInjectedKeys(field.type, false, [...resolved.ownerPath, field], keys, displayContext);
         });
     }

--- a/packages/dynamic-instructions/src/validators.ts
+++ b/packages/dynamic-instructions/src/validators.ts
@@ -144,7 +144,7 @@ function createValidatorForTypeNode(nodeName: string, node: TypeNode, definedTyp
             return keyValueValidator;
         }
         case 'structTypeNode': {
-            const structShape = node.fields.reduce<Record<string, StructUnknown>>((acc, field) => {
+            const structShape = (node.fields ?? []).reduce<Record<string, StructUnknown>>((acc, field) => {
                 acc[field.name] = createValidatorForTypeNode(
                     `${nodeName}_struct_${field.name}`,
                     field.type,
@@ -155,7 +155,7 @@ function createValidatorForTypeNode(nodeName: string, node: TypeNode, definedTyp
             return object(structShape) as StructUnknown;
         }
         case 'tupleTypeNode': {
-            const validators = node.items.map((typeNode, index) =>
+            const validators = (node.items ?? []).map((typeNode, index) =>
                 createValidatorForTypeNode(`${nodeName}_tuple${typeNode.kind}_${index}`, typeNode, definedTypes),
             );
             return tuple(validators as [StructUnknown, ...StructUnknown[]]) as StructUnknown;
@@ -190,7 +190,7 @@ function createValidatorForTypeNode(nodeName: string, node: TypeNode, definedTyp
             return createValidatorForTypeNode(`${nodeName}_size_prefix`, node.type, definedTypes);
         }
         case 'enumTypeNode': {
-            return EnumVariantValidator(nodeName, node.variants, definedTypes);
+            return EnumVariantValidator(nodeName, node.variants ?? [], definedTypes);
         }
         case 'amountTypeNode': {
             return AmountTypeValidator(nodeName);

--- a/packages/dynamic-instructions/test/accounts/create-account-meta.test.ts
+++ b/packages/dynamic-instructions/test/accounts/create-account-meta.test.ts
@@ -69,9 +69,10 @@ const transferIx = instructionNode({
 const transferRoot = makeRoot(transferIx);
 
 // initializeMint: 2 accounts, no remainingAccounts
+const initMintMintAccount = instructionAccountNode({ isSigner: false, isWritable: true, name: 'mint' });
 const initMintIx = instructionNode({
     accounts: [
-        instructionAccountNode({ isSigner: false, isWritable: true, name: 'mint' }),
+        initMintMintAccount,
         instructionAccountNode({
             defaultValue: publicKeyValueNode('SysvarRent111111111111111111111111111111111'),
             isSigner: false,
@@ -200,7 +201,7 @@ describe('createAccountMeta: remaining accounts', () => {
 describe('createAccountMeta: UNSUPPORTED_OPTIONAL_ACCOUNT_STRATEGY', () => {
     test('should throw when optionalAccountStrategy is unsupported', async () => {
         const optionalAccount = {
-            ...initMintIx.accounts[0],
+            ...initMintMintAccount,
             defaultValue: undefined,
             isOptional: true,
         };

--- a/packages/dynamic-instructions/test/arguments/encode-instruction-arguments.test.ts
+++ b/packages/dynamic-instructions/test/arguments/encode-instruction-arguments.test.ts
@@ -121,7 +121,7 @@ describe('encodeInstructionArguments', () => {
     test('should throw DEFAULT_VALUE_MISSING when omitted argument has no defaultValue', () => {
         const modifiedIx: InstructionNode = {
             ...writeIx,
-            arguments: writeIx.arguments.map(arg =>
+            arguments: (writeIx.arguments ?? []).map(arg =>
                 arg.name === 'discriminator' ? { ...arg, defaultValue: undefined } : arg,
             ),
         };

--- a/packages/dynamic-instructions/test/test-utils.ts
+++ b/packages/dynamic-instructions/test/test-utils.ts
@@ -189,7 +189,7 @@ export function makeParsedInstruction(
     accountAddresses: ReadonlyMap<string, Address> = new Map(),
 ): ParsedInstruction {
     return {
-        accounts: instruction.accounts.flatMap(account => {
+        accounts: (instruction.accounts ?? []).flatMap(account => {
             const address = accountAddresses.get(account.name);
             return address ? [{ address, name: account.name, role: AccountRole.READONLY }] : [];
         }),

--- a/packages/dynamic-parsers/src/discriminators.ts
+++ b/packages/dynamic-parsers/src/discriminators.ts
@@ -69,7 +69,7 @@ function matchFieldDiscriminator(
         });
     }
     const struct = typeNode as StructTypeNode;
-    const field = struct.fields.find(field => field.name === discriminator.name);
+    const field = (struct.fields ?? []).find(field => field.name === discriminator.name);
     if (!field) {
         throw new CodamaError(CODAMA_ERROR__DISCRIMINATOR_FIELD_NOT_FOUND, {
             field: discriminator.name,

--- a/packages/dynamic-parsers/src/identify.ts
+++ b/packages/dynamic-parsers/src/identify.ts
@@ -98,7 +98,7 @@ export function getByteIdentificationVisitor<TKind extends IdentifiableNodeKind>
             },
             visitInstruction(node) {
                 if (!node.discriminators) return;
-                const struct = structTypeNodeFromInstructionArgumentNodes(node.arguments);
+                const struct = structTypeNodeFromInstructionArgumentNodes(node.arguments ?? []);
                 const match = matchDiscriminators(bytes, node.discriminators, struct, codecAndValueVisitors);
                 return match ? stack.getPath(node.kind) : undefined;
             },
@@ -123,5 +123,7 @@ function getNodeCandidates(
     program: ProgramNode,
     kind: IdentifiableNodeKind | IdentifiableNodeKind[],
 ): (AccountNode | EventNode | InstructionNode)[] {
-    return [...program.accounts, ...program.events, ...program.instructions].filter(isNodeFilter(kind));
+    return [...(program.accounts ?? []), ...(program.events ?? []), ...(program.instructions ?? [])].filter(
+        isNodeFilter(kind),
+    );
 }

--- a/packages/dynamic-parsers/src/parsers.ts
+++ b/packages/dynamic-parsers/src/parsers.ts
@@ -71,7 +71,7 @@ export function parseInstruction(
     const parsedData = parseInstructionData(root, instruction.data);
     if (!parsedData) return undefined;
     const instructionNode = getLastNodeFromPath(parsedData.path);
-    const accounts: ParsedInstructionAccounts = instructionNode.accounts.flatMap((account, index) => {
+    const accounts: ParsedInstructionAccounts = (instructionNode.accounts ?? []).flatMap((account, index) => {
         const accountMeta = instruction.accounts[index];
         if (!accountMeta) return [];
         return [{ ...accountMeta, name: account.name }];

--- a/packages/dynamic-parsers/test/discriminators.test.ts
+++ b/packages/dynamic-parsers/test/discriminators.test.ts
@@ -122,8 +122,9 @@ describe('matchDiscriminators', () => {
             const discriminator = constantDiscriminatorNode(
                 constantValueNode(definedTypeLinkNode('typeB1', programLinkNode('programB')), numberValueNode(42)),
             );
+            const account = accountNode({ discriminators: [discriminator], name: 'myAccount' });
             const programA = programNode({
-                accounts: [accountNode({ discriminators: [discriminator], name: 'myAccount' })],
+                accounts: [account],
                 definedTypes: [
                     definedTypeNode({
                         name: 'typeA',
@@ -148,7 +149,7 @@ describe('matchDiscriminators', () => {
             visit(root, getRecordLinkablesVisitor(linkables));
 
             // And a stack keeping track of the current visited nodes.
-            const stack = new NodeStack([root, programA, programA.accounts[0]]);
+            const stack = new NodeStack([root, programA, account]);
             codecAndValueVisitors = getCodecAndValueVisitors(linkables, { stack });
 
             // When we match the discriminator which should resolve to a u32 number equal to 42.
@@ -244,8 +245,9 @@ describe('matchDiscriminators', () => {
                     type: definedTypeLinkNode('typeB1', programLinkNode('programB')),
                 }),
             ]);
+            const account = accountNode({ data: fields, discriminators: [discriminator], name: 'myAccount' });
             const programA = programNode({
-                accounts: [accountNode({ data: fields, discriminators: [discriminator], name: 'myAccount' })],
+                accounts: [account],
                 definedTypes: [
                     definedTypeNode({
                         name: 'typeA',
@@ -270,7 +272,7 @@ describe('matchDiscriminators', () => {
             visit(root, getRecordLinkablesVisitor(linkables));
 
             // And a stack keeping track of the current visited nodes.
-            const stack = new NodeStack([root, programA, programA.accounts[0]]);
+            const stack = new NodeStack([root, programA, account]);
             codecAndValueVisitors = getCodecAndValueVisitors(linkables, { stack });
 
             // When we match the discriminator which should resolve to a u32 number equal to 42.

--- a/packages/dynamic-parsers/test/identify.test.ts
+++ b/packages/dynamic-parsers/test/identify.test.ts
@@ -22,15 +22,16 @@ import { hex } from './_setup';
 
 describe('identifyAccountData', () => {
     test('it identifies an account using its discriminator nodes', () => {
+        const account = accountNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myAccount' });
         const root = rootNode(
             programNode({
-                accounts: [accountNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myAccount' })],
+                accounts: [account],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
         );
         const result = identifyAccountData(root, hex('01020304'));
-        expect(result).toStrictEqual([root, root.program, root.program.accounts[0]]);
+        expect(result).toStrictEqual([root, root.program, account]);
     });
     test('it fails to identify accounts whose discriminator nodes do not match the given data', () => {
         const root = rootNode(
@@ -45,33 +46,31 @@ describe('identifyAccountData', () => {
     });
     test('it identifies a single account without discriminators as a fallback', () => {
         // Given a program with exactly one account that has no discriminator nodes.
-        const root = rootNode(
-            programNode({ accounts: [accountNode({ name: 'myAccount' })], name: 'myProgram', publicKey: '1111' }),
-        );
+        const account = accountNode({ name: 'myAccount' });
+        const root = rootNode(programNode({ accounts: [account], name: 'myProgram', publicKey: '1111' }));
         // When we identify account data that matches no discriminator.
         const result = identifyAccountData(root, hex('01020304'));
         // Then we expect the sole non-discriminated account to be identified as the fallback.
-        expect(result).toStrictEqual([root, root.program, root.program.accounts[0]]);
+        expect(result).toStrictEqual([root, root.program, account]);
     });
     test('it identifies the first matching account if multiple accounts match', () => {
+        const accountA = accountNode({
+            discriminators: [sizeDiscriminatorNode(4)],
+            name: 'accountA',
+        });
+        const accountB = accountNode({
+            discriminators: [constantDiscriminatorNode(constantValueNodeFromBytes('base16', 'ff'))],
+            name: 'accountB',
+        });
         const root = rootNode(
             programNode({
-                accounts: [
-                    accountNode({
-                        discriminators: [sizeDiscriminatorNode(4)],
-                        name: 'accountA',
-                    }),
-                    accountNode({
-                        discriminators: [constantDiscriminatorNode(constantValueNodeFromBytes('base16', 'ff'))],
-                        name: 'accountB',
-                    }),
-                ],
+                accounts: [accountA, accountB],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
         );
         const result = identifyAccountData(root, hex('ff010203'));
-        expect(result).toStrictEqual([root, root.program, root.program.accounts[0]]);
+        expect(result).toStrictEqual([root, root.program, accountA]);
     });
     test('it does not identify accounts in additional programs', () => {
         const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [
@@ -99,15 +98,16 @@ describe('identifyAccountData', () => {
 
 describe('identifyInstructionData', () => {
     test('it identifies an instruction using its discriminator nodes', () => {
+        const instruction = instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myInstruction' });
         const root = rootNode(
             programNode({
-                instructions: [instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'myInstruction' })],
+                instructions: [instruction],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
         );
         const result = identifyInstructionData(root, hex('01020304'));
-        expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
+        expect(result).toStrictEqual([root, root.program, instruction]);
     });
     test('it fails to identify instructions whose discriminator nodes do not match the given data', () => {
         const root = rootNode(
@@ -124,9 +124,10 @@ describe('identifyInstructionData', () => {
     });
     test('it identifies a single instruction without discriminator as a fallback', () => {
         // Given a program with exactly one instruction that has no discriminator nodes.
+        const instruction = instructionNode({ name: 'myInstruction' });
         const root = rootNode(
             programNode({
-                instructions: [instructionNode({ name: 'myInstruction' })],
+                instructions: [instruction],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
@@ -134,27 +135,26 @@ describe('identifyInstructionData', () => {
         // When we identify instruction data that matches no discriminator.
         const result = identifyInstructionData(root, hex('01020304'));
         // Then we expect the single instruction to be identified as the fallback.
-        expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
+        expect(result).toStrictEqual([root, root.program, instruction]);
     });
     test('it identifies the first matching instruction if multiple instructions match', () => {
+        const instructionA = instructionNode({
+            discriminators: [sizeDiscriminatorNode(4)],
+            name: 'instructionA',
+        });
+        const instructionB = instructionNode({
+            discriminators: [constantDiscriminatorNode(constantValueNodeFromBytes('base16', 'ff'))],
+            name: 'instructionB',
+        });
         const root = rootNode(
             programNode({
-                instructions: [
-                    instructionNode({
-                        discriminators: [sizeDiscriminatorNode(4)],
-                        name: 'instructionA',
-                    }),
-                    instructionNode({
-                        discriminators: [constantDiscriminatorNode(constantValueNodeFromBytes('base16', 'ff'))],
-                        name: 'instructionB',
-                    }),
-                ],
+                instructions: [instructionA, instructionB],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
         );
         const result = identifyInstructionData(root, hex('ff010203'));
-        expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
+        expect(result).toStrictEqual([root, root.program, instructionA]);
     });
     test('it does not identify instructions in additional programs', () => {
         const root = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }), [
@@ -199,12 +199,13 @@ describe('identifyInstructionData', () => {
 
     test('it prefers a discriminator match over a fallback', () => {
         // Given a program with a instruction with discriminator and without.
+        const withDiscriminator = instructionNode({
+            discriminators: [sizeDiscriminatorNode(4)],
+            name: 'withDiscriminator',
+        });
         const root = rootNode(
             programNode({
-                instructions: [
-                    instructionNode({ discriminators: [sizeDiscriminatorNode(4)], name: 'withDiscriminator' }),
-                    instructionNode({ name: 'withoutDiscriminator' }),
-                ],
+                instructions: [withDiscriminator, instructionNode({ name: 'withoutDiscriminator' })],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
@@ -212,7 +213,7 @@ describe('identifyInstructionData', () => {
         // When we identify bytes that match the discriminator (length 4).
         const result = identifyInstructionData(root, hex('01020304'));
         // Then we expect the discriminated instruction, not the fallback.
-        expect(result).toStrictEqual([root, root.program, root.program.instructions[0]]);
+        expect(result).toStrictEqual([root, root.program, withDiscriminator]);
     });
 
     test('it does not identify via fallback more than one instructions without discriminator', () => {
@@ -233,21 +234,20 @@ describe('identifyInstructionData', () => {
 
 describe('identifyEventData', () => {
     test('it identifies an event using its discriminator nodes', () => {
+        const event = eventNode({
+            data: structTypeNode([]),
+            discriminators: [sizeDiscriminatorNode(4)],
+            name: 'myEvent',
+        });
         const root = rootNode(
             programNode({
-                events: [
-                    eventNode({
-                        data: structTypeNode([]),
-                        discriminators: [sizeDiscriminatorNode(4)],
-                        name: 'myEvent',
-                    }),
-                ],
+                events: [event],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
         );
         const result = identifyEventData(root, hex('01020304'));
-        expect(result).toStrictEqual([root, root.program, root.program.events[0]]);
+        expect(result).toStrictEqual([root, root.program, event]);
     });
     test('it fails to identify events whose discriminator nodes do not match the given data', () => {
         const root = rootNode(
@@ -268,9 +268,10 @@ describe('identifyEventData', () => {
     });
     test('it identifies a single event without discriminators as a fallback', () => {
         // Given a program with exactly one event that has no discriminator nodes.
+        const event = eventNode({ data: structTypeNode([]), name: 'myEvent' });
         const root = rootNode(
             programNode({
-                events: [eventNode({ data: structTypeNode([]), name: 'myEvent' })],
+                events: [event],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
@@ -278,7 +279,7 @@ describe('identifyEventData', () => {
         // When we identify event data that matches no discriminator.
         const result = identifyEventData(root, hex('01020304'));
         // Then we expect the single event to be identified as the fallback.
-        expect(result).toStrictEqual([root, root.program, root.program.events[0]]);
+        expect(result).toStrictEqual([root, root.program, event]);
     });
     test('it does not identify events using instruction discriminators', () => {
         const root = rootNode(
@@ -292,42 +293,39 @@ describe('identifyEventData', () => {
         expect(result).toBeUndefined();
     });
     test('it identifies tuple events using constant discriminators', () => {
+        const event = eventNode({
+            data: hiddenPrefixTypeNode(tupleTypeNode([numberTypeNode('u32')]), [
+                constantValueNode(fixedSizeTypeNode(bytesTypeNode(), 2), constantValueNodeFromBytes('base16', '0102')),
+            ]),
+            discriminators: [
+                constantDiscriminatorNode(
+                    constantValueNode(
+                        fixedSizeTypeNode(bytesTypeNode(), 2),
+                        constantValueNodeFromBytes('base16', '0102'),
+                    ),
+                ),
+            ],
+            name: 'tupleEvent',
+        });
         const root = rootNode(
             programNode({
-                events: [
-                    eventNode({
-                        data: hiddenPrefixTypeNode(tupleTypeNode([numberTypeNode('u32')]), [
-                            constantValueNode(
-                                fixedSizeTypeNode(bytesTypeNode(), 2),
-                                constantValueNodeFromBytes('base16', '0102'),
-                            ),
-                        ]),
-                        discriminators: [
-                            constantDiscriminatorNode(
-                                constantValueNode(
-                                    fixedSizeTypeNode(bytesTypeNode(), 2),
-                                    constantValueNodeFromBytes('base16', '0102'),
-                                ),
-                            ),
-                        ],
-                        name: 'tupleEvent',
-                    }),
-                ],
+                events: [event],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
         );
         const result = identifyEventData(root, hex('01022a000000'));
-        expect(result).toStrictEqual([root, root.program, root.program.events[0]]);
+        expect(result).toStrictEqual([root, root.program, event]);
     });
 });
 
 describe('identifyData', () => {
     test('it identifies via fallback single node without discriminator', () => {
         // Given a program with one account without discriminator.
+        const account = accountNode({ name: 'myAccount' });
         const root = rootNode(
             programNode({
-                accounts: [accountNode({ name: 'myAccount' })],
+                accounts: [account],
                 instructions: [instructionNode({ name: 'myInstruction' })],
                 name: 'myProgram',
                 publicKey: '1111',
@@ -336,7 +334,7 @@ describe('identifyData', () => {
         // When we identify only account node kind.
         const result = identifyData(root, hex('01020304'), 'accountNode');
         // Then we expect the single account to be identified as the fallback.
-        expect(result).toStrictEqual([root, root.program, root.program.accounts[0]]);
+        expect(result).toStrictEqual([root, root.program, account]);
     });
 
     test('it does not identify via fallback when trying to identify multiple node kinds without discriminator', () => {

--- a/packages/dynamic-parsers/test/parsers.test.ts
+++ b/packages/dynamic-parsers/test/parsers.test.ts
@@ -29,29 +29,28 @@ import { hex } from './_setup';
 
 describe('parseAccountData', () => {
     test('it parses some account data from a root node', () => {
+        const account = accountNode({
+            data: structTypeNode([
+                structFieldTypeNode({
+                    defaultValue: numberValueNode(9),
+                    name: 'discriminator',
+                    type: numberTypeNode('u8'),
+                }),
+                structFieldTypeNode({
+                    name: 'firstname',
+                    type: sizePrefixTypeNode(stringTypeNode('utf8'), numberTypeNode('u16')),
+                }),
+                structFieldTypeNode({
+                    name: 'age',
+                    type: numberTypeNode('u8'),
+                }),
+            ]),
+            discriminators: [fieldDiscriminatorNode('discriminator')],
+            name: 'myAccount',
+        });
         const root = rootNode(
             programNode({
-                accounts: [
-                    accountNode({
-                        data: structTypeNode([
-                            structFieldTypeNode({
-                                defaultValue: numberValueNode(9),
-                                name: 'discriminator',
-                                type: numberTypeNode('u8'),
-                            }),
-                            structFieldTypeNode({
-                                name: 'firstname',
-                                type: sizePrefixTypeNode(stringTypeNode('utf8'), numberTypeNode('u16')),
-                            }),
-                            structFieldTypeNode({
-                                name: 'age',
-                                type: numberTypeNode('u8'),
-                            }),
-                        ]),
-                        discriminators: [fieldDiscriminatorNode('discriminator')],
-                        name: 'myAccount',
-                    }),
-                ],
+                accounts: [account],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
@@ -59,20 +58,19 @@ describe('parseAccountData', () => {
         const result = parseAccountData(root, hex('090500416c6963652a'));
         expect(result).toStrictEqual({
             data: { age: 42, discriminator: 9, firstname: 'Alice' },
-            path: [root, root.program, root.program.accounts[0]],
+            path: [root, root.program, account],
         });
     });
 
     test('it decodes a single account without discriminator', () => {
         // Given a program with exactly one account without discriminator.
+        const account = accountNode({
+            data: structTypeNode([structFieldTypeNode({ name: 'value', type: numberTypeNode('u32') })]),
+            name: 'myAccount',
+        });
         const root = rootNode(
             programNode({
-                accounts: [
-                    accountNode({
-                        data: structTypeNode([structFieldTypeNode({ name: 'value', type: numberTypeNode('u32') })]),
-                        name: 'myAccount',
-                    }),
-                ],
+                accounts: [account],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
@@ -82,36 +80,35 @@ describe('parseAccountData', () => {
         // Then we expect the single account to be decoded via the fallback.
         expect(result).toStrictEqual({
             data: { value: 42 },
-            path: [root, root.program, root.program.accounts[0]],
+            path: [root, root.program, account],
         });
     });
 });
 
 describe('parseInstructionData', () => {
     test('it parses some instruction data from a root node', () => {
+        const instruction = instructionNode({
+            arguments: [
+                instructionArgumentNode({
+                    defaultValue: numberValueNode(9),
+                    name: 'discriminator',
+                    type: numberTypeNode('u8'),
+                }),
+                instructionArgumentNode({
+                    name: 'firstname',
+                    type: sizePrefixTypeNode(stringTypeNode('utf8'), numberTypeNode('u16')),
+                }),
+                instructionArgumentNode({
+                    name: 'age',
+                    type: numberTypeNode('u8'),
+                }),
+            ],
+            discriminators: [fieldDiscriminatorNode('discriminator')],
+            name: 'myInstruction',
+        });
         const root = rootNode(
             programNode({
-                instructions: [
-                    instructionNode({
-                        arguments: [
-                            instructionArgumentNode({
-                                defaultValue: numberValueNode(9),
-                                name: 'discriminator',
-                                type: numberTypeNode('u8'),
-                            }),
-                            instructionArgumentNode({
-                                name: 'firstname',
-                                type: sizePrefixTypeNode(stringTypeNode('utf8'), numberTypeNode('u16')),
-                            }),
-                            instructionArgumentNode({
-                                name: 'age',
-                                type: numberTypeNode('u8'),
-                            }),
-                        ],
-                        discriminators: [fieldDiscriminatorNode('discriminator')],
-                        name: 'myInstruction',
-                    }),
-                ],
+                instructions: [instruction],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
@@ -119,20 +116,19 @@ describe('parseInstructionData', () => {
         const result = parseInstructionData(root, hex('090500416c6963652a'));
         expect(result).toStrictEqual({
             data: { age: 42, discriminator: 9, firstname: 'Alice' },
-            path: [root, root.program, root.program.instructions[0]],
+            path: [root, root.program, instruction],
         });
     });
 
     test('it decodes a single instruction without discriminator', () => {
         // Given a program with exactly one instruction that has no discriminator (Memo-shaped).
+        const instruction = instructionNode({
+            arguments: [instructionArgumentNode({ name: 'message', type: stringTypeNode('utf8') })],
+            name: 'memo',
+        });
         const root = rootNode(
             programNode({
-                instructions: [
-                    instructionNode({
-                        arguments: [instructionArgumentNode({ name: 'message', type: stringTypeNode('utf8') })],
-                        name: 'memo',
-                    }),
-                ],
+                instructions: [instruction],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
@@ -144,7 +140,7 @@ describe('parseInstructionData', () => {
         // Then we expect instruction to be decoded.
         expect(result).toStrictEqual({
             data: { message: 'Hello' },
-            path: [root, root.program, root.program.instructions[0]],
+            path: [root, root.program, instruction],
         });
     });
 
@@ -237,29 +233,28 @@ describe('parseInstructionData', () => {
 
 describe('parseEventData', () => {
     test('it parses some event data from a root node', () => {
+        const event = eventNode({
+            data: structTypeNode([
+                structFieldTypeNode({
+                    defaultValue: numberValueNode(9),
+                    name: 'discriminator',
+                    type: numberTypeNode('u8'),
+                }),
+                structFieldTypeNode({
+                    name: 'firstname',
+                    type: sizePrefixTypeNode(stringTypeNode('utf8'), numberTypeNode('u16')),
+                }),
+                structFieldTypeNode({
+                    name: 'age',
+                    type: numberTypeNode('u8'),
+                }),
+            ]),
+            discriminators: [fieldDiscriminatorNode('discriminator')],
+            name: 'myEvent',
+        });
         const root = rootNode(
             programNode({
-                events: [
-                    eventNode({
-                        data: structTypeNode([
-                            structFieldTypeNode({
-                                defaultValue: numberValueNode(9),
-                                name: 'discriminator',
-                                type: numberTypeNode('u8'),
-                            }),
-                            structFieldTypeNode({
-                                name: 'firstname',
-                                type: sizePrefixTypeNode(stringTypeNode('utf8'), numberTypeNode('u16')),
-                            }),
-                            structFieldTypeNode({
-                                name: 'age',
-                                type: numberTypeNode('u8'),
-                            }),
-                        ]),
-                        discriminators: [fieldDiscriminatorNode('discriminator')],
-                        name: 'myEvent',
-                    }),
-                ],
+                events: [event],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
@@ -267,31 +262,27 @@ describe('parseEventData', () => {
         const result = parseEventData(root, hex('090500416c6963652a'));
         expect(result).toStrictEqual({
             data: { age: 42, discriminator: 9, firstname: 'Alice' },
-            path: [root, root.program, root.program.events[0]],
+            path: [root, root.program, event],
         });
     });
     test('it parses tuple event data from a root node', () => {
+        const event = eventNode({
+            data: hiddenPrefixTypeNode(tupleTypeNode([numberTypeNode('u32')]), [
+                constantValueNode(fixedSizeTypeNode(bytesTypeNode(), 2), constantValueNodeFromBytes('base16', '0102')),
+            ]),
+            discriminators: [
+                constantDiscriminatorNode(
+                    constantValueNode(
+                        fixedSizeTypeNode(bytesTypeNode(), 2),
+                        constantValueNodeFromBytes('base16', '0102'),
+                    ),
+                ),
+            ],
+            name: 'tupleEvent',
+        });
         const root = rootNode(
             programNode({
-                events: [
-                    eventNode({
-                        data: hiddenPrefixTypeNode(tupleTypeNode([numberTypeNode('u32')]), [
-                            constantValueNode(
-                                fixedSizeTypeNode(bytesTypeNode(), 2),
-                                constantValueNodeFromBytes('base16', '0102'),
-                            ),
-                        ]),
-                        discriminators: [
-                            constantDiscriminatorNode(
-                                constantValueNode(
-                                    fixedSizeTypeNode(bytesTypeNode(), 2),
-                                    constantValueNodeFromBytes('base16', '0102'),
-                                ),
-                            ),
-                        ],
-                        name: 'tupleEvent',
-                    }),
-                ],
+                events: [event],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
@@ -299,20 +290,19 @@ describe('parseEventData', () => {
         const result = parseEventData(root, hex('01022a000000'));
         expect(result).toStrictEqual({
             data: [42],
-            path: [root, root.program, root.program.events[0]],
+            path: [root, root.program, event],
         });
     });
 
     test('it decodes a single event without discriminator', () => {
         // Given a program with exactly one non-discriminated event.
+        const event = eventNode({
+            data: structTypeNode([structFieldTypeNode({ name: 'value', type: numberTypeNode('u32') })]),
+            name: 'myEvent',
+        });
         const root = rootNode(
             programNode({
-                events: [
-                    eventNode({
-                        data: structTypeNode([structFieldTypeNode({ name: 'value', type: numberTypeNode('u32') })]),
-                        name: 'myEvent',
-                    }),
-                ],
+                events: [event],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
@@ -322,7 +312,7 @@ describe('parseEventData', () => {
         // Then we expect the event to be decoded via the fallback.
         expect(result).toStrictEqual({
             data: { value: 42 },
-            path: [root, root.program, root.program.events[0]],
+            path: [root, root.program, event],
         });
     });
 });
@@ -330,15 +320,14 @@ describe('parseEventData', () => {
 describe('parseInstruction', () => {
     test('it parses a single instruction without discriminator', () => {
         // Given a Memo-shaped program: one instruction without discriminator with a single signer account.
+        const memoInstruction = instructionNode({
+            accounts: [instructionAccountNode({ isSigner: true, isWritable: false, name: 'signer' })],
+            arguments: [instructionArgumentNode({ name: 'message', type: stringTypeNode('utf8') })],
+            name: 'memo',
+        });
         const root = rootNode(
             programNode({
-                instructions: [
-                    instructionNode({
-                        accounts: [instructionAccountNode({ isSigner: true, isWritable: false, name: 'signer' })],
-                        arguments: [instructionArgumentNode({ name: 'message', type: stringTypeNode('utf8') })],
-                        name: 'memo',
-                    }),
-                ],
+                instructions: [memoInstruction],
                 name: 'myProgram',
                 publicKey: '1111',
             }),
@@ -358,7 +347,7 @@ describe('parseInstruction', () => {
         expect(result).toStrictEqual({
             accounts: [{ address: '1111', name: 'signer', role: AccountRole.READONLY_SIGNER }],
             data: { message: 'Hello' },
-            path: [root, root.program, root.program.instructions[0]],
+            path: [root, root.program, memoInstruction],
         });
     });
 });
@@ -366,14 +355,13 @@ describe('parseInstruction', () => {
 describe('parseData', () => {
     test('it decodes via fallback a single node without discriminator', () => {
         // Given a program with one account without discriminator.
+        const account = accountNode({
+            data: structTypeNode([structFieldTypeNode({ name: 'value', type: numberTypeNode('u32') })]),
+            name: 'myAccount',
+        });
         const root = rootNode(
             programNode({
-                accounts: [
-                    accountNode({
-                        data: structTypeNode([structFieldTypeNode({ name: 'value', type: numberTypeNode('u32') })]),
-                        name: 'myAccount',
-                    }),
-                ],
+                accounts: [account],
                 instructions: [
                     instructionNode({
                         arguments: [instructionArgumentNode({ name: 'message', type: stringTypeNode('utf8') })],
@@ -389,7 +377,7 @@ describe('parseData', () => {
         // Then we expect the single account to be decoded via the fallback.
         expect(result).toStrictEqual({
             data: { value: 42 },
-            path: [root, root.program, root.program.accounts[0]],
+            path: [root, root.program, account],
         });
     });
 

--- a/packages/library/test/index.test.ts
+++ b/packages/library/test/index.test.ts
@@ -1,6 +1,16 @@
 import { expect, test } from 'vitest';
 
-import { createFromRoot, identityVisitor, programNode, rootNode, rootNodeVisitor, voidVisitor } from '../src';
+import {
+    CODAMA_VERSION,
+    createFromJson,
+    createFromRoot,
+    getAllInstructions,
+    identityVisitor,
+    programNode,
+    rootNode,
+    rootNodeVisitor,
+    voidVisitor,
+} from '../src';
 
 test('it exports node helpers', () => {
     expect(typeof rootNode).toBe('function');
@@ -22,4 +32,35 @@ test('it updates the root node returned by visitors', () => {
     const visitor = rootNodeVisitor(node => rootNode(programNode({ ...node.program, name: 'myTransformedProgram' })));
     codama.update(visitor) satisfies void;
     expect(codama.getRoot()).toEqual(rootNode(programNode({ name: 'myTransformedProgram', publicKey: '1111' })));
+});
+
+test('it reads an IDL that omits every array attribute without throwing (skip-when-empty)', () => {
+    // A minimal IDL that omits every (formerly-required) array attribute. An
+    // absent array is semantically identical to an empty one, so readers must
+    // tolerate it (see the "Array attributes are omitted when empty" convention
+    // in the `@codama/spec` README).
+    const json = JSON.stringify({
+        kind: 'rootNode',
+        program: {
+            kind: 'programNode',
+            name: 'myProgram',
+            publicKey: '1111',
+            version: '1.0.0',
+        },
+        standard: 'codama',
+        version: CODAMA_VERSION,
+    });
+
+    const codama = createFromJson(json);
+
+    // A downstream accessor normalises the absent array to `[]` rather than throwing.
+    expect(getAllInstructions(codama.getRoot())).toEqual([]);
+
+    // Running the identity visitor over the partial IDL does not throw and
+    // re-serialises without re-introducing empty arrays (key order aside).
+    codama.update(identityVisitor());
+    const reserialised = JSON.parse(codama.getJson()) as { program: Record<string, unknown> };
+    expect(reserialised).toEqual(JSON.parse(json) as unknown);
+    expect('accounts' in reserialised.program).toBe(false);
+    expect('instructions' in reserialised.program).toBe(false);
 });

--- a/packages/node-types/src/generated/InstructionNode.ts
+++ b/packages/node-types/src/generated/InstructionNode.ts
@@ -15,8 +15,8 @@ type SelfInstructionNode = InstructionNode;
 
 /** A program instruction: its accounts, arguments, byte-delta hints, discriminators, optional status, and optional sub-instructions. */
 export interface InstructionNode<
-    TAccounts extends Array<InstructionAccountNode> = Array<InstructionAccountNode>,
-    TArguments extends Array<InstructionArgumentNode> = Array<InstructionArgumentNode>,
+    TAccounts extends Array<InstructionAccountNode> | undefined = Array<InstructionAccountNode> | undefined,
+    TArguments extends Array<InstructionArgumentNode> | undefined = Array<InstructionArgumentNode> | undefined,
     TExtraArguments extends Array<InstructionArgumentNode> | undefined = Array<InstructionArgumentNode> | undefined,
     TRemainingAccounts extends Array<InstructionRemainingAccountsNode> | undefined =
         | Array<InstructionRemainingAccountsNode>
@@ -41,9 +41,9 @@ export interface InstructionNode<
 
     // Children.
     /** The accounts the instruction operates on, in order. */
-    readonly accounts: TAccounts;
+    readonly accounts?: TAccounts;
     /** The serialised arguments of the instruction, in order. */
-    readonly arguments: TArguments;
+    readonly arguments?: TArguments;
     /** Additional arguments exposed in the generated client API but not serialised on the wire. */
     readonly extraArguments?: TExtraArguments;
     /** Variable-length tails of accounts appended after the named account slots. */

--- a/packages/node-types/src/generated/PdaNode.ts
+++ b/packages/node-types/src/generated/PdaNode.ts
@@ -3,7 +3,7 @@ import type { Docs } from '../Docs';
 import type { PdaSeedNode } from './pdaSeedNodes/PdaSeedNode';
 
 /** A program-derived address: its name, optional program ID override, and the seeds used to derive it. */
-export interface PdaNode<TSeeds extends Array<PdaSeedNode> = Array<PdaSeedNode>> {
+export interface PdaNode<TSeeds extends Array<PdaSeedNode> | undefined = Array<PdaSeedNode> | undefined> {
     readonly kind: 'pdaNode';
 
     // Data.
@@ -16,5 +16,5 @@ export interface PdaNode<TSeeds extends Array<PdaSeedNode> = Array<PdaSeedNode>>
 
     // Children.
     /** The seeds used to derive the PDA, in order. */
-    readonly seeds: TSeeds;
+    readonly seeds?: TSeeds;
 }

--- a/packages/node-types/src/generated/ProgramNode.ts
+++ b/packages/node-types/src/generated/ProgramNode.ts
@@ -12,13 +12,13 @@ import type { ProgramOrigin } from './shared/programOrigin';
 
 /** A Solana program: its identity, version, accounts, instructions, defined types, PDAs, events, errors, and constants. */
 export interface ProgramNode<
-    TPdas extends Array<PdaNode> = Array<PdaNode>,
-    TAccounts extends Array<AccountNode> = Array<AccountNode>,
-    TInstructions extends Array<InstructionNode> = Array<InstructionNode>,
-    TDefinedTypes extends Array<DefinedTypeNode> = Array<DefinedTypeNode>,
-    TErrors extends Array<ErrorNode> = Array<ErrorNode>,
-    TEvents extends Array<EventNode> = Array<EventNode>,
-    TConstants extends Array<ConstantNode> = Array<ConstantNode>,
+    TPdas extends Array<PdaNode> | undefined = Array<PdaNode> | undefined,
+    TAccounts extends Array<AccountNode> | undefined = Array<AccountNode> | undefined,
+    TInstructions extends Array<InstructionNode> | undefined = Array<InstructionNode> | undefined,
+    TDefinedTypes extends Array<DefinedTypeNode> | undefined = Array<DefinedTypeNode> | undefined,
+    TErrors extends Array<ErrorNode> | undefined = Array<ErrorNode> | undefined,
+    TEvents extends Array<EventNode> | undefined = Array<EventNode> | undefined,
+    TConstants extends Array<ConstantNode> | undefined = Array<ConstantNode> | undefined,
 > {
     readonly kind: 'programNode';
 
@@ -36,17 +36,17 @@ export interface ProgramNode<
 
     // Children.
     /** The accounts owned by the program. */
-    readonly accounts: TAccounts;
+    readonly accounts?: TAccounts;
     /** The instructions exposed by the program. */
-    readonly instructions: TInstructions;
+    readonly instructions?: TInstructions;
     /** The reusable types defined by the program. */
-    readonly definedTypes: TDefinedTypes;
+    readonly definedTypes?: TDefinedTypes;
     /** The PDAs derived by the program. */
-    readonly pdas: TPdas;
+    readonly pdas?: TPdas;
     /** The events emitted by the program. */
-    readonly events: TEvents;
+    readonly events?: TEvents;
     /** The errors returned by the program. */
-    readonly errors: TErrors;
+    readonly errors?: TErrors;
     /** The constants exposed by the program. */
-    readonly constants: TConstants;
+    readonly constants?: TConstants;
 }

--- a/packages/node-types/src/generated/RootNode.ts
+++ b/packages/node-types/src/generated/RootNode.ts
@@ -7,7 +7,7 @@ import type { CodamaVersion } from './shared/codamaVersion';
  */
 export interface RootNode<
     TProgram extends ProgramNode = ProgramNode,
-    TAdditionalPrograms extends Array<ProgramNode> = Array<ProgramNode>,
+    TAdditionalPrograms extends Array<ProgramNode> | undefined = Array<ProgramNode> | undefined,
 > {
     readonly kind: 'rootNode';
 
@@ -21,5 +21,5 @@ export interface RootNode<
     /** The primary program described by the document. */
     readonly program: TProgram;
     /** Additional programs referenced by the primary program. */
-    readonly additionalPrograms: TAdditionalPrograms;
+    readonly additionalPrograms?: TAdditionalPrograms;
 }

--- a/packages/node-types/src/generated/contextualValueNodes/PdaValueNode.ts
+++ b/packages/node-types/src/generated/contextualValueNodes/PdaValueNode.ts
@@ -4,7 +4,7 @@ import type { PdaValueProgramId } from './PdaValueProgramId';
 
 /** Resolves to a PDA derived from a list of seed values. */
 export interface PdaValueNode<
-    TSeeds extends Array<PdaSeedValueNode> = Array<PdaSeedValueNode>,
+    TSeeds extends Array<PdaSeedValueNode> | undefined = Array<PdaSeedValueNode> | undefined,
     TProgramId extends PdaValueProgramId | undefined = PdaValueProgramId | undefined,
     TPda extends PdaValuePda = PdaValuePda,
 > {
@@ -14,7 +14,7 @@ export interface PdaValueNode<
     /** The PDA being derived — either a link to a defined PDA or an inline `pdaNode`. */
     readonly pda: TPda;
     /** The seed values used to derive the PDA, paired with their seed names. */
-    readonly seeds: TSeeds;
+    readonly seeds?: TSeeds;
     /** The program ID used to derive the PDA. When omitted, the PDA’s declared program is used. */
     readonly programId?: TProgramId;
 }

--- a/packages/node-types/src/generated/typeNodes/EnumTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/EnumTypeNode.ts
@@ -4,14 +4,14 @@ import type { NumberTypeNode } from './NumberTypeNode';
 
 /** A tagged union: a numeric discriminator followed by one of several variant payloads. */
 export interface EnumTypeNode<
-    TVariants extends Array<EnumVariantTypeNode> = Array<EnumVariantTypeNode>,
+    TVariants extends Array<EnumVariantTypeNode> | undefined = Array<EnumVariantTypeNode> | undefined,
     TSize extends NestedTypeNode<NumberTypeNode> = NestedTypeNode<NumberTypeNode>,
 > {
     readonly kind: 'enumTypeNode';
 
     // Children.
     /** The variants of the enum, in declaration order. */
-    readonly variants: TVariants;
+    readonly variants?: TVariants;
     /** The numeric type used to serialise the discriminator. */
     readonly size: TSize;
 }

--- a/packages/node-types/src/generated/typeNodes/HiddenPrefixTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/HiddenPrefixTypeNode.ts
@@ -4,7 +4,7 @@ import type { TypeNode } from './TypeNode';
 /** Prefixes another type with a list of constant values that are written and read but not surfaced as fields to consumers. */
 export interface HiddenPrefixTypeNode<
     TType extends TypeNode = TypeNode,
-    TPrefix extends Array<ConstantValueNode> = Array<ConstantValueNode>,
+    TPrefix extends Array<ConstantValueNode> | undefined = Array<ConstantValueNode> | undefined,
 > {
     readonly kind: 'hiddenPrefixTypeNode';
 
@@ -12,5 +12,5 @@ export interface HiddenPrefixTypeNode<
     /** The wrapped type whose serialisation is preceded by the hidden prefix. */
     readonly type: TType;
     /** The constant values written before the wrapped type, in order. */
-    readonly prefix: TPrefix;
+    readonly prefix?: TPrefix;
 }

--- a/packages/node-types/src/generated/typeNodes/HiddenSuffixTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/HiddenSuffixTypeNode.ts
@@ -4,7 +4,7 @@ import type { TypeNode } from './TypeNode';
 /** Suffixes another type with a list of constant values that are written and read but not surfaced as fields to consumers. */
 export interface HiddenSuffixTypeNode<
     TType extends TypeNode = TypeNode,
-    TSuffix extends Array<ConstantValueNode> = Array<ConstantValueNode>,
+    TSuffix extends Array<ConstantValueNode> | undefined = Array<ConstantValueNode> | undefined,
 > {
     readonly kind: 'hiddenSuffixTypeNode';
 
@@ -12,5 +12,5 @@ export interface HiddenSuffixTypeNode<
     /** The wrapped type whose serialisation is followed by the hidden suffix. */
     readonly type: TType;
     /** The constant values written after the wrapped type, in order. */
-    readonly suffix: TSuffix;
+    readonly suffix?: TSuffix;
 }

--- a/packages/node-types/src/generated/typeNodes/StructTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/StructTypeNode.ts
@@ -1,10 +1,12 @@
 import type { StructFieldTypeNode } from './StructFieldTypeNode';
 
 /** A composite type made of an ordered list of named fields. Fields are encoded and decoded in declaration order. */
-export interface StructTypeNode<TFields extends Array<StructFieldTypeNode> = Array<StructFieldTypeNode>> {
+export interface StructTypeNode<
+    TFields extends Array<StructFieldTypeNode> | undefined = Array<StructFieldTypeNode> | undefined,
+> {
     readonly kind: 'structTypeNode';
 
     // Children.
     /** The fields of the struct, in declaration order. */
-    readonly fields: TFields;
+    readonly fields?: TFields;
 }

--- a/packages/node-types/src/generated/typeNodes/TupleTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/TupleTypeNode.ts
@@ -1,10 +1,10 @@
 import type { TypeNode } from './TypeNode';
 
 /** A heterogeneous fixed-length sequence in which each positional slot has its own type. */
-export interface TupleTypeNode<TItems extends Array<TypeNode> = Array<TypeNode>> {
+export interface TupleTypeNode<TItems extends Array<TypeNode> | undefined = Array<TypeNode> | undefined> {
     readonly kind: 'tupleTypeNode';
 
     // Children.
     /** The type of each positional slot, in order. */
-    readonly items: TItems;
+    readonly items?: TItems;
 }

--- a/packages/node-types/src/generated/valueNodes/ArrayValueNode.ts
+++ b/packages/node-types/src/generated/valueNodes/ArrayValueNode.ts
@@ -1,10 +1,10 @@
 import type { ValueNode } from './ValueNode';
 
 /** A concrete array value: a list of value nodes. */
-export interface ArrayValueNode<TItems extends Array<ValueNode> = Array<ValueNode>> {
+export interface ArrayValueNode<TItems extends Array<ValueNode> | undefined = Array<ValueNode> | undefined> {
     readonly kind: 'arrayValueNode';
 
     // Children.
     /** The items of the array, in order. */
-    readonly items: TItems;
+    readonly items?: TItems;
 }

--- a/packages/node-types/src/generated/valueNodes/MapValueNode.ts
+++ b/packages/node-types/src/generated/valueNodes/MapValueNode.ts
@@ -1,10 +1,12 @@
 import type { MapEntryValueNode } from './MapEntryValueNode';
 
 /** A concrete map value: a list of (key, value) entries. */
-export interface MapValueNode<TEntries extends Array<MapEntryValueNode> = Array<MapEntryValueNode>> {
+export interface MapValueNode<
+    TEntries extends Array<MapEntryValueNode> | undefined = Array<MapEntryValueNode> | undefined,
+> {
     readonly kind: 'mapValueNode';
 
     // Children.
     /** The entries of the map, in order. */
-    readonly entries: TEntries;
+    readonly entries?: TEntries;
 }

--- a/packages/node-types/src/generated/valueNodes/SetValueNode.ts
+++ b/packages/node-types/src/generated/valueNodes/SetValueNode.ts
@@ -1,10 +1,10 @@
 import type { ValueNode } from './ValueNode';
 
 /** A concrete set value: a list of unique value nodes. */
-export interface SetValueNode<TItems extends Array<ValueNode> = Array<ValueNode>> {
+export interface SetValueNode<TItems extends Array<ValueNode> | undefined = Array<ValueNode> | undefined> {
     readonly kind: 'setValueNode';
 
     // Children.
     /** The items of the set. */
-    readonly items: TItems;
+    readonly items?: TItems;
 }

--- a/packages/node-types/src/generated/valueNodes/StructValueNode.ts
+++ b/packages/node-types/src/generated/valueNodes/StructValueNode.ts
@@ -1,10 +1,12 @@
 import type { StructFieldValueNode } from './StructFieldValueNode';
 
 /** A concrete struct value: a list of named field values. */
-export interface StructValueNode<TFields extends Array<StructFieldValueNode> = Array<StructFieldValueNode>> {
+export interface StructValueNode<
+    TFields extends Array<StructFieldValueNode> | undefined = Array<StructFieldValueNode> | undefined,
+> {
     readonly kind: 'structValueNode';
 
     // Children.
     /** The named fields of the struct value. */
-    readonly fields: TFields;
+    readonly fields?: TFields;
 }

--- a/packages/node-types/src/generated/valueNodes/TupleValueNode.ts
+++ b/packages/node-types/src/generated/valueNodes/TupleValueNode.ts
@@ -1,10 +1,10 @@
 import type { ValueNode } from './ValueNode';
 
 /** A concrete tuple value: a fixed-length sequence of positional value nodes. */
-export interface TupleValueNode<TItems extends Array<ValueNode> = Array<ValueNode>> {
+export interface TupleValueNode<TItems extends Array<ValueNode> | undefined = Array<ValueNode> | undefined> {
     readonly kind: 'tupleValueNode';
 
     // Children.
     /** The positional items of the tuple, in order. */
-    readonly items: TItems;
+    readonly items?: TItems;
 }

--- a/packages/nodes-from-anchor/src/extractPdasVisitor.ts
+++ b/packages/nodes-from-anchor/src/extractPdasVisitor.ts
@@ -47,11 +47,11 @@ export function extractPdasVisitor() {
 export function extractPdasFromProgram(program: ProgramNode): ProgramNode {
     const hashVisitor = getUniqueHashStringVisitor();
     const pdaMap = new Map<Fingerprint, PdaNode>();
-    const usedNames = new Set<CamelCaseString>(program.pdas.map(p => p.name));
+    const usedNames = new Set<CamelCaseString>((program.pdas ?? []).map(p => p.name));
     const nameToFingerprint = new Map<CamelCaseString, Fingerprint>();
 
-    const rewrittenInstructions = program.instructions.map(instruction => {
-        const rewrittenAccounts = instruction.accounts.map(account => {
+    const rewrittenInstructions = (program.instructions ?? []).map(instruction => {
+        const rewrittenAccounts = (instruction.accounts ?? []).map(account => {
             if (
                 !account.defaultValue ||
                 !isNode(account.defaultValue, 'pdaValueNode') ||
@@ -98,6 +98,6 @@ export function extractPdasFromProgram(program: ProgramNode): ProgramNode {
     return programNode({
         ...program,
         instructions: rewrittenInstructions,
-        pdas: [...program.pdas, ...pdaMap.values()],
+        pdas: [...(program.pdas ?? []), ...pdaMap.values()],
     });
 }

--- a/packages/nodes-from-anchor/src/v00/AccountNode.ts
+++ b/packages/nodes-from-anchor/src/v00/AccountNode.ts
@@ -37,7 +37,7 @@ export function accountNodeFromAnchorV00(
             name: 'discriminator',
             type: fixedSizeTypeNode(bytesTypeNode(), 8),
         });
-        data = structTypeNode([discriminator, ...data.fields]);
+        data = structTypeNode([discriminator, ...(data.fields ?? [])]);
         discriminators = [fieldDiscriminatorNode('discriminator')];
     }
 

--- a/packages/nodes-from-anchor/src/v01/AccountNode.ts
+++ b/packages/nodes-from-anchor/src/v01/AccountNode.ts
@@ -39,7 +39,7 @@ export function accountNodeFromAnchorV01(
     });
 
     return accountNode({
-        data: structTypeNode([discriminator, ...data.fields]),
+        data: structTypeNode([discriminator, ...(data.fields ?? [])]),
         discriminators: [fieldDiscriminatorNode('discriminator')],
         name,
     });

--- a/packages/nodes-from-anchor/test/v00/ConstantNode.test.ts
+++ b/packages/nodes-from-anchor/test/v00/ConstantNode.test.ts
@@ -116,6 +116,8 @@ test('it parses constants in full program', () => {
     });
 
     expect(node.constants).toHaveLength(2);
-    expect(node.constants[0]).toEqual(constantNode('maxItems', numberTypeNode('u32'), numberValueNode(100)));
-    expect(node.constants[1]).toEqual(constantNode('seedPrefix', bytesTypeNode(), bytesValueNode('base16', '616263')));
+    expect((node.constants ?? [])[0]).toEqual(constantNode('maxItems', numberTypeNode('u32'), numberValueNode(100)));
+    expect((node.constants ?? [])[1]).toEqual(
+        constantNode('seedPrefix', bytesTypeNode(), bytesValueNode('base16', '616263')),
+    );
 });

--- a/packages/nodes-from-anchor/test/v01/ConstantNode.test.ts
+++ b/packages/nodes-from-anchor/test/v01/ConstantNode.test.ts
@@ -152,6 +152,8 @@ test('it parses constants in full program', () => {
     });
 
     expect(node.constants).toHaveLength(2);
-    expect(node.constants[0]).toEqual(constantNode('maxItems', numberTypeNode('u32'), numberValueNode(100)));
-    expect(node.constants[1]).toEqual(constantNode('seedPrefix', bytesTypeNode(), bytesValueNode('base16', '616263')));
+    expect((node.constants ?? [])[0]).toEqual(constantNode('maxItems', numberTypeNode('u32'), numberValueNode(100)));
+    expect((node.constants ?? [])[1]).toEqual(
+        constantNode('seedPrefix', bytesTypeNode(), bytesValueNode('base16', '616263')),
+    );
 });

--- a/packages/nodes-from-anchor/test/v01/extractPdasVisitor.test.ts
+++ b/packages/nodes-from-anchor/test/v01/extractPdasVisitor.test.ts
@@ -52,7 +52,7 @@ test('it extracts a single PDA to program level', () => {
             seeds: [constantPdaSeedNodeFromBytes('base58', 'F9bS')],
         }),
     ]);
-    expect(result.instructions[0].accounts[0].defaultValue).toEqual(pdaValueNode(pdaLinkNode('myPda'), []));
+    expect((result.instructions ?? [])[0].accounts?.[0]!.defaultValue).toEqual(pdaValueNode(pdaLinkNode('myPda'), []));
 });
 
 test('it deduplicates the same PDA across two instructions', () => {
@@ -92,11 +92,11 @@ test('it deduplicates the same PDA across two instructions', () => {
 
     // Only one PDA extracted.
     expect(result.pdas).toHaveLength(1);
-    expect(result.pdas[0].name).toBe('myPda');
+    expect((result.pdas ?? [])[0].name).toBe('myPda');
 
     // Both instructions use pdaLinkNode.
-    for (const ix of result.instructions) {
-        const account = ix.accounts[0];
+    for (const ix of result.instructions ?? []) {
+        const account = (ix.accounts ?? [])[0];
         expect(account.defaultValue).toEqual(
             pdaValueNode(pdaLinkNode('myPda'), [pdaSeedValueNode('owner', accountValueNode('owner'))]),
         );
@@ -146,8 +146,8 @@ test('it handles name collisions with different seeds by suffixing', () => {
     const result = extractPdasFromProgram(program);
 
     expect(result.pdas).toHaveLength(2);
-    expect(result.pdas[0].name).toBe('authority');
-    expect(result.pdas[1].name).toBe('instructionBAuthority');
+    expect((result.pdas ?? [])[0].name).toBe('authority');
+    expect((result.pdas ?? [])[1].name).toBe('instructionBAuthority');
     expect(warnSpy).toHaveBeenCalledOnce();
 
     warnSpy.mockRestore();
@@ -177,9 +177,9 @@ test('it excludes foreign-program PDAs', () => {
 
     const result = extractPdasFromProgram(program);
 
-    expect(result.pdas).toEqual([]);
+    expect(result.pdas ?? []).toEqual([]);
     // Account is unchanged (still inline pdaNode).
-    expect(result.instructions[0].accounts[0].defaultValue).toEqual(
+    expect((result.instructions ?? [])[0].accounts?.[0]!.defaultValue).toEqual(
         pdaValueNode(
             pdaNode({
                 name: 'ata',
@@ -220,10 +220,10 @@ test('it keeps dynamic programId on pdaValueNode, not on PdaNode', () => {
     const result = extractPdasFromProgram(program);
 
     // PdaNode has no programId.
-    expect(result.pdas[0].programId).toBeUndefined();
+    expect((result.pdas ?? [])[0].programId).toBeUndefined();
 
     // pdaValueNode still has the dynamic programId.
-    const defaultValue = result.instructions[0].accounts[0].defaultValue;
+    const defaultValue = (result.instructions ?? [])[0].accounts?.[0]!.defaultValue;
     expect(defaultValue).toEqual(
         pdaValueNode(
             pdaLinkNode('dynamicPda'),
@@ -269,13 +269,13 @@ test('it deduplicates same seeds with different account names using first name',
     const result = extractPdasFromProgram(program);
 
     expect(result.pdas).toHaveLength(1);
-    expect(result.pdas[0].name).toBe('authority');
+    expect((result.pdas ?? [])[0].name).toBe('authority');
 
     // Both instructions link to the first-encountered name.
-    expect(result.instructions[0].accounts[0].defaultValue).toEqual(
+    expect((result.instructions ?? [])[0].accounts?.[0]!.defaultValue).toEqual(
         pdaValueNode(pdaLinkNode('authority'), [pdaSeedValueNode('owner', accountValueNode('owner'))]),
     );
-    expect(result.instructions[1].accounts[0].defaultValue).toEqual(
+    expect((result.instructions ?? [])[1].accounts?.[0]!.defaultValue).toEqual(
         pdaValueNode(pdaLinkNode('authority'), [pdaSeedValueNode('owner', accountValueNode('owner'))]),
     );
 });
@@ -310,8 +310,8 @@ test('it preserves existing program-level PDAs', () => {
     const result = extractPdasFromProgram(program);
 
     expect(result.pdas).toHaveLength(2);
-    expect(result.pdas[0]).toEqual(existingPda);
-    expect(result.pdas[1].name).toBe('newPda');
+    expect((result.pdas ?? [])[0]).toEqual(existingPda);
+    expect((result.pdas ?? [])[1].name).toBe('newPda');
 });
 
 test('it returns empty pdas when no PDA accounts exist', () => {
@@ -326,7 +326,7 @@ test('it returns empty pdas when no PDA accounts exist', () => {
     ]);
 
     const result = extractPdasFromProgram(program);
-    expect(result.pdas).toEqual([]);
+    expect(result.pdas ?? []).toEqual([]);
     // Nothing changed on the node at all.
     expect(result).toEqual(program);
 });

--- a/packages/nodes/src/EnumTypeNode.ts
+++ b/packages/nodes/src/EnumTypeNode.ts
@@ -1,7 +1,7 @@
 import type { EnumTypeNode } from '@codama/node-types';
 
 export function isScalarEnum(node: EnumTypeNode): boolean {
-    return node.variants.every(variant => variant.kind === 'enumEmptyVariantTypeNode');
+    return (node.variants ?? []).every(variant => variant.kind === 'enumEmptyVariantTypeNode');
 }
 
 export function isDataEnum(node: EnumTypeNode): boolean {

--- a/packages/nodes/src/InstructionNode.ts
+++ b/packages/nodes/src/InstructionNode.ts
@@ -16,7 +16,7 @@ export function parseOptionalAccountStrategy(
 }
 
 export function getAllInstructionArguments(node: InstructionNode): InstructionArgumentNode[] {
-    return [...node.arguments, ...(node.extraArguments ?? [])];
+    return [...(node.arguments ?? []), ...(node.extraArguments ?? [])];
 }
 
 export function getAllInstructionsWithSubs(
@@ -31,7 +31,7 @@ export function getAllInstructionsWithSubs(
         return subInstructionsFirst ? [...subInstructions, node] : [node, ...subInstructions];
     }
 
-    const instructions = isNode(node, 'programNode') ? node.instructions : getAllInstructions(node);
+    const instructions = isNode(node, 'programNode') ? (node.instructions ?? []) : getAllInstructions(node);
 
     return instructions.flatMap(instruction => getAllInstructionsWithSubs(instruction, config));
 }

--- a/packages/nodes/src/ProgramNode.ts
+++ b/packages/nodes/src/ProgramNode.ts
@@ -13,33 +13,33 @@ import type {
 export function getAllPrograms(node: ProgramNode | ProgramNode[] | RootNode): ProgramNode[] {
     if (Array.isArray(node)) return node;
     if (node.kind === 'programNode') return [node];
-    return [node.program, ...node.additionalPrograms];
+    return [node.program, ...(node.additionalPrograms ?? [])];
 }
 
 export function getAllPdas(node: ProgramNode | ProgramNode[] | RootNode): PdaNode[] {
-    return getAllPrograms(node).flatMap(program => program.pdas);
+    return getAllPrograms(node).flatMap(program => program.pdas ?? []);
 }
 
 export function getAllAccounts(node: ProgramNode | ProgramNode[] | RootNode): AccountNode[] {
-    return getAllPrograms(node).flatMap(program => program.accounts);
+    return getAllPrograms(node).flatMap(program => program.accounts ?? []);
 }
 
 export function getAllEvents(node: ProgramNode | ProgramNode[] | RootNode): EventNode[] {
-    return getAllPrograms(node).flatMap(program => program.events);
+    return getAllPrograms(node).flatMap(program => program.events ?? []);
 }
 
 export function getAllDefinedTypes(node: ProgramNode | ProgramNode[] | RootNode): DefinedTypeNode[] {
-    return getAllPrograms(node).flatMap(program => program.definedTypes);
+    return getAllPrograms(node).flatMap(program => program.definedTypes ?? []);
 }
 
 export function getAllInstructions(node: ProgramNode | ProgramNode[] | RootNode): InstructionNode[] {
-    return getAllPrograms(node).flatMap(program => program.instructions);
+    return getAllPrograms(node).flatMap(program => program.instructions ?? []);
 }
 
 export function getAllErrors(node: ProgramNode | ProgramNode[] | RootNode): ErrorNode[] {
-    return getAllPrograms(node).flatMap(program => program.errors);
+    return getAllPrograms(node).flatMap(program => program.errors ?? []);
 }
 
 export function getAllConstants(node: ProgramNode | ProgramNode[] | RootNode): ConstantNode[] {
-    return getAllPrograms(node).flatMap(program => program.constants);
+    return getAllPrograms(node).flatMap(program => program.constants ?? []);
 }

--- a/packages/nodes/src/generated/AccountNode.ts
+++ b/packages/nodes/src/generated/AccountNode.ts
@@ -29,6 +29,7 @@ export function accountNode<
         // Children.
         data: (input.data ?? structTypeNode([])) as TData,
         ...(input.pda !== undefined && { pda: input.pda }),
-        ...(input.discriminators !== undefined && { discriminators: input.discriminators }),
+        ...(input.discriminators !== undefined &&
+            input.discriminators.length > 0 && { discriminators: input.discriminators as TDiscriminators }),
     });
 }

--- a/packages/nodes/src/generated/EventNode.ts
+++ b/packages/nodes/src/generated/EventNode.ts
@@ -24,6 +24,7 @@ export function eventNode<
 
         // Children.
         data: input.data,
-        ...(input.discriminators !== undefined && { discriminators: input.discriminators }),
+        ...(input.discriminators !== undefined &&
+            input.discriminators.length > 0 && { discriminators: input.discriminators as TDiscriminators }),
     });
 }

--- a/packages/nodes/src/generated/InstructionNode.ts
+++ b/packages/nodes/src/generated/InstructionNode.ts
@@ -13,8 +13,8 @@ import type {
 import { camelCase, DocsInput, parseDocs } from '../shared';
 
 export type InstructionNodeInput<
-    TAccounts extends Array<InstructionAccountNode> = Array<InstructionAccountNode>,
-    TArguments extends Array<InstructionArgumentNode> = Array<InstructionArgumentNode>,
+    TAccounts extends Array<InstructionAccountNode> | undefined = Array<InstructionAccountNode> | undefined,
+    TArguments extends Array<InstructionArgumentNode> | undefined = Array<InstructionArgumentNode> | undefined,
     TExtraArguments extends Array<InstructionArgumentNode> | undefined = Array<InstructionArgumentNode> | undefined,
     TRemainingAccounts extends Array<InstructionRemainingAccountsNode> | undefined =
         | Array<InstructionRemainingAccountsNode>
@@ -50,8 +50,8 @@ export type InstructionNodeInput<
 
 /** A program instruction: its accounts, arguments, byte-delta hints, discriminators, optional status, and optional sub-instructions. */
 export function instructionNode<
-    const TAccounts extends Array<InstructionAccountNode> = [],
-    const TArguments extends Array<InstructionArgumentNode> = [],
+    const TAccounts extends Array<InstructionAccountNode> | undefined = [],
+    const TArguments extends Array<InstructionArgumentNode> | undefined = [],
     const TExtraArguments extends Array<InstructionArgumentNode> | undefined = undefined,
     const TRemainingAccounts extends Array<InstructionRemainingAccountsNode> | undefined = undefined,
     const TByteDeltas extends Array<InstructionByteDeltaNode> | undefined = undefined,
@@ -98,16 +98,22 @@ export function instructionNode<
         optionalAccountStrategy: input.optionalAccountStrategy ?? 'programId',
 
         // Children.
-        accounts: (input.accounts ?? []) as TAccounts,
-        arguments: (input.arguments ?? []) as TArguments,
-        ...(input.extraArguments !== undefined && { extraArguments: input.extraArguments }),
-        ...(input.remainingAccounts !== undefined && { remainingAccounts: input.remainingAccounts }),
-        ...(input.byteDeltas !== undefined && { byteDeltas: input.byteDeltas }),
-        ...(input.discriminators !== undefined && { discriminators: input.discriminators }),
+        ...(input.accounts !== undefined && input.accounts.length > 0 && { accounts: input.accounts as TAccounts }),
+        ...(input.arguments !== undefined &&
+            input.arguments.length > 0 && { arguments: input.arguments as TArguments }),
+        ...(input.extraArguments !== undefined &&
+            input.extraArguments.length > 0 && { extraArguments: input.extraArguments as TExtraArguments }),
+        ...(input.remainingAccounts !== undefined &&
+            input.remainingAccounts.length > 0 && { remainingAccounts: input.remainingAccounts as TRemainingAccounts }),
+        ...(input.byteDeltas !== undefined &&
+            input.byteDeltas.length > 0 && { byteDeltas: input.byteDeltas as TByteDeltas }),
+        ...(input.discriminators !== undefined &&
+            input.discriminators.length > 0 && { discriminators: input.discriminators as TDiscriminators }),
         ...(input.status !== undefined && { status: input.status }),
-        ...(input.subInstructions !== undefined && { subInstructions: input.subInstructions }),
-        ...(input.provides !== undefined && { provides: input.provides }),
+        ...(input.subInstructions !== undefined &&
+            input.subInstructions.length > 0 && { subInstructions: input.subInstructions as TSubInstructions }),
+        ...(input.provides !== undefined && input.provides.length > 0 && { provides: input.provides as TProvides }),
         ...(input.display !== undefined && { display: input.display }),
-        ...(input.plugins !== undefined && { plugins: input.plugins }),
+        ...(input.plugins !== undefined && input.plugins.length > 0 && { plugins: input.plugins as TPlugins }),
     });
 }

--- a/packages/nodes/src/generated/PdaNode.ts
+++ b/packages/nodes/src/generated/PdaNode.ts
@@ -1,7 +1,7 @@
 import type { PdaNode, PdaSeedNode } from '@codama/node-types';
 import { camelCase, DocsInput, parseDocs } from '../shared';
 
-export type PdaNodeInput<TSeeds extends Array<PdaSeedNode> = Array<PdaSeedNode>> = Omit<
+export type PdaNodeInput<TSeeds extends Array<PdaSeedNode> | undefined = Array<PdaSeedNode> | undefined> = Omit<
     PdaNode<TSeeds>,
     'docs' | 'kind' | 'name'
 > & {
@@ -10,7 +10,9 @@ export type PdaNodeInput<TSeeds extends Array<PdaSeedNode> = Array<PdaSeedNode>>
 };
 
 /** A program-derived address: its name, optional program ID override, and the seeds used to derive it. */
-export function pdaNode<const TSeeds extends Array<PdaSeedNode>>(input: PdaNodeInput<TSeeds>): PdaNode<TSeeds> {
+export function pdaNode<const TSeeds extends Array<PdaSeedNode> | undefined>(
+    input: PdaNodeInput<TSeeds>,
+): PdaNode<TSeeds> {
     const parsedDocs = parseDocs(input.docs);
     return Object.freeze({
         kind: 'pdaNode',
@@ -21,6 +23,6 @@ export function pdaNode<const TSeeds extends Array<PdaSeedNode>>(input: PdaNodeI
         ...(input.programId !== undefined && { programId: input.programId }),
 
         // Children.
-        seeds: input.seeds,
+        ...(input.seeds !== undefined && input.seeds.length > 0 && { seeds: input.seeds as TSeeds }),
     });
 }

--- a/packages/nodes/src/generated/ProgramNode.ts
+++ b/packages/nodes/src/generated/ProgramNode.ts
@@ -11,13 +11,13 @@ import type {
 import { camelCase, DocsInput, parseDocs } from '../shared';
 
 export type ProgramNodeInput<
-    TPdas extends Array<PdaNode> = Array<PdaNode>,
-    TAccounts extends Array<AccountNode> = Array<AccountNode>,
-    TInstructions extends Array<InstructionNode> = Array<InstructionNode>,
-    TDefinedTypes extends Array<DefinedTypeNode> = Array<DefinedTypeNode>,
-    TErrors extends Array<ErrorNode> = Array<ErrorNode>,
-    TEvents extends Array<EventNode> = Array<EventNode>,
-    TConstants extends Array<ConstantNode> = Array<ConstantNode>,
+    TPdas extends Array<PdaNode> | undefined = Array<PdaNode> | undefined,
+    TAccounts extends Array<AccountNode> | undefined = Array<AccountNode> | undefined,
+    TInstructions extends Array<InstructionNode> | undefined = Array<InstructionNode> | undefined,
+    TDefinedTypes extends Array<DefinedTypeNode> | undefined = Array<DefinedTypeNode> | undefined,
+    TErrors extends Array<ErrorNode> | undefined = Array<ErrorNode> | undefined,
+    TEvents extends Array<EventNode> | undefined = Array<EventNode> | undefined,
+    TConstants extends Array<ConstantNode> | undefined = Array<ConstantNode> | undefined,
 > = Omit<
     Partial<ProgramNode<TPdas, TAccounts, TInstructions, TDefinedTypes, TErrors, TEvents, TConstants>>,
     'docs' | 'kind' | 'name' | 'publicKey'
@@ -29,13 +29,13 @@ export type ProgramNodeInput<
 
 /** A Solana program: its identity, version, accounts, instructions, defined types, PDAs, events, errors, and constants. */
 export function programNode<
-    const TPdas extends Array<PdaNode> = [],
-    const TAccounts extends Array<AccountNode> = [],
-    const TInstructions extends Array<InstructionNode> = [],
-    const TDefinedTypes extends Array<DefinedTypeNode> = [],
-    const TErrors extends Array<ErrorNode> = [],
-    const TEvents extends Array<EventNode> = [],
-    const TConstants extends Array<ConstantNode> = [],
+    const TPdas extends Array<PdaNode> | undefined = [],
+    const TAccounts extends Array<AccountNode> | undefined = [],
+    const TInstructions extends Array<InstructionNode> | undefined = [],
+    const TDefinedTypes extends Array<DefinedTypeNode> | undefined = [],
+    const TErrors extends Array<ErrorNode> | undefined = [],
+    const TEvents extends Array<EventNode> | undefined = [],
+    const TConstants extends Array<ConstantNode> | undefined = [],
 >(
     input: ProgramNodeInput<TPdas, TAccounts, TInstructions, TDefinedTypes, TErrors, TEvents, TConstants>,
 ): ProgramNode<TPdas, TAccounts, TInstructions, TDefinedTypes, TErrors, TEvents, TConstants> {
@@ -51,12 +51,15 @@ export function programNode<
         ...(parsedDocs.length > 0 && { docs: parsedDocs }),
 
         // Children.
-        accounts: (input.accounts ?? []) as TAccounts,
-        instructions: (input.instructions ?? []) as TInstructions,
-        definedTypes: (input.definedTypes ?? []) as TDefinedTypes,
-        pdas: (input.pdas ?? []) as TPdas,
-        events: (input.events ?? []) as TEvents,
-        errors: (input.errors ?? []) as TErrors,
-        constants: (input.constants ?? []) as TConstants,
+        ...(input.accounts !== undefined && input.accounts.length > 0 && { accounts: input.accounts as TAccounts }),
+        ...(input.instructions !== undefined &&
+            input.instructions.length > 0 && { instructions: input.instructions as TInstructions }),
+        ...(input.definedTypes !== undefined &&
+            input.definedTypes.length > 0 && { definedTypes: input.definedTypes as TDefinedTypes }),
+        ...(input.pdas !== undefined && input.pdas.length > 0 && { pdas: input.pdas as TPdas }),
+        ...(input.events !== undefined && input.events.length > 0 && { events: input.events as TEvents }),
+        ...(input.errors !== undefined && input.errors.length > 0 && { errors: input.errors as TErrors }),
+        ...(input.constants !== undefined &&
+            input.constants.length > 0 && { constants: input.constants as TConstants }),
     });
 }

--- a/packages/nodes/src/generated/RootNode.ts
+++ b/packages/nodes/src/generated/RootNode.ts
@@ -5,7 +5,10 @@ import { CODAMA_VERSION } from './codamaVersion';
  * The root of a Codama IDL document.
  * Pairs a primary program with any number of additional programs and tags the document with the spec version.
  */
-export function rootNode<const TProgram extends ProgramNode, const TAdditionalPrograms extends Array<ProgramNode> = []>(
+export function rootNode<
+    const TProgram extends ProgramNode,
+    const TAdditionalPrograms extends Array<ProgramNode> | undefined = [],
+>(
     program: TProgram,
     additionalPrograms: TAdditionalPrograms = [] as Array<ProgramNode> as TAdditionalPrograms,
 ): RootNode<TProgram, TAdditionalPrograms> {
@@ -18,6 +21,7 @@ export function rootNode<const TProgram extends ProgramNode, const TAdditionalPr
 
         // Children.
         program,
-        additionalPrograms,
+        ...(additionalPrograms !== undefined &&
+            additionalPrograms.length > 0 && { additionalPrograms: additionalPrograms as TAdditionalPrograms }),
     });
 }

--- a/packages/nodes/src/generated/contextualValueNodes/PdaValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/PdaValueNode.ts
@@ -3,7 +3,7 @@ import { pdaLinkNode } from '../linkNodes/PdaLinkNode';
 
 /** Resolves to a PDA derived from a list of seed values. */
 export function pdaValueNode<
-    const TSeeds extends Array<PdaSeedValueNode> = [],
+    const TSeeds extends Array<PdaSeedValueNode> | undefined = [],
     const TProgramId extends PdaValueProgramId | undefined = undefined,
     const TPda extends PdaValuePda = PdaValuePda,
 >(
@@ -16,7 +16,7 @@ export function pdaValueNode<
 
         // Children.
         pda: (typeof pda === 'string' ? pdaLinkNode(pda) : pda) as TPda,
-        seeds,
+        ...(seeds !== undefined && seeds.length > 0 && { seeds: seeds as TSeeds }),
         ...(programId !== undefined && { programId }),
     });
 }

--- a/packages/nodes/src/generated/contextualValueNodes/ResolverValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/ResolverValueNode.ts
@@ -21,6 +21,7 @@ export function resolverValueNode<const TDependsOn extends Array<ResolverDepende
         ...(parsedDocs.length > 0 && { docs: parsedDocs }),
 
         // Children.
-        ...(options.dependsOn !== undefined && { dependsOn: options.dependsOn }),
+        ...(options.dependsOn !== undefined &&
+            options.dependsOn.length > 0 && { dependsOn: options.dependsOn as TDependsOn }),
     });
 }

--- a/packages/nodes/src/generated/typeNodes/EnumTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/EnumTypeNode.ts
@@ -3,7 +3,7 @@ import { numberTypeNode } from './NumberTypeNode';
 
 /** A tagged union: a numeric discriminator followed by one of several variant payloads. */
 export function enumTypeNode<
-    const TVariants extends Array<EnumVariantTypeNode>,
+    const TVariants extends Array<EnumVariantTypeNode> | undefined,
     const TSize extends NestedTypeNode<NumberTypeNode> = NumberTypeNode<'u8'>,
 >(
     variants: TVariants,
@@ -15,7 +15,7 @@ export function enumTypeNode<
         kind: 'enumTypeNode',
 
         // Children.
-        variants,
+        ...(variants !== undefined && variants.length > 0 && { variants: variants as TVariants }),
         size: (options.size ?? numberTypeNode('u8')) as TSize,
     });
 }

--- a/packages/nodes/src/generated/typeNodes/HiddenPrefixTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/HiddenPrefixTypeNode.ts
@@ -1,15 +1,15 @@
 import type { ConstantValueNode, HiddenPrefixTypeNode, TypeNode } from '@codama/node-types';
 
 /** Prefixes another type with a list of constant values that are written and read but not surfaced as fields to consumers. */
-export function hiddenPrefixTypeNode<const TType extends TypeNode, const TPrefix extends Array<ConstantValueNode>>(
-    type: TType,
-    prefix: TPrefix,
-): HiddenPrefixTypeNode<TType, TPrefix> {
+export function hiddenPrefixTypeNode<
+    const TType extends TypeNode,
+    const TPrefix extends Array<ConstantValueNode> | undefined,
+>(type: TType, prefix: TPrefix): HiddenPrefixTypeNode<TType, TPrefix> {
     return Object.freeze({
         kind: 'hiddenPrefixTypeNode',
 
         // Children.
         type,
-        prefix,
+        ...(prefix !== undefined && prefix.length > 0 && { prefix: prefix as TPrefix }),
     });
 }

--- a/packages/nodes/src/generated/typeNodes/HiddenSuffixTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/HiddenSuffixTypeNode.ts
@@ -1,15 +1,15 @@
 import type { ConstantValueNode, HiddenSuffixTypeNode, TypeNode } from '@codama/node-types';
 
 /** Suffixes another type with a list of constant values that are written and read but not surfaced as fields to consumers. */
-export function hiddenSuffixTypeNode<const TType extends TypeNode, const TSuffix extends Array<ConstantValueNode>>(
-    type: TType,
-    suffix: TSuffix,
-): HiddenSuffixTypeNode<TType, TSuffix> {
+export function hiddenSuffixTypeNode<
+    const TType extends TypeNode,
+    const TSuffix extends Array<ConstantValueNode> | undefined,
+>(type: TType, suffix: TSuffix): HiddenSuffixTypeNode<TType, TSuffix> {
     return Object.freeze({
         kind: 'hiddenSuffixTypeNode',
 
         // Children.
         type,
-        suffix,
+        ...(suffix !== undefined && suffix.length > 0 && { suffix: suffix as TSuffix }),
     });
 }

--- a/packages/nodes/src/generated/typeNodes/StructTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/StructTypeNode.ts
@@ -1,13 +1,13 @@
 import type { StructFieldTypeNode, StructTypeNode } from '@codama/node-types';
 
 /** A composite type made of an ordered list of named fields. Fields are encoded and decoded in declaration order. */
-export function structTypeNode<const TFields extends Array<StructFieldTypeNode>>(
+export function structTypeNode<const TFields extends Array<StructFieldTypeNode> | undefined>(
     fields: TFields,
 ): StructTypeNode<TFields> {
     return Object.freeze({
         kind: 'structTypeNode',
 
         // Children.
-        fields,
+        ...(fields !== undefined && fields.length > 0 && { fields: fields as TFields }),
     });
 }

--- a/packages/nodes/src/generated/typeNodes/TupleTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/TupleTypeNode.ts
@@ -1,11 +1,11 @@
 import type { TupleTypeNode, TypeNode } from '@codama/node-types';
 
 /** A heterogeneous fixed-length sequence in which each positional slot has its own type. */
-export function tupleTypeNode<const TItems extends Array<TypeNode>>(items: TItems): TupleTypeNode<TItems> {
+export function tupleTypeNode<const TItems extends Array<TypeNode> | undefined>(items: TItems): TupleTypeNode<TItems> {
     return Object.freeze({
         kind: 'tupleTypeNode',
 
         // Children.
-        items,
+        ...(items !== undefined && items.length > 0 && { items: items as TItems }),
     });
 }

--- a/packages/nodes/src/generated/valueNodes/ArrayValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/ArrayValueNode.ts
@@ -1,11 +1,13 @@
 import type { ArrayValueNode, ValueNode } from '@codama/node-types';
 
 /** A concrete array value: a list of value nodes. */
-export function arrayValueNode<const TItems extends Array<ValueNode>>(items: TItems): ArrayValueNode<TItems> {
+export function arrayValueNode<const TItems extends Array<ValueNode> | undefined>(
+    items: TItems,
+): ArrayValueNode<TItems> {
     return Object.freeze({
         kind: 'arrayValueNode',
 
         // Children.
-        items,
+        ...(items !== undefined && items.length > 0 && { items: items as TItems }),
     });
 }

--- a/packages/nodes/src/generated/valueNodes/MapValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/MapValueNode.ts
@@ -1,13 +1,13 @@
 import type { MapEntryValueNode, MapValueNode } from '@codama/node-types';
 
 /** A concrete map value: a list of (key, value) entries. */
-export function mapValueNode<const TEntries extends Array<MapEntryValueNode>>(
+export function mapValueNode<const TEntries extends Array<MapEntryValueNode> | undefined>(
     entries: TEntries,
 ): MapValueNode<TEntries> {
     return Object.freeze({
         kind: 'mapValueNode',
 
         // Children.
-        entries,
+        ...(entries !== undefined && entries.length > 0 && { entries: entries as TEntries }),
     });
 }

--- a/packages/nodes/src/generated/valueNodes/SetValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/SetValueNode.ts
@@ -1,11 +1,11 @@
 import type { SetValueNode, ValueNode } from '@codama/node-types';
 
 /** A concrete set value: a list of unique value nodes. */
-export function setValueNode<const TItems extends Array<ValueNode>>(items: TItems): SetValueNode<TItems> {
+export function setValueNode<const TItems extends Array<ValueNode> | undefined>(items: TItems): SetValueNode<TItems> {
     return Object.freeze({
         kind: 'setValueNode',
 
         // Children.
-        items,
+        ...(items !== undefined && items.length > 0 && { items: items as TItems }),
     });
 }

--- a/packages/nodes/src/generated/valueNodes/StructValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/StructValueNode.ts
@@ -1,13 +1,13 @@
 import type { StructFieldValueNode, StructValueNode } from '@codama/node-types';
 
 /** A concrete struct value: a list of named field values. */
-export function structValueNode<const TFields extends Array<StructFieldValueNode>>(
+export function structValueNode<const TFields extends Array<StructFieldValueNode> | undefined>(
     fields: TFields,
 ): StructValueNode<TFields> {
     return Object.freeze({
         kind: 'structValueNode',
 
         // Children.
-        fields,
+        ...(fields !== undefined && fields.length > 0 && { fields: fields as TFields }),
     });
 }

--- a/packages/nodes/src/generated/valueNodes/TupleValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/TupleValueNode.ts
@@ -1,11 +1,13 @@
 import type { TupleValueNode, ValueNode } from '@codama/node-types';
 
 /** A concrete tuple value: a fixed-length sequence of positional value nodes. */
-export function tupleValueNode<const TItems extends Array<ValueNode>>(items: TItems): TupleValueNode<TItems> {
+export function tupleValueNode<const TItems extends Array<ValueNode> | undefined>(
+    items: TItems,
+): TupleValueNode<TItems> {
     return Object.freeze({
         kind: 'tupleValueNode',
 
         // Children.
-        items,
+        ...(items !== undefined && items.length > 0 && { items: items as TItems }),
     });
 }

--- a/packages/nodes/test/ProgramNode.test.ts
+++ b/packages/nodes/test/ProgramNode.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 
-import { programNode } from '../src';
+import { accountNode, programNode, structTypeNode } from '../src';
 
 test('it returns the right node kind', () => {
     const node = programNode({ name: 'foo', publicKey: '1111' });
@@ -10,4 +10,29 @@ test('it returns the right node kind', () => {
 test('it returns a frozen object', () => {
     const node = programNode({ name: 'foo', publicKey: '1111' });
     expect(Object.isFrozen(node)).toBe(true);
+});
+
+test('it omits array attributes entirely when they are empty (skip-when-empty)', () => {
+    // Arrays are omitted when empty on write. An absent array and an empty
+    // array are semantically identical (see the "Array attributes are omitted
+    // when empty" convention in the `@codama/spec` README).
+    const node = programNode({ name: 'foo', publicKey: '1111' });
+    expect('accounts' in node).toBe(false);
+    expect('instructions' in node).toBe(false);
+    expect('pdas' in node).toBe(false);
+    expect('definedTypes' in node).toBe(false);
+    expect('events' in node).toBe(false);
+    expect('errors' in node).toBe(false);
+    expect('constants' in node).toBe(false);
+});
+
+test('it omits an array attribute even when an explicit empty array is passed', () => {
+    const node = programNode({ accounts: [], name: 'foo', publicKey: '1111' });
+    expect('accounts' in node).toBe(false);
+});
+
+test('it keeps array attributes when they are non-empty', () => {
+    const account = accountNode({ data: structTypeNode([]), name: 'myAccount' });
+    const node = programNode({ accounts: [account], name: 'foo', publicKey: '1111' });
+    expect(node.accounts).toEqual([account]);
 });

--- a/packages/spec-generators/src/nodeTypes/fragments/attributeBodyLine.ts
+++ b/packages/spec-generators/src/nodeTypes/fragments/attributeBodyLine.ts
@@ -9,8 +9,14 @@ import { getTypeExprFragment } from './typeExpr';
  * Render one attribute as a body line inside an interface declaration.
  * Type-parameter attributes use their type-parameter identifier (e.g.
  * `readonly data: TData;`); other attributes use the rendered type
- * expression. Optional attributes carry a `?:` marker; `docs` (if any)
+ * expression. Optional attributes — and every array attribute,
+ * regardless of `optional` — carry a `?:` marker; `docs` (if any)
  * become a JSDoc prefix.
+ *
+ * Arrays are always optional on the type because they skip-when-empty:
+ * an empty array is omitted from the node, so a reader may always find
+ * the attribute absent (see the "Array attributes are omitted when
+ * empty" convention in the `@codama/spec` README).
  */
 export function getAttributeBodyLineFragment(
     nodeKind: string,
@@ -18,7 +24,7 @@ export function getAttributeBodyLineFragment(
     scope: Pick<RenderScope, 'narrowableDataAttributes'>,
 ): Fragment {
     const docPrefix = getDocblockFragment(attr.docs, { withLineJump: true });
-    const optionalMark = attr.optional === true ? '?' : '';
+    const optionalMark = attr.optional === true || attr.type.kind === 'array' ? '?' : '';
     const typeFragment = isNodeTypeParameterAttribute(nodeKind, attr, scope)
         ? getTypeParameterIdentifierFragment(attr)
         : getTypeExprFragment(attr.type);

--- a/packages/spec-generators/src/nodeTypes/fragments/typeParameterDefinition.ts
+++ b/packages/spec-generators/src/nodeTypes/fragments/typeParameterDefinition.ts
@@ -20,8 +20,16 @@ export interface TypeParameterDefinitionOptions {
 /**
  * Render the type-parameter definition for one type-parameter
  * attribute, e.g. `TData extends Foo = Foo` (or `… | undefined = …
- * | undefined` when the attribute is optional). Callers must only
- * invoke this for attributes that already surface as type parameters.
+ * | undefined` when the attribute is optional — or an array). Callers
+ * must only invoke this for attributes that already surface as type
+ * parameters.
+ *
+ * Array attributes always append `| undefined` because they
+ * skip-when-empty: an empty array is omitted from the node, so the
+ * attribute may always be absent (see the "Array attributes are omitted
+ * when empty" convention in the `@codama/spec` README). This keeps the
+ * interface's type-parameter constraint in lockstep with the node
+ * function's (see `getNodeTypeParameterConstraint`).
  */
 export function getTypeParameterDefinitionFragment(
     attr: AttributeSpec,
@@ -32,6 +40,7 @@ export function getTypeParameterDefinitionFragment(
         options.selfAlias && isTypeExprSelfReferential(attr.type, options.selfAlias.kind)
             ? getTypeExprWithSelfAliasFragment(attr.type, options.selfAlias.kind, options.selfAlias.alias)
             : getTypeExprFragment(attr.type);
-    const constraint = attr.optional === true ? fragment`${baseFragment} | undefined` : baseFragment;
+    const constraint =
+        attr.optional === true || attr.type.kind === 'array' ? fragment`${baseFragment} | undefined` : baseFragment;
     return fragment`${identifier} extends ${constraint} = ${constraint}`;
 }

--- a/packages/spec-generators/src/nodes/fragments/nodeFunctionAttribute.ts
+++ b/packages/spec-generators/src/nodes/fragments/nodeFunctionAttribute.ts
@@ -13,16 +13,22 @@ import { isStringIdentifierAttr } from '../paramIdentifier';
  *      Hidden attributes are never exposed to the caller, so no
  *      other rule applies.
  *   2. `value` override → emit the override's expression verbatim.
- *   3. `stringIdentifier()`-typed → wrap reader in `camelCase(...)`,
+ *   3. Array-typed attribute → skip-when-empty conditional spread,
+ *      regardless of `optional`. An empty or absent array is omitted
+ *      from the node entirely (see the "Array attributes are omitted
+ *      when empty" convention in the `@codama/spec` README). The
+ *      generic cast (`as TGeneric`) is preserved for type-parameter
+ *      arrays so callers keep their narrowed tuple type.
+ *   4. `stringIdentifier()`-typed → wrap reader in `camelCase(...)`,
  *      under a conditional spread when optional.
- *   4. `coerce` override → emit the coerce fragment, with `as TGeneric`
+ *   5. `coerce` override → emit the coerce fragment, with `as TGeneric`
  *      cast when the attribute is a type parameter, under a conditional
  *      spread when optional.
- *   5. `default` override → bare positional args carry the default at
+ *   6. `default` override → bare positional args carry the default at
  *      the signature level; bag/object-input attributes get a
  *      body-level `?? <default>` fallback.
- *   6. Optional attribute → conditional spread.
- *   7. Required attribute → pass-through, with shorthand `{ key }` when
+ *   7. Optional attribute → conditional spread.
+ *   8. Required attribute → pass-through, with shorthand `{ key }` when
  *      the reader equals the key.
  */
 export function getNodeFunctionAttributeFragment(
@@ -40,6 +46,18 @@ export function getNodeFunctionAttributeFragment(
 
     if (override && 'value' in override) {
         return fragment`${key}: ${override.value},`;
+    }
+
+    if (attr.type.kind === 'array') {
+        // Arrays skip-when-empty: an empty or absent array is omitted
+        // from the node. `reader` may be `undefined` (optional or
+        // defaulted-at-signature positional), so coalesce to `[]` before
+        // testing length. Type-parameter arrays keep their `as TGeneric`
+        // cast so a caller's narrowed tuple type survives.
+        const value = typeParameterAttribute
+            ? fragment`${reader} as ${getTypeParameterIdentifierFragment(typeParameterAttribute)}`
+            : fragment`${reader}`;
+        return fragment`...(${reader} !== undefined && ${reader}.length > 0 && { ${key}: ${value} }),`;
     }
 
     if (isStringIdentifierAttr(attr)) {

--- a/packages/spec-generators/src/nodes/fragments/nodeFunctionPositionalArguments.ts
+++ b/packages/spec-generators/src/nodes/fragments/nodeFunctionPositionalArguments.ts
@@ -109,9 +109,18 @@ function renderParamDefaultClause(
     // on a `ProgramNode[]` attribute) widens the literal expression
     // before the final narrowing — matches the existing hand-written
     // pattern `[] as ProgramNode[] as TAdditionalPrograms`.
+    //
+    // For array attributes the intermediate is the bare element-array
+    // type rather than the `| undefined` type-parameter constraint:
+    // widening a literal `[]` never needs the `| undefined`, and
+    // including it just adds noise to the generated output.
     if (typeParameterAttribute) {
         const genericName = getTypeParameterIdentifierFragment(typeParameterAttribute);
-        const intermediate = override.genericDefault ?? getNodeTypeParameterConstraint(typeParameterAttribute);
+        const intermediate =
+            override.genericDefault ??
+            (typeParameterAttribute.type.kind === 'array'
+                ? getTypeExprFragment(typeParameterAttribute.type)
+                : getNodeTypeParameterConstraint(typeParameterAttribute));
         const needsIntermediate = intermediate.content !== override.default.content;
         const castChain = needsIntermediate
             ? fragment`${override.default} as ${intermediate} as ${genericName}`

--- a/packages/spec-generators/src/nodes/fragments/nodeTypeParameters.ts
+++ b/packages/spec-generators/src/nodes/fragments/nodeTypeParameters.ts
@@ -7,12 +7,18 @@ import { getTypeExprFragment } from './typeExpr';
 
 /**
  * The constraint Fragment for the type parameter derived from `attr`.
- * Optional attributes get `| undefined` appended; required attributes
+ * Optional attributes — and every array attribute, regardless of
+ * `optional` — get `| undefined` appended; other required attributes
  * use the bare type expression.
+ *
+ * Arrays are always optional because they skip-when-empty: an empty
+ * array is omitted from the node, so a reader may always find the
+ * attribute absent (see the "Array attributes are omitted when empty"
+ * convention in the `@codama/spec` README).
  */
 export function getNodeTypeParameterConstraint(attr: AttributeSpec): Fragment {
     const baseType = getTypeExprFragment(attr.type);
-    return attr.optional === true ? fragment`${baseType} | undefined` : baseType;
+    return attr.optional === true || attr.type.kind === 'array' ? fragment`${baseType} | undefined` : baseType;
 }
 
 /**

--- a/packages/spec-generators/test/nodeTypes/fragments/typeParameterDefinition.test.ts
+++ b/packages/spec-generators/test/nodeTypes/fragments/typeParameterDefinition.test.ts
@@ -14,9 +14,14 @@ describe('getTypeParameterDefinitionFragment', () => {
         expect(result.content).toBe('TPayload extends InnerTypeNode | undefined = InnerTypeNode | undefined');
     });
 
-    it('renders an array-of-node child as an Array<T> type parameter', () => {
+    it('renders an array-of-node child as an optional Array<T> type parameter (arrays skip-when-empty)', () => {
+        // Arrays always append `| undefined`, regardless of `optional`, because they
+        // are omitted when empty on write (see the "Array attributes are omitted when
+        // empty" convention in the `@codama/spec` README).
         const result = getTypeParameterDefinitionFragment(attribute('items', array(node('innerTypeNode'))));
-        expect(result.content).toBe('TItems extends Array<InnerTypeNode> = Array<InnerTypeNode>');
+        expect(result.content).toBe(
+            'TItems extends Array<InnerTypeNode> | undefined = Array<InnerTypeNode> | undefined',
+        );
     });
 
     it('renders a narrowable data attribute as a type parameter over its enumeration constraint', () => {

--- a/packages/spec-generators/test/nodes/fragments/nodeFunctionAttribute.test.ts
+++ b/packages/spec-generators/test/nodes/fragments/nodeFunctionAttribute.test.ts
@@ -93,12 +93,34 @@ describe('getNodeFunctionAttributeFragment', () => {
         expect(out).toContain('...(program !== undefined && {');
     });
 
-    it('rule 5: default override on a non-bare type-parameter attribute emits a `?? <default>` fallback', () => {
+    it('rule 3: an array type-parameter attribute becomes a skip-when-empty spread, keeping its generic cast', () => {
+        // Arrays skip-when-empty and take precedence over a `default` override
+        // in the body — an empty or absent array is omitted from the node (see
+        // the "Array attributes are omitted when empty" convention in the
+        // `@codama/spec` README). The `as TItems` cast is preserved.
         const attr = specAttr(attribute('items', array(union('ValueNode'))));
         const override: AttributeOverride = { default: fragment`[]` };
         const typeParamAttr = typeParamAttrFor(attribute('items', array(union('ValueNode'))));
         const out = getNodeFunctionAttributeFragment(attr, 'input.items', override, typeParamAttr, false).content;
-        expect(out).toBe('items: (input.items ?? []) as TItems,');
+        expect(out).toBe(
+            '...(input.items !== undefined && input.items.length > 0 && { items: input.items as TItems }),',
+        );
+    });
+
+    it('rule 3: a non-generic array attribute becomes a skip-when-empty spread without a cast', () => {
+        const attr = specAttr(optionalAttribute('discriminators', array(union('DiscriminatorNode'))));
+        const out = getNodeFunctionAttributeFragment(attr, 'input.discriminators', undefined, undefined, false).content;
+        expect(out).toBe(
+            '...(input.discriminators !== undefined && input.discriminators.length > 0 && ' +
+                '{ discriminators: input.discriminators }),',
+        );
+    });
+
+    it('rule 6: default override on a non-array type-parameter attribute emits a `?? <default>` fallback', () => {
+        const attr = specAttr(attribute('size', u32()));
+        const override: AttributeOverride = { default: fragment`0` };
+        const out = getNodeFunctionAttributeFragment(attr, 'input.size', override, undefined, false).content;
+        expect(out).toBe('size: input.size ?? 0,');
     });
 
     it('rule 6: optional attribute without overrides becomes a conditional spread', () => {

--- a/packages/spec-generators/test/nodes/fragments/nodeFunctionPositionalArguments.test.ts
+++ b/packages/spec-generators/test/nodes/fragments/nodeFunctionPositionalArguments.test.ts
@@ -1,5 +1,5 @@
 import { fragment } from '@codama/fragments/javascript';
-import { attribute, defineNode, enumeration, node, optionalAttribute, u32, union } from '@codama/spec/api';
+import { array, attribute, defineNode, enumeration, node, optionalAttribute, u32, union } from '@codama/spec/api';
 import { describe, expect, it } from 'vitest';
 
 import type { NodeConstructorConfig } from '../../../src/nodes/config';
@@ -68,6 +68,27 @@ describe('getNodeFunctionPositionalArgumentsFragment', () => {
         expect(out).toContain('options: {');
         expect(out).toContain('subtract?:');
         expect(out).toContain('= {}');
+    });
+
+    it("widens an array attribute's `[]` default through the bare element-array type, without `| undefined`", () => {
+        // The intermediate cast widens the `[]` literal before the final
+        // narrowing to the generic. For arrays it must NOT include the
+        // `| undefined` from the type-parameter constraint — that would just
+        // add noise to the generated output.
+        const n = defineNode('myNode', {
+            attributes: [attribute('items', array(node('itemNode')))],
+        });
+        const config: NodeConstructorConfig = {
+            attributes: { items: { default: fragment`[]` } },
+            positionalArgs: ['items'],
+        };
+        const out = getNodeFunctionPositionalArgumentsFragment(
+            n,
+            getNodeTypeParameterAttributes(n, scope),
+            config,
+        ).content;
+        expect(out).toContain('= [] as Array<ItemNode> as TItems');
+        expect(out).not.toContain('| undefined');
     });
 
     it('excludes `hidden`-defaulted attributes from both signature and bag', () => {

--- a/packages/validators/src/getValidationItemsVisitor.ts
+++ b/packages/validators/src/getValidationItemsVisitor.ts
@@ -84,10 +84,11 @@ export function getValidationItemsVisitor(): Visitor<readonly ValidationItem[]> 
 
                 visitEnumType(node, { next }) {
                     const items = [] as ValidationItem[];
-                    if (node.variants.length === 0) {
+                    const variants = node.variants ?? [];
+                    if (variants.length === 0) {
                         items.push(validationItem('warn', 'Enum has no variants.', node, stack));
                     }
-                    node.variants.forEach(variant => {
+                    variants.forEach(variant => {
                         if (!variant.name) {
                             items.push(validationItem('error', 'Enum variant has no name.', node, stack));
                         }
@@ -117,7 +118,7 @@ export function getValidationItemsVisitor(): Visitor<readonly ValidationItem[]> 
 
                     // Check for duplicate account names.
                     const accountNameHistogram = new Map<string, number>();
-                    node.accounts.forEach(account => {
+                    (node.accounts ?? []).forEach(account => {
                         if (!account.name) {
                             items.push(validationItem('error', 'Instruction account has no name.', node, stack));
                             return;
@@ -166,7 +167,9 @@ export function getValidationItemsVisitor(): Visitor<readonly ValidationItem[]> 
                     getAllInstructionArguments(node).forEach(argument => {
                         const { defaultValue } = argument;
                         if (isNode(defaultValue, 'accountBumpValueNode')) {
-                            const defaultAccount = node.accounts.find(account => account.name === defaultValue.name);
+                            const defaultAccount = (node.accounts ?? []).find(
+                                account => account.name === defaultValue.name,
+                            );
                             if (defaultAccount && defaultAccount.isSigner !== false) {
                                 items.push(
                                     validationItem(
@@ -214,7 +217,7 @@ export function getValidationItemsVisitor(): Visitor<readonly ValidationItem[]> 
 
                     // Check for duplicate field names.
                     const fieldNameHistogram = new Map<string, number>();
-                    node.fields.forEach(field => {
+                    (node.fields ?? []).forEach(field => {
                         if (!field.name) return; // Handled by TypeStructField
                         const count = (fieldNameHistogram.get(field.name) ?? 0) + 1;
                         fieldNameHistogram.set(field.name, count);
@@ -235,7 +238,7 @@ export function getValidationItemsVisitor(): Visitor<readonly ValidationItem[]> 
 
                 visitTupleType(node, { next }) {
                     const items = [] as ValidationItem[];
-                    if (node.items.length === 0) {
+                    if ((node.items ?? []).length === 0) {
                         items.push(validationItem('warn', 'Tuple has no items.', node, stack));
                     }
                     return [...items, ...next(node)];

--- a/packages/validators/test/getValidationItemsVisitor.test.ts
+++ b/packages/validators/test/getValidationItemsVisitor.test.ts
@@ -41,23 +41,21 @@ test('it validates program nodes', () => {
 
 test('it validates nested nodes', () => {
     // Given the following tuple with nested issues.
-    const node = tupleTypeNode([
-        tupleTypeNode([]),
-        structTypeNode([
-            structFieldTypeNode({ name: 'owner', type: publicKeyTypeNode() }),
-            structFieldTypeNode({ name: 'owner', type: publicKeyTypeNode() }),
-        ]),
+    const tupleNode = tupleTypeNode([]);
+    const duplicateOwnerField = structFieldTypeNode({ name: 'owner', type: publicKeyTypeNode() });
+    const structNode = structTypeNode([
+        duplicateOwnerField,
+        structFieldTypeNode({ name: 'owner', type: publicKeyTypeNode() }),
     ]);
+    const node = tupleTypeNode([tupleNode, structNode]);
 
     // When we get the validation items using a visitor.
     const items = visit(node, getValidationItemsVisitor());
 
     // Then we expect the following validation errors.
-    const tupleNode = node.items[0];
-    const structNode = node.items[1];
     expect(items).toEqual([
         validationItem('warn', 'Tuple has no items.', tupleNode, [node, tupleNode]),
-        validationItem('error', 'Struct field name "owner" is not unique.', structNode.fields[0], [node, structNode]),
+        validationItem('error', 'Struct field name "owner" is not unique.', duplicateOwnerField, [node, structNode]),
     ]);
 });
 

--- a/packages/visitors-core/src/getByteSizeVisitor.ts
+++ b/packages/visitors-core/src/getByteSizeVisitor.ts
@@ -110,7 +110,7 @@ export function getByteSizeVisitor(
                     const prefix = visit(node.size, self);
                     if (prefix === null) return null;
                     if (isScalarEnum(node)) return prefix;
-                    const variantSizes = node.variants.map(v => visit(v, self));
+                    const variantSizes = (node.variants ?? []).map(v => visit(v, self));
                     const allVariantHaveTheSameFixedSize = variantSizes.every((one, _, all) => one === all[0]);
                     return allVariantHaveTheSameFixedSize && variantSizes.length > 0 && variantSizes[0] !== null
                         ? variantSizes[0] + prefix
@@ -122,7 +122,7 @@ export function getByteSizeVisitor(
                 },
 
                 visitInstruction(node, { self }) {
-                    return sumSizes(node.arguments.map(arg => visit(arg, self)));
+                    return sumSizes((node.arguments ?? []).map(arg => visit(arg, self)));
                 },
 
                 visitInstructionArgument(node, { self }) {

--- a/packages/visitors-core/src/getMaxByteSizeVisitor.ts
+++ b/packages/visitors-core/src/getMaxByteSizeVisitor.ts
@@ -102,7 +102,7 @@ export function getMaxByteSizeVisitor(
                     const prefix = visit(node.size, self);
                     if (prefix === null) return null;
                     if (isScalarEnum(node)) return prefix;
-                    const variantSizes = node.variants.map(v => visit(v, self));
+                    const variantSizes = (node.variants ?? []).map(v => visit(v, self));
                     if (variantSizes.includes(null)) return null;
                     const maxVariantSize = Math.max(...(variantSizes as number[]));
                     return prefix + maxVariantSize;
@@ -113,7 +113,7 @@ export function getMaxByteSizeVisitor(
                 },
 
                 visitInstruction(node, { self }) {
-                    return sumSizes(node.arguments.map(arg => visit(arg, self)));
+                    return sumSizes((node.arguments ?? []).map(arg => visit(arg, self)));
                 },
 
                 visitInstructionArgument(node, { self }) {

--- a/packages/visitors-core/src/getResolvedInstructionInputsVisitor.ts
+++ b/packages/visitors-core/src/getResolvedInstructionInputsVisitor.ts
@@ -125,7 +125,7 @@ export function getResolvedInstructionInputsVisitor(
                 localResolved.resolvedIsSigner = account.isSigner === false ? false : 'either';
                 localResolved.resolvedIsOptional = false;
                 const { seeds } = localResolved.defaultValue;
-                seeds.forEach(seed => {
+                (seeds ?? []).forEach(seed => {
                     if (!isNode(seed.value, 'accountValueNode')) return;
                     const dependency = visitedAccounts.get(seed.value.name)!;
                     if (dependency.resolvedIsOptional) {
@@ -172,7 +172,7 @@ export function getResolvedInstructionInputsVisitor(
         dependencies.forEach(dependency => {
             let input: InstructionInput | null = null;
             if (isNode(dependency, 'accountValueNode')) {
-                const dependencyAccount = instruction.accounts.find(a => a.name === dependency.name);
+                const dependencyAccount = (instruction.accounts ?? []).find(a => a.name === dependency.name);
                 if (!dependencyAccount) {
                     throw new CodamaError(CODAMA_ERROR__VISITORS__INVALID_INSTRUCTION_DEFAULT_VALUE_DEPENDENCY, {
                         dependency,
@@ -218,8 +218,8 @@ export function getResolvedInstructionInputsVisitor(
         visitedArgs = new Map();
 
         const inputs: InstructionInput[] = [
-            ...node.accounts,
-            ...node.arguments.filter(a => {
+            ...(node.accounts ?? []),
+            ...(node.arguments ?? []).filter(a => {
                 if (includeDataArgumentValueNodes) return a.defaultValue;
                 return a.defaultValue && !isNode(a.defaultValue, VALUE_NODES);
             }),
@@ -251,8 +251,8 @@ export function deduplicateInstructionDependencies(dependencies: InstructionDepe
 export function getInstructionDependencies(input: InstructionInput | InstructionNode): InstructionDependency[] {
     if (isNode(input, 'instructionNode')) {
         return deduplicateInstructionDependencies([
-            ...input.accounts.flatMap(getInstructionDependencies),
-            ...input.arguments.flatMap(getInstructionDependencies),
+            ...(input.accounts ?? []).flatMap(getInstructionDependencies),
+            ...(input.arguments ?? []).flatMap(getInstructionDependencies),
             ...(input.extraArguments ?? []).flatMap(getInstructionDependencies),
         ]);
     }
@@ -274,7 +274,7 @@ export function getInstructionDependencies(input: InstructionInput | Instruction
 
     if (isNode(input.defaultValue, 'pdaValueNode')) {
         const dependencies = new Map<CamelCaseString, InstructionDependency>();
-        input.defaultValue.seeds.forEach(seed => {
+        (input.defaultValue.seeds ?? []).forEach(seed => {
             if (isNode(seed.value, ['accountValueNode', 'argumentValueNode'])) {
                 dependencies.set(seed.value.name, { ...seed.value });
             }

--- a/packages/visitors-core/src/identityVisitor.ts
+++ b/packages/visitors-core/src/identityVisitor.ts
@@ -63,7 +63,7 @@ export function identityVisitor<TNodeKind extends NodeKind = NodeKind>(
                 return enumEmptyVariantTypeNode(node.name);
             }
             assertIsNode(newStruct, 'structTypeNode');
-            if (newStruct.fields.length === 0) {
+            if ((newStruct.fields ?? []).length === 0) {
                 return enumEmptyVariantTypeNode(node.name);
             }
             return enumStructVariantTypeNode(node.name, newStruct, node.discriminator);
@@ -77,7 +77,7 @@ export function identityVisitor<TNodeKind extends NodeKind = NodeKind>(
                 return enumEmptyVariantTypeNode(node.name);
             }
             assertIsNode(newTuple, 'tupleTypeNode');
-            if (newTuple.items.length === 0) {
+            if ((newTuple.items ?? []).length === 0) {
                 return enumEmptyVariantTypeNode(node.name);
             }
             return enumTupleVariantTypeNode(node.name, newTuple, node.discriminator);

--- a/packages/visitors-core/test/NodeSelector.test.ts
+++ b/packages/visitors-core/test/NodeSelector.test.ts
@@ -35,153 +35,98 @@ import {
     visit,
 } from '../src';
 
-// Given the following tree.
-const tree = rootNode(
-    programNode({
-        accounts: [
-            accountNode({
-                data: structTypeNode([
-                    structFieldTypeNode({
-                        name: 'owner',
-                        type: publicKeyTypeNode(),
-                    }),
-                    structFieldTypeNode({
-                        name: 'mint',
-                        type: publicKeyTypeNode(),
-                    }),
-                    structFieldTypeNode({
-                        name: 'amount',
-                        type: numberTypeNode('u64'),
-                    }),
-                    structFieldTypeNode({
-                        name: 'delegatedAmount',
-                        type: optionTypeNode(numberTypeNode('u64'), {
-                            prefix: numberTypeNode('u32'),
-                        }),
-                    }),
-                ]),
-                name: 'token',
-            }),
-        ],
-        definedTypes: [],
-        errors: [
-            errorNode({
-                code: 0,
-                message: 'Invalid program ID',
-                name: 'invalidProgramId',
-            }),
-            errorNode({
-                code: 1,
-                message: 'Invalid token owner',
-                name: 'invalidTokenOwner',
-            }),
-        ],
-        instructions: [
-            instructionNode({
-                accounts: [
-                    instructionAccountNode({
-                        isSigner: false,
-                        isWritable: true,
-                        name: 'token',
-                    }),
-                    instructionAccountNode({
-                        isSigner: false,
-                        isWritable: true,
-                        name: 'mint',
-                    }),
-                    instructionAccountNode({
-                        isSigner: true,
-                        isWritable: false,
-                        name: 'mintAuthority',
-                    }),
-                ],
-                arguments: [
-                    instructionArgumentNode({
-                        name: 'amount',
-                        type: numberTypeNode('u64'),
-                    }),
-                ],
-                name: 'mintToken',
-            }),
-        ],
-        name: 'splToken',
-        publicKey: '1111',
-        version: '1.0.0',
-    }),
-    [
-        programNode({
-            accounts: [
-                accountNode({
-                    data: structTypeNode([
-                        structFieldTypeNode({
-                            name: 'owner',
-                            type: publicKeyTypeNode(),
-                        }),
-                        structFieldTypeNode({
-                            name: 'opened',
-                            type: booleanTypeNode(numberTypeNode('u64')),
-                        }),
-                        structFieldTypeNode({
-                            name: 'amount',
-                            type: numberTypeNode('u64'),
-                        }),
-                        structFieldTypeNode({
-                            name: 'wrappingPaper',
-                            type: definedTypeLinkNode('wrappingPaper'),
-                        }),
-                    ]),
-                    name: 'gift',
-                }),
-            ],
-            definedTypes: [
-                definedTypeNode({
-                    name: 'wrappingPaper',
-                    type: enumTypeNode([
-                        enumEmptyVariantTypeNode('blue'),
-                        enumEmptyVariantTypeNode('red'),
-                        enumStructVariantTypeNode(
-                            'gold',
-                            structTypeNode([
-                                structFieldTypeNode({
-                                    name: 'owner',
-                                    type: publicKeyTypeNode(),
-                                }),
-                            ]),
-                        ),
-                    ]),
-                }),
-            ],
-            errors: [
-                errorNode({
-                    code: 0,
-                    message: 'Invalid program ID',
-                    name: 'invalidProgramId',
-                }),
-            ],
-            instructions: [
-                instructionNode({
-                    accounts: [
-                        instructionAccountNode({
-                            isSigner: false,
-                            isWritable: true,
-                            name: 'gift',
-                        }),
-                        instructionAccountNode({
-                            isSigner: true,
-                            isWritable: false,
-                            name: 'owner',
-                        }),
-                    ],
-                    arguments: [],
-                    name: 'openGift',
-                }),
-            ],
-            name: 'christmasProgram',
-            publicKey: '2222',
-            version: '1.0.0',
-        }),
+// Given the following tree. Nodes referenced by the assertions below are
+// hoisted into named locals so the assertions can reference them directly,
+// rather than re-reading them back through the (optionally-typed) node graph.
+
+// splToken account fields.
+const tokenAccountOwnerField = structFieldTypeNode({ name: 'owner', type: publicKeyTypeNode() });
+const tokenAccountMintField = structFieldTypeNode({ name: 'mint', type: publicKeyTypeNode() });
+const tokenAccountAmountField = structFieldTypeNode({ name: 'amount', type: numberTypeNode('u64') });
+const tokenDelegatedAmountOption = optionTypeNode(numberTypeNode('u64'), { prefix: numberTypeNode('u32') });
+const tokenAccountDelegatedAmountField = structFieldTypeNode({
+    name: 'delegatedAmount',
+    type: tokenDelegatedAmountOption,
+});
+const tokenAccount = accountNode({
+    data: structTypeNode([
+        tokenAccountOwnerField,
+        tokenAccountMintField,
+        tokenAccountAmountField,
+        tokenAccountDelegatedAmountField,
+    ]),
+    name: 'token',
+});
+
+// splToken instruction.
+const mintTokenAmountArgument = instructionArgumentNode({ name: 'amount', type: numberTypeNode('u64') });
+const mintTokenInstruction = instructionNode({
+    accounts: [
+        instructionAccountNode({ isSigner: false, isWritable: true, name: 'token' }),
+        instructionAccountNode({ isSigner: false, isWritable: true, name: 'mint' }),
+        instructionAccountNode({ isSigner: true, isWritable: false, name: 'mintAuthority' }),
     ],
-);
+    arguments: [mintTokenAmountArgument],
+    name: 'mintToken',
+});
+
+const splTokenProgram = programNode({
+    accounts: [tokenAccount],
+    errors: [
+        errorNode({ code: 0, message: 'Invalid program ID', name: 'invalidProgramId' }),
+        errorNode({ code: 1, message: 'Invalid token owner', name: 'invalidTokenOwner' }),
+    ],
+    instructions: [mintTokenInstruction],
+    name: 'splToken',
+    publicKey: '1111',
+    version: '1.0.0',
+});
+
+// christmasProgram account fields.
+const giftAccountOwnerField = structFieldTypeNode({ name: 'owner', type: publicKeyTypeNode() });
+const giftAccountOpenedField = structFieldTypeNode({ name: 'opened', type: booleanTypeNode(numberTypeNode('u64')) });
+const giftAccountAmountField = structFieldTypeNode({ name: 'amount', type: numberTypeNode('u64') });
+const giftAccountWrappingPaperField = structFieldTypeNode({
+    name: 'wrappingPaper',
+    type: definedTypeLinkNode('wrappingPaper'),
+});
+const giftAccount = accountNode({
+    data: structTypeNode([
+        giftAccountOwnerField,
+        giftAccountOpenedField,
+        giftAccountAmountField,
+        giftAccountWrappingPaperField,
+    ]),
+    name: 'gift',
+});
+
+// christmasProgram wrappingPaper defined type.
+const wrappingPaperGoldOwnerField = structFieldTypeNode({ name: 'owner', type: publicKeyTypeNode() });
+const wrappingPaperBlueVariant = enumEmptyVariantTypeNode('blue');
+const wrappingPaperRedVariant = enumEmptyVariantTypeNode('red');
+const wrappingPaperEnumGold = enumStructVariantTypeNode('gold', structTypeNode([wrappingPaperGoldOwnerField]));
+const wrappingPaperEnum = enumTypeNode([wrappingPaperBlueVariant, wrappingPaperRedVariant, wrappingPaperEnumGold]);
+const wrappingPaper = definedTypeNode({ name: 'wrappingPaper', type: wrappingPaperEnum });
+
+// christmasProgram instruction.
+const openGiftGiftAccount = instructionAccountNode({ isSigner: false, isWritable: true, name: 'gift' });
+const openGiftOwnerAccount = instructionAccountNode({ isSigner: true, isWritable: false, name: 'owner' });
+const openGiftInstruction = instructionNode({
+    accounts: [openGiftGiftAccount, openGiftOwnerAccount],
+    name: 'openGift',
+});
+
+const christmasProgram = programNode({
+    accounts: [giftAccount],
+    definedTypes: [wrappingPaper],
+    errors: [errorNode({ code: 0, message: 'Invalid program ID', name: 'invalidProgramId' })],
+    instructions: [openGiftInstruction],
+    name: 'christmasProgram',
+    publicKey: '2222',
+    version: '1.0.0',
+});
+
+const tree = rootNode(splTokenProgram, [christmasProgram]);
 
 const macro = (selector: NodeSelector, expectedSelected: Node[]) => {
     const title =
@@ -247,88 +192,64 @@ const macro = (selector: NodeSelector, expectedSelected: Node[]) => {
  *     [errorNode] invalidProgramId (0)
  */
 
-const splTokenProgram = tree.program;
-const christmasProgram = tree.additionalPrograms[0];
-const tokenAccount = splTokenProgram.accounts[0];
-const tokenDelegatedAmountOption = tokenAccount.data.fields[3].type;
-const mintTokenInstruction = splTokenProgram.instructions[0];
-const giftAccount = christmasProgram.accounts[0];
-const openGiftInstruction = christmasProgram.instructions[0];
-const wrappingPaper = christmasProgram.definedTypes[0];
-const wrappingPaperEnum = wrappingPaper.type;
-const wrappingPaperEnumGold = wrappingPaperEnum.variants[2];
-
 // Select programs.
 macro('[programNode]', [splTokenProgram, christmasProgram]);
 macro('[programNode]splToken', [splTokenProgram]);
 macro('christmasProgram', [christmasProgram]);
 
 // Select and filter owner nodes.
-macro('owner', [
-    tokenAccount.data.fields[0],
-    giftAccount.data.fields[0],
-    wrappingPaperEnumGold.struct.fields[0],
-    openGiftInstruction.accounts[1],
-]);
-macro('[structFieldTypeNode]owner', [
-    tokenAccount.data.fields[0],
-    giftAccount.data.fields[0],
-    wrappingPaperEnumGold.struct.fields[0],
-]);
-macro('splToken.owner', [tokenAccount.data.fields[0]]);
-macro('[instructionNode].owner', [openGiftInstruction.accounts[1]]);
-macro('[accountNode].owner', [tokenAccount.data.fields[0], giftAccount.data.fields[0]]);
-macro('[accountNode]token.owner', [tokenAccount.data.fields[0]]);
-macro('christmasProgram.[accountNode].owner', [giftAccount.data.fields[0]]);
+macro('owner', [tokenAccountOwnerField, giftAccountOwnerField, wrappingPaperGoldOwnerField, openGiftOwnerAccount]);
+macro('[structFieldTypeNode]owner', [tokenAccountOwnerField, giftAccountOwnerField, wrappingPaperGoldOwnerField]);
+macro('splToken.owner', [tokenAccountOwnerField]);
+macro('[instructionNode].owner', [openGiftOwnerAccount]);
+macro('[accountNode].owner', [tokenAccountOwnerField, giftAccountOwnerField]);
+macro('[accountNode]token.owner', [tokenAccountOwnerField]);
+macro('christmasProgram.[accountNode].owner', [giftAccountOwnerField]);
 macro('[programNode]christmasProgram.[definedTypeNode]wrappingPaper.[enumStructVariantTypeNode]gold.owner', [
-    wrappingPaperEnumGold.struct.fields[0],
+    wrappingPaperGoldOwnerField,
 ]);
-macro('christmasProgram.wrappingPaper.gold.owner', [wrappingPaperEnumGold.struct.fields[0]]);
+macro('christmasProgram.wrappingPaper.gold.owner', [wrappingPaperGoldOwnerField]);
 
 // Select all descendants of a node.
 macro('wrappingPaper.*', [
-    giftAccount.data.fields[3].type,
+    giftAccountWrappingPaperField.type,
     wrappingPaperEnum,
     wrappingPaperEnum.size,
-    wrappingPaperEnum.variants[0],
-    wrappingPaperEnum.variants[1],
-    wrappingPaperEnum.variants[2],
+    wrappingPaperBlueVariant,
+    wrappingPaperRedVariant,
+    wrappingPaperEnumGold,
     wrappingPaperEnumGold.struct,
-    wrappingPaperEnumGold.struct.fields[0],
-    wrappingPaperEnumGold.struct.fields[0].type,
+    wrappingPaperGoldOwnerField,
+    wrappingPaperGoldOwnerField.type,
 ]);
-macro('wrappingPaper.[structFieldTypeNode]', [wrappingPaperEnumGold.struct.fields[0]]);
-macro('wrappingPaper.blue', [wrappingPaperEnum.variants[0]]);
-macro('amount.*', [
-    tokenAccount.data.fields[2].type,
-    mintTokenInstruction.arguments[0].type,
-    giftAccount.data.fields[2].type,
-]);
-macro('[instructionNode].amount.*', [mintTokenInstruction.arguments[0].type]);
+macro('wrappingPaper.[structFieldTypeNode]', [wrappingPaperGoldOwnerField]);
+macro('wrappingPaper.blue', [wrappingPaperBlueVariant]);
+macro('amount.*', [tokenAccountAmountField.type, mintTokenAmountArgument.type, giftAccountAmountField.type]);
+macro('[instructionNode].amount.*', [mintTokenAmountArgument.type]);
 macro('[structFieldTypeNode].*', [
-    tokenAccount.data.fields[0].type,
-    tokenAccount.data.fields[1].type,
-    tokenAccount.data.fields[2].type,
-    tokenAccount.data.fields[3].type,
+    tokenAccountOwnerField.type,
+    tokenAccountMintField.type,
+    tokenAccountAmountField.type,
+    tokenAccountDelegatedAmountField.type,
     tokenDelegatedAmountOption.prefix,
     tokenDelegatedAmountOption.item,
-    giftAccount.data.fields[0].type,
-    giftAccount.data.fields[1].type,
-    giftAccount.data.fields[1].type.size,
-    giftAccount.data.fields[2].type,
-    giftAccount.data.fields[3].type,
-    wrappingPaperEnumGold.struct.fields[0].type,
+    giftAccountOwnerField.type,
+    giftAccountOpenedField.type,
+    giftAccountOpenedField.type.size,
+    giftAccountAmountField.type,
+    giftAccountWrappingPaperField.type,
+    wrappingPaperGoldOwnerField.type,
 ]);
 macro('[structFieldTypeNode].*.*', [
     tokenDelegatedAmountOption.prefix,
     tokenDelegatedAmountOption.item,
-    giftAccount.data.fields[1].type.size,
+    giftAccountOpenedField.type.size,
 ]);
 
 // Select multiple node kinds.
 macro('[accountNode]gift.[publicKeyTypeNode|booleanTypeNode]', [
-    giftAccount.data.fields[0].type,
-    giftAccount.data.fields[1].type,
+    giftAccountOwnerField.type,
+    giftAccountOpenedField.type,
 ]);
 
 // Select using functions.

--- a/packages/visitors-core/test/bottomUpTransformerVisitor.test.ts
+++ b/packages/visitors-core/test/bottomUpTransformerVisitor.test.ts
@@ -125,8 +125,9 @@ test('it can transform nodes using multiple node selectors', () => {
 test('it can start from an existing stack', () => {
     // Given the following tuple node inside a program node.
     const tuple = tupleTypeNode([numberTypeNode('u32'), publicKeyTypeNode()]);
+    const myTuple = definedTypeNode({ name: 'myTuple', type: tuple });
     const program = programNode({
-        definedTypes: [definedTypeNode({ name: 'myTuple', type: tuple })],
+        definedTypes: [myTuple],
         name: 'myProgram',
         publicKey: '1111',
     });
@@ -139,7 +140,7 @@ test('it can start from an existing stack', () => {
     };
 
     // When we visit the tuple with an existing stack that contains the program node.
-    const stack = new NodeStack([program, program.definedTypes[0]]);
+    const stack = new NodeStack([program, myTuple]);
     const resultWithStack = visit(tuple, bottomUpTransformerVisitor([transformer], { stack }));
 
     // Then we expect the number node to have been removed.

--- a/packages/visitors-core/test/extendVisitor.test.ts
+++ b/packages/visitors-core/test/extendVisitor.test.ts
@@ -38,7 +38,8 @@ test('it can visit itself using the exposed self argument', () => {
         (_, values) => values.reduce((a, b) => a + b, 1),
     );
     const visitor = extendVisitor(baseVisitor, {
-        visitTupleType: (node, { self }) => (node.items.length > 1 ? visit(node.items[0], self) : 0) + 1,
+        visitTupleType: (node, { self }) =>
+            ((node.items ?? []).length > 1 ? visit((node.items ?? [])[0], self) : 0) + 1,
     });
 
     // When we visit the tree using that visitor.

--- a/packages/visitors-core/test/getByteSizeVisitor.test.ts
+++ b/packages/visitors-core/test/getByteSizeVisitor.test.ts
@@ -206,13 +206,12 @@ describe('definedTypeLinkNode', () => {
         expectSizeWithContext([context, definedTypeLinkNode('myType')], null);
     });
     test('it follows linked nodes using the correct paths when jumping between programs', () => {
+        const typeA = definedTypeNode({
+            name: 'typeA',
+            type: definedTypeLinkNode('typeB1', programLinkNode('programB')),
+        });
         const programA = programNode({
-            definedTypes: [
-                definedTypeNode({
-                    name: 'typeA',
-                    type: definedTypeLinkNode('typeB1', programLinkNode('programB')),
-                }),
-            ],
+            definedTypes: [typeA],
             name: 'programA',
             publicKey: '1111',
         });
@@ -226,7 +225,7 @@ describe('definedTypeLinkNode', () => {
         });
         const context = rootNode(programA, [programB]);
 
-        expectSizeWithContext([context, programA, programA.definedTypes[0]], 8);
+        expectSizeWithContext([context, programA, typeA], 8);
     });
 });
 

--- a/packages/visitors-core/test/getMaxByteSizeVisitor.test.ts
+++ b/packages/visitors-core/test/getMaxByteSizeVisitor.test.ts
@@ -205,13 +205,12 @@ describe('definedTypeLinkNode', () => {
         expectMaxSizeWithContext([context, definedTypeLinkNode('myType')], null);
     });
     test('it follows linked nodes using the correct paths when jumping between programs', () => {
+        const typeA = definedTypeNode({
+            name: 'typeA',
+            type: definedTypeLinkNode('typeB1', programLinkNode('programB')),
+        });
         const programA = programNode({
-            definedTypes: [
-                definedTypeNode({
-                    name: 'typeA',
-                    type: definedTypeLinkNode('typeB1', programLinkNode('programB')),
-                }),
-            ],
+            definedTypes: [typeA],
             name: 'programA',
             publicKey: '1111',
         });
@@ -225,7 +224,7 @@ describe('definedTypeLinkNode', () => {
         });
         const context = rootNode(programA, [programB]);
 
-        expectMaxSizeWithContext([context, programA, programA.definedTypes[0]], 3);
+        expectMaxSizeWithContext([context, programA, typeA], 3);
     });
 });
 

--- a/packages/visitors-core/test/getResolvedInstructionInputsVisitor.test.ts
+++ b/packages/visitors-core/test/getResolvedInstructionInputsVisitor.test.ts
@@ -37,14 +37,14 @@ test('it returns all instruction accounts in order of resolution', () => {
     // Then we expect the accounts to be in order of resolution.
     expect(result).toEqual([
         {
-            ...node.accounts[1],
+            ...(node.accounts ?? [])[1],
             dependsOn: [],
             isPda: false,
             resolvedIsOptional: false,
             resolvedIsSigner: true,
         },
         {
-            ...node.accounts[0],
+            ...(node.accounts ?? [])[0],
             dependsOn: [accountValueNode('authority')],
             isPda: false,
             resolvedIsOptional: false,
@@ -77,7 +77,7 @@ test('it sets the resolved signer to either when a non signer defaults to a sign
 
     // Then we expect the resolved signer to be either for the non signer account.
     expect(result[1]).toEqual({
-        ...node.accounts[0],
+        ...(node.accounts ?? [])[0],
         dependsOn: [accountValueNode('authority')],
         isPda: false,
         resolvedIsOptional: false,
@@ -109,7 +109,7 @@ test('it sets the resolved signer to either when a signer defaults to a non sign
 
     // Then we expect the resolved signer to be either for the signer account.
     expect(result[1]).toEqual({
-        ...node.accounts[0],
+        ...(node.accounts ?? [])[0],
         dependsOn: [accountValueNode('authority')],
         isPda: false,
         resolvedIsOptional: false,
@@ -149,14 +149,14 @@ test('it includes instruction data arguments with default values', () => {
     // Then we expect the following inputs.
     expect(result).toEqual([
         {
-            ...node.accounts[0],
+            ...(node.accounts ?? [])[0],
             dependsOn: [],
             isPda: false,
             resolvedIsOptional: false,
             resolvedIsSigner: true,
         },
         {
-            ...node.arguments[0],
+            ...(node.arguments ?? [])[0],
             dependsOn: [accountValueNode('owner')],
         },
     ]);
@@ -197,7 +197,7 @@ test('it includes instruction extra arguments with default values', () => {
     // Then we expect the following inputs.
     expect(result).toEqual([
         {
-            ...node.accounts[0],
+            ...(node.accounts ?? [])[0],
             dependsOn: [],
             isPda: false,
             resolvedIsOptional: false,
@@ -249,14 +249,14 @@ test('it resolves the seeds of a PdaValueNode first', () => {
     // Then we expect the accounts to be in order of resolution.
     expect(result).toEqual([
         {
-            ...node.accounts[1],
+            ...(node.accounts ?? [])[1],
             dependsOn: [],
             isPda: false,
             resolvedIsOptional: false,
             resolvedIsSigner: true,
         },
         {
-            ...node.accounts[0],
+            ...(node.accounts ?? [])[0],
             dependsOn: [accountValueNode('payer')],
             isPda: false,
             resolvedIsOptional: false,
@@ -290,14 +290,14 @@ test('it resolves the program id of a PdaValueNode first', () => {
     // Then we expect the accounts to be in order of resolution.
     expect(result).toEqual([
         {
-            ...node.accounts[1],
+            ...(node.accounts ?? [])[1],
             dependsOn: [],
             isPda: false,
             resolvedIsOptional: false,
             resolvedIsSigner: false,
         },
         {
-            ...node.accounts[0],
+            ...(node.accounts ?? [])[0],
             dependsOn: [accountValueNode('counterProgram')],
             isPda: false,
             resolvedIsOptional: false,

--- a/packages/visitors-core/test/identityVisitor.test.ts
+++ b/packages/visitors-core/test/identityVisitor.test.ts
@@ -16,8 +16,8 @@ test('it visits all nodes and returns different instances of the same nodes', ()
     // But the nodes are different instances.
     expect(result).not.toBe(node);
     assertIsNode(result, 'tupleTypeNode');
-    expect(result.items[0]).not.toBe(node.items[0]);
-    expect(result.items[1]).not.toBe(node.items[1]);
+    expect((result.items ?? [])[0]).not.toBe((node.items ?? [])[0]);
+    expect((result.items ?? [])[1]).not.toBe((node.items ?? [])[1]);
 });
 
 test('it can remove nodes by returning null', () => {
@@ -54,8 +54,8 @@ test('it can create partial visitors', () => {
     expect(result).toEqual(node);
     expect(result).not.toBe(node);
     assertIsNode(result, 'tupleTypeNode');
-    expect(result.items[0]).not.toBe(node.items[0]);
-    expect(result.items[1]).not.toBe(node.items[1]);
+    expect((result.items ?? [])[0]).not.toBe((node.items ?? [])[0]);
+    expect((result.items ?? [])[1]).not.toBe((node.items ?? [])[1]);
 
     // But the unsupported node was not visited.
     expect(events).toEqual(['visiting:tupleTypeNode', 'visiting:numberTypeNode']);

--- a/packages/visitors-core/test/mapVisitor.test.ts
+++ b/packages/visitors-core/test/mapVisitor.test.ts
@@ -5,7 +5,9 @@ import { mapVisitor, mergeVisitor, staticVisitor, visit, Visitor } from '../src'
 
 test('it maps the return value of a visitor to another', () => {
     // Given the following 3-nodes tree.
-    const node = tupleTypeNode([numberTypeNode('u32'), publicKeyTypeNode()]);
+    const item0 = numberTypeNode('u32');
+    const item1 = publicKeyTypeNode();
+    const node = tupleTypeNode([item0, item1]);
 
     // And a merge visitor A that lists the kind of each node.
     const visitorA = mergeVisitor(
@@ -18,8 +20,8 @@ test('it maps the return value of a visitor to another', () => {
 
     // Then we expect the following results when visiting different nodes.
     expect(visit(node, visitorB)).toBe(49);
-    expect(visit(node.items[0], visitorB)).toBe(16);
-    expect(visit(node.items[1], visitorB)).toBe(17);
+    expect(visit(item0, visitorB)).toBe(16);
+    expect(visit(item1, visitorB)).toBe(17);
 });
 
 test('it creates partial visitors from partial visitors', () => {

--- a/packages/visitors-core/test/nodes/InstructionNode.test.ts
+++ b/packages/visitors-core/test/nodes/InstructionNode.test.ts
@@ -57,9 +57,9 @@ test('identityVisitor', () => {
 
 test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[instructionNode]', null);
-    expectDeleteNodesVisitor(node, '[instructionAccountNode]', { ...node, accounts: [] });
-    expectDeleteNodesVisitor(node, '[instructionArgumentNode]', { ...node, arguments: [] });
-    expectDeleteNodesVisitor(node, '[fieldDiscriminatorNode]', { ...node, discriminators: [] });
+    expectDeleteNodesVisitor(node, '[instructionAccountNode]', { ...node, accounts: undefined });
+    expectDeleteNodesVisitor(node, '[instructionArgumentNode]', { ...node, arguments: undefined });
+    expectDeleteNodesVisitor(node, '[fieldDiscriminatorNode]', { ...node, discriminators: undefined });
 });
 
 test('debugStringVisitor', () => {

--- a/packages/visitors-core/test/nodes/PdaNode.test.ts
+++ b/packages/visitors-core/test/nodes/PdaNode.test.ts
@@ -34,7 +34,7 @@ test('identityVisitor', () => {
 
 test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[pdaNode]', null);
-    expectDeleteNodesVisitor(node, ['[variablePdaSeedNode]', '[constantPdaSeedNode]'], { ...node, seeds: [] });
+    expectDeleteNodesVisitor(node, ['[variablePdaSeedNode]', '[constantPdaSeedNode]'], { ...node, seeds: undefined });
     expectDeleteNodesVisitor(node, '[publicKeyTypeNode]', {
         ...node,
         seeds: [constantPdaSeedNode(numberTypeNode('u8'), numberValueNode(123456))],

--- a/packages/visitors-core/test/nodes/ProgramNode.test.ts
+++ b/packages/visitors-core/test/nodes/ProgramNode.test.ts
@@ -46,12 +46,12 @@ test('identityVisitor', () => {
 
 test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[programNode]', null);
-    expectDeleteNodesVisitor(node, '[pdaNode]', { ...node, pdas: [] });
-    expectDeleteNodesVisitor(node, '[accountNode]', { ...node, accounts: [] });
-    expectDeleteNodesVisitor(node, '[eventNode]', { ...node, events: [] });
-    expectDeleteNodesVisitor(node, '[instructionNode]', { ...node, instructions: [] });
-    expectDeleteNodesVisitor(node, '[definedTypeNode]', { ...node, definedTypes: [] });
-    expectDeleteNodesVisitor(node, '[errorNode]', { ...node, errors: [] });
+    expectDeleteNodesVisitor(node, '[pdaNode]', { ...node, pdas: undefined });
+    expectDeleteNodesVisitor(node, '[accountNode]', { ...node, accounts: undefined });
+    expectDeleteNodesVisitor(node, '[eventNode]', { ...node, events: undefined });
+    expectDeleteNodesVisitor(node, '[instructionNode]', { ...node, instructions: undefined });
+    expectDeleteNodesVisitor(node, '[definedTypeNode]', { ...node, definedTypes: undefined });
+    expectDeleteNodesVisitor(node, '[errorNode]', { ...node, errors: undefined });
 });
 
 test('debugStringVisitor', () => {

--- a/packages/visitors-core/test/nodes/RootNode.test.ts
+++ b/packages/visitors-core/test/nodes/RootNode.test.ts
@@ -32,7 +32,7 @@ test('identityVisitor', () => {
 test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[rootNode]', null);
     expectDeleteNodesVisitor(node, '[programNode]', null);
-    expectDeleteNodesVisitor(node, '[programNode]splAddressLookupTable', { ...node, additionalPrograms: [] });
+    expectDeleteNodesVisitor(node, '[programNode]splAddressLookupTable', { ...node, additionalPrograms: undefined });
 });
 
 test('debugStringVisitor', () => {

--- a/packages/visitors-core/test/nodes/contextualValueNodes/PdaValueNode.test.ts
+++ b/packages/visitors-core/test/nodes/contextualValueNodes/PdaValueNode.test.ts
@@ -53,7 +53,7 @@ test('identityVisitor with inlined PdaNode', () => {
 test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[pdaValueNode]', null);
     expectDeleteNodesVisitor(node, '[pdaLinkNode]', null);
-    expectDeleteNodesVisitor(node, '[pdaSeedValueNode]', { ...node, seeds: [] });
+    expectDeleteNodesVisitor(node, '[pdaSeedValueNode]', { ...node, seeds: undefined });
 });
 
 test('debugStringVisitor', () => {

--- a/packages/visitors-core/test/nodes/typeNodes/EnumTypeNode.test.ts
+++ b/packages/visitors-core/test/nodes/typeNodes/EnumTypeNode.test.ts
@@ -47,7 +47,7 @@ test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(
         node,
         ['[enumEmptyVariantTypeNode]', '[enumTupleVariantTypeNode]', '[enumStructVariantTypeNode]'],
-        { ...node, variants: [] },
+        { ...node, variants: undefined },
     );
     expectDeleteNodesVisitor(node, ['[tupleTypeNode]', '[structFieldTypeNode]'], {
         ...node,

--- a/packages/visitors-core/test/nodes/typeNodes/StructTypeNode.test.ts
+++ b/packages/visitors-core/test/nodes/typeNodes/StructTypeNode.test.ts
@@ -23,8 +23,8 @@ test('identityVisitor', () => {
 
 test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[structTypeNode]', null);
-    expectDeleteNodesVisitor(node, '[structFieldTypeNode]', { ...node, fields: [] });
-    expectDeleteNodesVisitor(node, ['[publicKeyTypeNode]', '[numberTypeNode]'], { ...node, fields: [] });
+    expectDeleteNodesVisitor(node, '[structFieldTypeNode]', { ...node, fields: undefined });
+    expectDeleteNodesVisitor(node, ['[publicKeyTypeNode]', '[numberTypeNode]'], { ...node, fields: undefined });
 });
 
 test('debugStringVisitor', () => {

--- a/packages/visitors-core/test/nodes/typeNodes/TupleTypeNode.test.ts
+++ b/packages/visitors-core/test/nodes/typeNodes/TupleTypeNode.test.ts
@@ -20,7 +20,7 @@ test('identityVisitor', () => {
 
 test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[tupleTypeNode]', null);
-    expectDeleteNodesVisitor(node, ['[publicKeyTypeNode]', '[numberTypeNode]'], { ...node, items: [] });
+    expectDeleteNodesVisitor(node, ['[publicKeyTypeNode]', '[numberTypeNode]'], { ...node, items: undefined });
 });
 
 test('debugStringVisitor', () => {

--- a/packages/visitors-core/test/nodes/valueNodes/ArrayValueNode.test.ts
+++ b/packages/visitors-core/test/nodes/valueNodes/ArrayValueNode.test.ts
@@ -24,7 +24,7 @@ test('identityVisitor', () => {
 
 test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[arrayValueNode]', null);
-    expectDeleteNodesVisitor(node, '[publicKeyValueNode]', { ...node, items: [] });
+    expectDeleteNodesVisitor(node, '[publicKeyValueNode]', { ...node, items: undefined });
 });
 
 test('debugStringVisitor', () => {

--- a/packages/visitors-core/test/nodes/valueNodes/MapValueNode.test.ts
+++ b/packages/visitors-core/test/nodes/valueNodes/MapValueNode.test.ts
@@ -24,7 +24,7 @@ test('identityVisitor', () => {
 
 test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[mapValueNode]', null);
-    expectDeleteNodesVisitor(node, '[mapEntryValueNode]', { ...node, entries: [] });
+    expectDeleteNodesVisitor(node, '[mapEntryValueNode]', { ...node, entries: undefined });
 });
 
 test('debugStringVisitor', () => {

--- a/packages/visitors-core/test/nodes/valueNodes/SetValueNode.test.ts
+++ b/packages/visitors-core/test/nodes/valueNodes/SetValueNode.test.ts
@@ -24,7 +24,7 @@ test('identityVisitor', () => {
 
 test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[setValueNode]', null);
-    expectDeleteNodesVisitor(node, '[publicKeyValueNode]', { ...node, items: [] });
+    expectDeleteNodesVisitor(node, '[publicKeyValueNode]', { ...node, items: undefined });
 });
 
 test('debugStringVisitor', () => {

--- a/packages/visitors-core/test/nodes/valueNodes/StructValueNode.test.ts
+++ b/packages/visitors-core/test/nodes/valueNodes/StructValueNode.test.ts
@@ -23,7 +23,7 @@ test('identityVisitor', () => {
 
 test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[structValueNode]', null);
-    expectDeleteNodesVisitor(node, '[structFieldValueNode]', { ...node, fields: [] });
+    expectDeleteNodesVisitor(node, '[structFieldValueNode]', { ...node, fields: undefined });
 });
 
 test('debugStringVisitor', () => {

--- a/packages/visitors-core/test/nodes/valueNodes/TupleValueNode.test.ts
+++ b/packages/visitors-core/test/nodes/valueNodes/TupleValueNode.test.ts
@@ -26,7 +26,7 @@ test('deleteNodesVisitor', () => {
     expectDeleteNodesVisitor(node, '[tupleValueNode]', null);
     expectDeleteNodesVisitor(node, ['[stringValueNode]', '[numberValueNode]', '[publicKeyValueNode]'], {
         ...node,
-        items: [],
+        items: undefined,
     });
 });
 

--- a/packages/visitors-core/test/nonNullableIdentityVisitor.test.ts
+++ b/packages/visitors-core/test/nonNullableIdentityVisitor.test.ts
@@ -19,6 +19,6 @@ test('it visits all nodes and returns different instances of the same nodes with
     // But the nodes are different instances.
     expect(result).not.toBe(node);
     assertIsNode(result, 'tupleTypeNode');
-    expect(result.items[0]).not.toBe(node.items[0]);
-    expect(result.items[1]).not.toBe(node.items[1]);
+    expect((result.items ?? [])[0]).not.toBe((node.items ?? [])[0]);
+    expect((result.items ?? [])[1]).not.toBe((node.items ?? [])[1]);
 });

--- a/packages/visitors-core/test/recordLinkablesVisitor.test.ts
+++ b/packages/visitors-core/test/recordLinkablesVisitor.test.ts
@@ -47,7 +47,7 @@ test('it records program nodes', () => {
 
     // Then we expect program paths to be recorded and retrievable.
     expect(linkables.getPath([programLinkNode('programA')])).toEqual([node, node.program]);
-    expect(linkables.getPath([programLinkNode('programB')])).toEqual([node, node.additionalPrograms[0]]);
+    expect(linkables.getPath([programLinkNode('programB')])).toEqual([node, (node.additionalPrograms ?? [])[0]]);
 });
 
 test('it records account nodes', () => {
@@ -66,8 +66,8 @@ test('it records account nodes', () => {
     visit(node, visitor);
 
     // Then we expect account paths to be recorded and retrievable.
-    expect(linkables.getPath([accountLinkNode('accountA', 'myProgram')])).toEqual([node, node.accounts[0]]);
-    expect(linkables.getPath([accountLinkNode('accountB', 'myProgram')])).toEqual([node, node.accounts[1]]);
+    expect(linkables.getPath([accountLinkNode('accountA', 'myProgram')])).toEqual([node, (node.accounts ?? [])[0]]);
+    expect(linkables.getPath([accountLinkNode('accountB', 'myProgram')])).toEqual([node, (node.accounts ?? [])[1]]);
 });
 
 test('it records defined type nodes', () => {
@@ -89,8 +89,14 @@ test('it records defined type nodes', () => {
     visit(node, visitor);
 
     // Then we expect defined type paths to be recorded and retrievable.
-    expect(linkables.getPath([definedTypeLinkNode('typeA', 'myProgram')])).toEqual([node, node.definedTypes[0]]);
-    expect(linkables.getPath([definedTypeLinkNode('typeB', 'myProgram')])).toEqual([node, node.definedTypes[1]]);
+    expect(linkables.getPath([definedTypeLinkNode('typeA', 'myProgram')])).toEqual([
+        node,
+        (node.definedTypes ?? [])[0],
+    ]);
+    expect(linkables.getPath([definedTypeLinkNode('typeB', 'myProgram')])).toEqual([
+        node,
+        (node.definedTypes ?? [])[1],
+    ]);
 });
 
 test('it records pda nodes', () => {
@@ -109,8 +115,8 @@ test('it records pda nodes', () => {
     visit(node, visitor);
 
     // Then we expect pda paths to be recorded and retrievable.
-    expect(linkables.getPath([pdaLinkNode('pdaA', 'myProgram')])).toEqual([node, node.pdas[0]]);
-    expect(linkables.getPath([pdaLinkNode('pdaB', 'myProgram')])).toEqual([node, node.pdas[1]]);
+    expect(linkables.getPath([pdaLinkNode('pdaA', 'myProgram')])).toEqual([node, (node.pdas ?? [])[0]]);
+    expect(linkables.getPath([pdaLinkNode('pdaB', 'myProgram')])).toEqual([node, (node.pdas ?? [])[1]]);
 });
 
 test('it records instruction nodes', () => {
@@ -129,8 +135,14 @@ test('it records instruction nodes', () => {
     visit(node, visitor);
 
     // Then we expect instruction paths to be recorded and retrievable.
-    expect(linkables.getPath([instructionLinkNode('instructionA', 'myProgram')])).toEqual([node, node.instructions[0]]);
-    expect(linkables.getPath([instructionLinkNode('instructionB', 'myProgram')])).toEqual([node, node.instructions[1]]);
+    expect(linkables.getPath([instructionLinkNode('instructionA', 'myProgram')])).toEqual([
+        node,
+        (node.instructions ?? [])[0],
+    ]);
+    expect(linkables.getPath([instructionLinkNode('instructionB', 'myProgram')])).toEqual([
+        node,
+        (node.instructions ?? [])[1],
+    ]);
 });
 
 test('it records instruction account nodes', () => {
@@ -156,12 +168,12 @@ test('it records instruction account nodes', () => {
     const instruction = instructionLinkNode('myInstruction', 'myProgram');
     expect(linkables.getPath([instructionAccountLinkNode('accountA', instruction)])).toEqual([
         node,
-        node.instructions[0],
+        (node.instructions ?? [])[0],
         instructionAccounts[0],
     ]);
     expect(linkables.getPath([instructionAccountLinkNode('accountB', instruction)])).toEqual([
         node,
-        node.instructions[0],
+        (node.instructions ?? [])[0],
         instructionAccounts[1],
     ]);
 });
@@ -189,12 +201,12 @@ test('it records instruction argument nodes', () => {
     const instruction = instructionLinkNode('myInstruction', 'myProgram');
     expect(linkables.getPath([instructionArgumentLinkNode('argumentA', instruction)])).toEqual([
         node,
-        node.instructions[0],
+        (node.instructions ?? [])[0],
         instructionArguments[0],
     ]);
     expect(linkables.getPath([instructionArgumentLinkNode('argumentB', instruction)])).toEqual([
         node,
-        node.instructions[0],
+        (node.instructions ?? [])[0],
         instructionArguments[1],
     ]);
 });
@@ -256,20 +268,22 @@ test('it keeps track of the current program when extending a visitor', () => {
     visit(node, visitor);
 
     // Then we expect each program to have its own account.
-    expect(dictionary.programA).toBe(programA.accounts[0]);
-    expect(dictionary.programB).toBe(programB.accounts[0]);
+    expect(dictionary.programA).toBe((programA.accounts ?? [])[0]);
+    expect(dictionary.programB).toBe((programB.accounts ?? [])[0]);
 });
 
 test('it keeps track of the current instruction when extending a visitor', () => {
     // Given the following program node containing two instructions each containing an account with the same name.
+    const accountA = instructionAccountNode({ isSigner: true, isWritable: false, name: 'someAccount' });
+    const accountB = instructionAccountNode({ isSigner: true, isWritable: false, name: 'someAccount' });
     const node = programNode({
         instructions: [
             instructionNode({
-                accounts: [instructionAccountNode({ isSigner: true, isWritable: false, name: 'someAccount' })],
+                accounts: [accountA],
                 name: 'instructionA',
             }),
             instructionNode({
-                accounts: [instructionAccountNode({ isSigner: true, isWritable: false, name: 'someAccount' })],
+                accounts: [accountB],
                 name: 'instructionB',
             }),
         ],
@@ -299,8 +313,8 @@ test('it keeps track of the current instruction when extending a visitor', () =>
     visit(node, visitor);
 
     // Then we expect each instruction to have its own account.
-    expect(dictionary.instructionA).toBe(node.instructions[0].accounts[0]);
-    expect(dictionary.instructionB).toBe(node.instructions[1].accounts[0]);
+    expect(dictionary.instructionA).toBe(accountA);
+    expect(dictionary.instructionB).toBe(accountB);
 });
 
 test('it does not record linkable types that are not under a program node', () => {

--- a/packages/visitors-core/test/recordNodeStackVisitor.test.ts
+++ b/packages/visitors-core/test/recordNodeStackVisitor.test.ts
@@ -52,5 +52,5 @@ test('it includes the current node when applied last', () => {
     // Then we expect the number stacks to have been recorded
     // such that the number node themselves are included in the stack.
     expect(numberStacks.length).toBe(1);
-    expect(numberStacks[0].getPath()).toEqual([node, node.type, (node.type as TupleTypeNode).items[0]]);
+    expect(numberStacks[0].getPath()).toEqual([node, node.type, ((node.type as TupleTypeNode).items ?? [])[0]]);
 });

--- a/packages/visitors-core/test/singleNodeVisitor.test.ts
+++ b/packages/visitors-core/test/singleNodeVisitor.test.ts
@@ -8,7 +8,7 @@ test('it visits a single node and return a custom value', () => {
     const node = tupleTypeNode([numberTypeNode('u32'), tupleTypeNode([numberTypeNode('u32'), publicKeyTypeNode()])]);
 
     // And a visitor that counts the number of direct items in a tuple node.
-    const visitor = singleNodeVisitor('tupleTypeNode', node => node.items.length);
+    const visitor = singleNodeVisitor('tupleTypeNode', node => (node.items ?? []).length);
 
     // When we visit the tree using that visitor.
     const result = visit(node, visitor);
@@ -28,11 +28,13 @@ test('it can create rootNode only visitors that return new rootNode instances', 
     const node = rootNode({} as ProgramNode);
 
     // And a root node visitor that adds an additional program node.
-    const visitor = rootNodeVisitor(node => rootNode(node.program, [...node.additionalPrograms, {} as ProgramNode]));
+    const visitor = rootNodeVisitor(node =>
+        rootNode(node.program, [...(node.additionalPrograms ?? []), {} as ProgramNode]),
+    );
 
     // When we visit the empty root node using that visitor.
     const result = visit(node, visitor);
 
     // Then we expect the returned root node to have one additional program node.
-    expect(result.additionalPrograms.length).toBe(1);
+    expect((result.additionalPrograms ?? []).length).toBe(1);
 });

--- a/packages/visitors-core/test/staticVisitor.test.ts
+++ b/packages/visitors-core/test/staticVisitor.test.ts
@@ -5,27 +5,30 @@ import { staticVisitor, visit } from '../src';
 
 test('it returns the same value for any visited node', () => {
     // Given the following 3-nodes tree.
-    const node = tupleTypeNode([numberTypeNode('u32'), publicKeyTypeNode()]);
+    const item0 = numberTypeNode('u32');
+    const item1 = publicKeyTypeNode();
+    const node = tupleTypeNode([item0, item1]);
 
     // And a static visitor that returns the node kind for any visited node.
     const visitor = staticVisitor(node => node.kind);
 
     // Then we expect the following results when visiting different nodes.
     expect(visit(node, visitor)).toBe('tupleTypeNode');
-    expect(visit(node.items[0], visitor)).toBe('numberTypeNode');
-    expect(visit(node.items[1], visitor)).toBe('publicKeyTypeNode');
+    expect(visit(item0, visitor)).toBe('numberTypeNode');
+    expect(visit(item1, visitor)).toBe('publicKeyTypeNode');
 });
 
 test('it can create partial visitor', () => {
     // Given the following 3-nodes tree.
-    const node = tupleTypeNode([numberTypeNode('u32'), publicKeyTypeNode()]);
+    const item0 = numberTypeNode('u32');
+    const node = tupleTypeNode([item0, publicKeyTypeNode()]);
 
     // And a static visitor that supports only 2 of these nodes.
     const visitor = staticVisitor(node => node.kind, { keys: ['tupleTypeNode', 'numberTypeNode'] });
 
     // Then we expect the following results when visiting supported nodes.
     expect(visit(node, visitor)).toBe('tupleTypeNode');
-    expect(visit(node.items[0], visitor)).toBe('numberTypeNode');
+    expect(visit(item0, visitor)).toBe('numberTypeNode');
 
     // But expect an error when visiting an unsupported node.
     // @ts-expect-error PublicKeyTypeNode is not supported.

--- a/packages/visitors-core/test/topDownTransformerVisitor.test.ts
+++ b/packages/visitors-core/test/topDownTransformerVisitor.test.ts
@@ -67,7 +67,7 @@ test('it can create partial transformer visitors', () => {
                 select: '[tupleTypeNode]',
                 transform: node => {
                     assertIsNode(node, 'tupleTypeNode');
-                    return tupleTypeNode([numberTypeNode('u64'), ...node.items]) as unknown as typeof node;
+                    return tupleTypeNode([numberTypeNode('u64'), ...(node.items ?? [])]) as unknown as typeof node;
                 },
             },
         ],
@@ -133,8 +133,9 @@ test('it can transform nodes using multiple node selectors', () => {
 test('it can start from an existing stack', () => {
     // Given the following tuple node inside a program node.
     const tuple = tupleTypeNode([numberTypeNode('u32'), publicKeyTypeNode()]);
+    const myTuple = definedTypeNode({ name: 'myTuple', type: tuple });
     const program = programNode({
-        definedTypes: [definedTypeNode({ name: 'myTuple', type: tuple })],
+        definedTypes: [myTuple],
         name: 'myProgram',
         publicKey: '1111',
     });
@@ -147,7 +148,7 @@ test('it can start from an existing stack', () => {
     };
 
     // When we visit the tuple with an existing stack that contains the program node.
-    const stack = new NodeStack([program, program.definedTypes[0]]);
+    const stack = new NodeStack([program, myTuple]);
     const resultWithStack = visit(tuple, topDownTransformerVisitor([transformer], { stack }));
 
     // Then we expect the number node to have been removed.

--- a/packages/visitors-core/test/visitor.test.ts
+++ b/packages/visitors-core/test/visitor.test.ts
@@ -46,7 +46,7 @@ test('it can use visitOrElse to fallback if a nested node is not supported by th
             return 1;
         },
         visitTupleType(node) {
-            return node.items.map(child => visitOrElse(child, this, () => 42)).reduce((a, b) => a + b, 1);
+            return (node.items ?? []).map(child => visitOrElse(child, this, () => 42)).reduce((a, b) => a + b, 1);
         },
     };
 

--- a/packages/visitors/src/addPdasVisitor.ts
+++ b/packages/visitors/src/addPdasVisitor.ts
@@ -10,7 +10,7 @@ export function addPdasVisitor(pdas: Record<string, Omit<PdaNodeInput, 'programI
                 select: `[programNode]${programName}`,
                 transform: node => {
                     assertIsNode(node, 'programNode');
-                    const existingPdaNames = new Set(node.pdas.map(pda => pda.name));
+                    const existingPdaNames = new Set((node.pdas ?? []).map(pda => pda.name));
                     const newPdaNames = new Set(newPdas.map(pda => pda.name));
                     const overlappingPdaNames = new Set([...existingPdaNames].filter(name => newPdaNames.has(name)));
                     if (overlappingPdaNames.size > 0) {
@@ -22,7 +22,10 @@ export function addPdasVisitor(pdas: Record<string, Omit<PdaNodeInput, 'programI
                     }
                     return programNode({
                         ...node,
-                        pdas: [...node.pdas, ...newPdas.map(({ name, seeds, docs }) => pdaNode({ docs, name, seeds }))],
+                        pdas: [
+                            ...(node.pdas ?? []),
+                            ...newPdas.map(({ name, seeds, docs }) => pdaNode({ docs, name, seeds })),
+                        ],
                     });
                 },
             };

--- a/packages/visitors/src/createSubInstructionsFromEnumArgsVisitor.ts
+++ b/packages/visitors/src/createSubInstructionsFromEnumArgsVisitor.ts
@@ -30,7 +30,7 @@ export function createSubInstructionsFromEnumArgsVisitor(map: Record<string, str
                 transform: (node, stack) => {
                     assertIsNode(node, 'instructionNode');
 
-                    const argFields = node.arguments;
+                    const argFields = node.arguments ?? [];
                     const argName = camelCase(argNameInput);
                     const argFieldIndex = argFields.findIndex(field => field.name === argName);
                     const argField = argFieldIndex >= 0 ? argFields[argFieldIndex] : null;
@@ -60,7 +60,7 @@ export function createSubInstructionsFromEnumArgsVisitor(map: Record<string, str
                         });
                     }
 
-                    const subInstructions = argType.variants.map((variant, index): InstructionNode => {
+                    const subInstructions = (argType.variants ?? []).map((variant, index): InstructionNode => {
                         const subName = camelCase(`${node.name} ${variant.name}`);
                         const subFields = argFields.slice(0, argFieldIndex);
                         subFields.push(

--- a/packages/visitors/src/deduplicateIdenticalDefinedTypesVisitor.ts
+++ b/packages/visitors/src/deduplicateIdenticalDefinedTypesVisitor.ts
@@ -19,7 +19,7 @@ export function deduplicateIdenticalDefinedTypesVisitor() {
         // Fill the type map with all defined types.
         const allPrograms = getAllPrograms(root);
         allPrograms.forEach(program => {
-            program.definedTypes.forEach(type => {
+            (program.definedTypes ?? []).forEach(type => {
                 const typeWithProgram = { program, type };
                 const list = typeMap.get(type.name) ?? [];
                 typeMap.set(type.name, [...list, typeWithProgram]);

--- a/packages/visitors/src/fillDefaultPdaSeedValuesVisitor.ts
+++ b/packages/visitors/src/fillDefaultPdaSeedValuesVisitor.ts
@@ -51,7 +51,7 @@ export function fillDefaultPdaSeedValuesVisitor(
                     ? visitedNode.pda
                     : linkables.get([...instructionPath, visitedNode.pda]);
                 if (!foundPda) return visitedNode;
-                const seeds = addDefaultSeedValuesFromPdaWhenMissing(instruction, foundPda, visitedNode.seeds);
+                const seeds = addDefaultSeedValuesFromPdaWhenMissing(instruction, foundPda, visitedNode.seeds ?? []);
                 if (strictMode && !allSeedsAreValid(instruction, foundPda, seeds)) {
                     throw new CodamaError(CODAMA_ERROR__VISITORS__INVALID_PDA_SEED_VALUES, {
                         instruction,
@@ -79,10 +79,10 @@ function addDefaultSeedValuesFromPdaWhenMissing(
 }
 
 function getDefaultSeedValuesFromPda(instruction: InstructionNode, pda: PdaNode): PdaSeedValueNode[] {
-    return pda.seeds.flatMap((seed): PdaSeedValueNode[] => {
+    return (pda.seeds ?? []).flatMap((seed): PdaSeedValueNode[] => {
         if (!isNode(seed, 'variablePdaSeedNode')) return [];
 
-        const hasMatchingAccount = instruction.accounts.some(a => a.name === seed.name);
+        const hasMatchingAccount = (instruction.accounts ?? []).some(a => a.name === seed.name);
         if (isNode(seed.type, 'publicKeyTypeNode') && hasMatchingAccount) {
             return [pdaSeedValueNode(seed.name, accountValueNode(seed.name))];
         }
@@ -97,8 +97,9 @@ function getDefaultSeedValuesFromPda(instruction: InstructionNode, pda: PdaNode)
 }
 
 function allSeedsAreValid(instruction: InstructionNode, foundPda: PdaNode, seeds: PdaSeedValueNode[]) {
-    const hasAllVariableSeeds = foundPda.seeds.filter(isNodeFilter('variablePdaSeedNode')).length === seeds.length;
-    const allAccountsName = instruction.accounts.map(a => a.name);
+    const hasAllVariableSeeds =
+        (foundPda.seeds ?? []).filter(isNodeFilter('variablePdaSeedNode')).length === seeds.length;
+    const allAccountsName = (instruction.accounts ?? []).map(a => a.name);
     const allArgumentsName = getAllInstructionArguments(instruction).map(a => a.name);
     const validSeeds = seeds.every(seed => {
         if (isNode(seed.value, 'accountValueNode')) {

--- a/packages/visitors/src/flattenInstructionDataArgumentsVisitor.ts
+++ b/packages/visitors/src/flattenInstructionDataArgumentsVisitor.ts
@@ -17,7 +17,7 @@ export function flattenInstructionDataArgumentsVisitor() {
                 assertIsNode(instruction, 'instructionNode');
                 return instructionNode({
                     ...instruction,
-                    arguments: flattenInstructionArguments(instruction.arguments),
+                    arguments: flattenInstructionArguments(instruction.arguments ?? []),
                 });
             },
         },
@@ -35,7 +35,7 @@ export const flattenInstructionArguments = (
         options === '*' || camelCaseOptions.includes(camelCase(node.name));
     const inlinedArguments = nodes.flatMap(node => {
         if (isNode(node.type, 'structTypeNode') && shouldInline(node)) {
-            return node.type.fields.map(field => instructionArgumentNode({ ...field }));
+            return (node.type.fields ?? []).map(field => instructionArgumentNode({ ...field }));
         }
         return node;
     });

--- a/packages/visitors/src/flattenStructVisitor.ts
+++ b/packages/visitors/src/flattenStructVisitor.ts
@@ -28,9 +28,9 @@ export const flattenStruct = (node: Node, options: FlattenStructOptions = '*'): 
     const camelCaseOptions = options === '*' ? options : options.map(camelCase);
     const shouldInline = (field: StructFieldTypeNode): boolean =>
         options === '*' || camelCaseOptions.includes(camelCase(field.name));
-    const inlinedFields = node.fields.flatMap(field => {
+    const inlinedFields = (node.fields ?? []).flatMap(field => {
         if (isNode(field.type, 'structTypeNode') && shouldInline(field)) {
-            return field.type.fields;
+            return field.type.fields ?? [];
         }
         return [field];
     });

--- a/packages/visitors/src/getDefinedTypeHistogramVisitor.ts
+++ b/packages/visitors/src/getDefinedTypeHistogramVisitor.ts
@@ -107,7 +107,7 @@ export function getDefinedTypeHistogramVisitor(): Visitor<DefinedTypeHistogram> 
                 visitInstruction(node, { self }) {
                     mode = 'instruction';
                     stackLevel = 0;
-                    const dataHistograms = node.arguments.map(arg => visit(arg, self));
+                    const dataHistograms = (node.arguments ?? []).map(arg => visit(arg, self));
                     const extraHistograms = (node.extraArguments ?? []).map(arg => visit(arg, self));
                     mode = null;
                     const subHistograms = (node.subInstructions ?? []).map(ix => visit(ix, self));

--- a/packages/visitors/src/renameHelpers.ts
+++ b/packages/visitors/src/renameHelpers.ts
@@ -13,13 +13,17 @@ import {
 
 export function renameStructNode(node: StructTypeNode, map: Record<string, string>): StructTypeNode {
     return structTypeNode(
-        node.fields.map(field => (map[field.name] ? structFieldTypeNode({ ...field, name: map[field.name] }) : field)),
+        (node.fields ?? []).map(field =>
+            map[field.name] ? structFieldTypeNode({ ...field, name: map[field.name] }) : field,
+        ),
     );
 }
 
 export function renameEnumNode(node: EnumTypeNode, map: Record<string, string>): EnumTypeNode {
     return enumTypeNode(
-        node.variants.map(variant => (map[variant.name] ? renameEnumVariant(variant, map[variant.name]) : variant)),
+        (node.variants ?? []).map(variant =>
+            map[variant.name] ? renameEnumVariant(variant, map[variant.name]) : variant,
+        ),
         { ...node },
     );
 }

--- a/packages/visitors/src/setAccountDiscriminatorFromFieldVisitor.ts
+++ b/packages/visitors/src/setAccountDiscriminatorFromFieldVisitor.ts
@@ -22,7 +22,8 @@ export function setAccountDiscriminatorFromFieldVisitor(
                     assertIsNode(node, 'accountNode');
 
                     const accountData = resolveNestedTypeNode(node.data);
-                    const fieldIndex = accountData.fields.findIndex(f => f.name === field);
+                    const accountFields = accountData.fields ?? [];
+                    const fieldIndex = accountFields.findIndex(f => f.name === field);
                     if (fieldIndex < 0) {
                         throw new CodamaError(CODAMA_ERROR__VISITORS__ACCOUNT_FIELD_NOT_FOUND, {
                             account: node,
@@ -31,18 +32,18 @@ export function setAccountDiscriminatorFromFieldVisitor(
                         });
                     }
 
-                    const fieldNode = accountData.fields[fieldIndex];
+                    const fieldNode = accountFields[fieldIndex];
                     return accountNode({
                         ...node,
                         data: transformNestedTypeNode(node.data, () =>
                             structTypeNode([
-                                ...accountData.fields.slice(0, fieldIndex),
+                                ...accountFields.slice(0, fieldIndex),
                                 structFieldTypeNode({
                                     ...fieldNode,
                                     defaultValue: value,
                                     defaultValueStrategy: 'omitted',
                                 }),
-                                ...accountData.fields.slice(fieldIndex + 1),
+                                ...accountFields.slice(fieldIndex + 1),
                             ]),
                         ),
                         discriminators: [fieldDiscriminatorNode(field, offset), ...(node.discriminators ?? [])],

--- a/packages/visitors/src/setInstructionAccountDefaultValuesVisitor.ts
+++ b/packages/visitors/src/setInstructionAccountDefaultValuesVisitor.ts
@@ -168,7 +168,7 @@ export function setInstructionAccountDefaultValuesVisitor(rules: InstructionAcco
             extendVisitor(v, {
                 visitInstruction(node) {
                     const instructionPath = stack.getPath('instructionNode');
-                    const instructionAccounts = node.accounts.map((account): InstructionAccountNode => {
+                    const instructionAccounts = (node.accounts ?? []).map((account): InstructionAccountNode => {
                         const rule = matchRule(node, account);
                         if (!rule) return account;
 

--- a/packages/visitors/src/setInstructionDiscriminatorsVisitor.ts
+++ b/packages/visitors/src/setInstructionDiscriminatorsVisitor.ts
@@ -38,7 +38,7 @@ export function setInstructionDiscriminatorsVisitor(map: Record<string, Discrimi
 
                     return instructionNode({
                         ...node,
-                        arguments: [discriminatorArgument, ...node.arguments],
+                        arguments: [discriminatorArgument, ...(node.arguments ?? [])],
                         discriminators: [
                             fieldDiscriminatorNode(discriminator.name ?? 'discriminator'),
                             ...(node.discriminators ?? []),

--- a/packages/visitors/src/setStructDefaultValuesVisitor.ts
+++ b/packages/visitors/src/setStructDefaultValuesVisitor.ts
@@ -26,7 +26,7 @@ export function setStructDefaultValuesVisitor(map: StructDefaultValueMap) {
                     select: `${stack}.[structTypeNode]`,
                     transform: node => {
                         assertIsNode(node, 'structTypeNode');
-                        const fields = node.fields.map((field): StructFieldTypeNode => {
+                        const fields = (node.fields ?? []).map((field): StructFieldTypeNode => {
                             const defaultValue = camelCasedDefaultValues[field.name];
                             if (defaultValue === undefined) return field;
                             if (defaultValue === null) {
@@ -67,7 +67,7 @@ export function setStructDefaultValuesVisitor(map: StructDefaultValueMap) {
                         };
                         return instructionNode({
                             ...node,
-                            arguments: node.arguments.map(transformArguments),
+                            arguments: (node.arguments ?? []).map(transformArguments),
                             extraArguments: node.extraArguments
                                 ? node.extraArguments.map(transformArguments)
                                 : undefined,

--- a/packages/visitors/src/transformDefinedTypesIntoAccountsVisitor.ts
+++ b/packages/visitors/src/transformDefinedTypesIntoAccountsVisitor.ts
@@ -5,9 +5,9 @@ export function transformDefinedTypesIntoAccountsVisitor(definedTypes: string[])
     return pipe(nonNullableIdentityVisitor({ keys: ['rootNode', 'programNode'] }), v =>
         extendVisitor(v, {
             visitProgram(program) {
-                const typesToExtract = program.definedTypes.filter(node => definedTypes.includes(node.name));
+                const typesToExtract = (program.definedTypes ?? []).filter(node => definedTypes.includes(node.name));
 
-                const newDefinedTypes = program.definedTypes.filter(node => !definedTypes.includes(node.name));
+                const newDefinedTypes = (program.definedTypes ?? []).filter(node => !definedTypes.includes(node.name));
 
                 const newAccounts = typesToExtract.map(node => {
                     assertIsNode(node.type, 'structTypeNode');
@@ -21,7 +21,7 @@ export function transformDefinedTypesIntoAccountsVisitor(definedTypes: string[])
 
                 return programNode({
                     ...program,
-                    accounts: [...program.accounts, ...newAccounts],
+                    accounts: [...(program.accounts ?? []), ...newAccounts],
                     definedTypes: newDefinedTypes,
                 });
             },

--- a/packages/visitors/src/unwrapDefinedTypesVisitor.ts
+++ b/packages/visitors/src/unwrapDefinedTypesVisitor.ts
@@ -48,14 +48,14 @@ export function unwrapDefinedTypesVisitor(typesToInline: string[] | '*' = '*') {
                 visitProgram(program, { self }) {
                     return programNode({
                         ...program,
-                        accounts: program.accounts
+                        accounts: (program.accounts ?? [])
                             .map(account => visit(account, self))
                             .filter(assertIsNodeFilter('accountNode')),
-                        definedTypes: program.definedTypes
+                        definedTypes: (program.definedTypes ?? [])
                             .filter(definedType => !shouldInline(definedType.name, program.name))
                             .map(type => visit(type, self))
                             .filter(assertIsNodeFilter('definedTypeNode')),
-                        instructions: program.instructions
+                        instructions: (program.instructions ?? [])
                             .map(instruction => visit(instruction, self))
                             .filter(assertIsNodeFilter('instructionNode')),
                     });

--- a/packages/visitors/src/unwrapTupleEnumWithSingleStructVisitor.ts
+++ b/packages/visitors/src/unwrapTupleEnumWithSingleStructVisitor.ts
@@ -46,8 +46,9 @@ export function unwrapTupleEnumWithSingleStructVisitor(enumsOrVariantsToUnwrap: 
                         assertIsNode(node, 'enumTupleVariantTypeNode');
                         if (!shouldUnwrap(stack)) return node;
                         const tupleNode = resolveNestedTypeNode(node.tuple);
-                        if (tupleNode.items.length !== 1) return node;
-                        let item = tupleNode.items[0];
+                        const tupleItems = tupleNode.items ?? [];
+                        if (tupleItems.length !== 1) return node;
+                        let item = tupleItems[0];
                         if (isNode(item, 'definedTypeLinkNode')) {
                             const definedType = definedTypes.get(item.name);
                             if (!definedType) return node;

--- a/packages/visitors/src/updateAccountsVisitor.ts
+++ b/packages/visitors/src/updateAccountsVisitor.ts
@@ -83,12 +83,12 @@ export function updateAccountsVisitor(map: Record<string, AccountUpdates>) {
                             .filter(p => p.program === node.name)
                             .map(p => p.pda);
                         if (pdasToUpsertForProgram.length === 0) return node;
-                        const existingPdaNames = new Set(node.pdas.map(pda => pda.name));
+                        const existingPdaNames = new Set((node.pdas ?? []).map(pda => pda.name));
                         const pdasToCreate = pdasToUpsertForProgram.filter(p => !existingPdaNames.has(p.name));
                         const pdasToUpdate = new Map(
                             pdasToUpsertForProgram.filter(p => existingPdaNames.has(p.name)).map(p => [p.name, p]),
                         );
-                        const newPdas = [...node.pdas.map(p => pdasToUpdate.get(p.name) ?? p), ...pdasToCreate];
+                        const newPdas = [...(node.pdas ?? []).map(p => pdasToUpdate.get(p.name) ?? p), ...pdasToCreate];
                         return programNode({ ...node, pdas: newPdas });
                     },
                 },

--- a/packages/visitors/src/updateInstructionsVisitor.ts
+++ b/packages/visitors/src/updateInstructionsVisitor.ts
@@ -65,7 +65,7 @@ export function updateInstructionsVisitor(map: Record<string, InstructionUpdates
                 const instructionPath = stack.getPath('instructionNode');
                 const { accounts: accountUpdates, arguments: argumentUpdates, ...metadataUpdates } = updates;
                 const { newArguments, newExtraArguments } = handleInstructionArguments(node, argumentUpdates ?? {});
-                const newAccounts = node.accounts.map(account =>
+                const newAccounts = (node.accounts ?? []).map(account =>
                     handleInstructionAccount(instructionPath, account, accountUpdates ?? {}, linkables),
                 );
                 return instructionNode({
@@ -118,7 +118,7 @@ function handleInstructionArguments(
 } {
     const usedArguments = new Set<string>();
 
-    const newArguments = instruction.arguments.map(node => {
+    const newArguments = (instruction.arguments ?? []).map(node => {
         const argUpdate = argUpdates[node.name];
         if (!argUpdate) return node;
         usedArguments.add(node.name);

--- a/packages/visitors/test/addPdasVisitor.test.ts
+++ b/packages/visitors/test/addPdasVisitor.test.ts
@@ -52,7 +52,7 @@ test('it adds PDA nodes to a program', () => {
     const result = visit(node, addPdasVisitor({ myProgram: newPdas }));
 
     // Then we expect the following program to be returned.
-    expect(result).toEqual({ ...node, pdas: [...node.pdas, ...newPdas] });
+    expect(result).toEqual({ ...node, pdas: [...(node.pdas ?? []), ...newPdas] });
 });
 
 test('it fails to add a PDA if its name conflicts with an existing PDA on the program', () => {
@@ -142,5 +142,5 @@ test('it adds PDA nodes to a program with docs', () => {
     const result = visit(node, addPdasVisitor({ myProgram: newPdas }));
 
     // Then we expect the following program to be returned.
-    expect(result).toEqual({ ...node, pdas: [...node.pdas, ...newPdas] });
+    expect(result).toEqual({ ...node, pdas: [...(node.pdas ?? []), ...newPdas] });
 });

--- a/packages/visitors/test/fillDefaultPdaSeedValuesVisitor.test.ts
+++ b/packages/visitors/test/fillDefaultPdaSeedValuesVisitor.test.ts
@@ -21,21 +21,19 @@ import { fillDefaultPdaSeedValuesVisitor } from '../src';
 
 test('it fills missing pda seed values with default values', () => {
     // Given a pdaNode with three variable seeds.
+    const pda = pdaNode({
+        name: 'myPda',
+        seeds: [
+            variablePdaSeedNode('seed1', numberTypeNode('u64')),
+            variablePdaSeedNode('seed2', numberTypeNode('u64')),
+            variablePdaSeedNode('seed3', publicKeyTypeNode()),
+        ],
+    });
     const program = programNode({
         name: 'myProgram',
-        pdas: [
-            pdaNode({
-                name: 'myPda',
-                seeds: [
-                    variablePdaSeedNode('seed1', numberTypeNode('u64')),
-                    variablePdaSeedNode('seed2', numberTypeNode('u64')),
-                    variablePdaSeedNode('seed3', publicKeyTypeNode()),
-                ],
-            }),
-        ],
+        pdas: [pda],
         publicKey: '1111',
     });
-    const pda = program.pdas[0];
 
     // And a linkable dictionary that recorded this PDA.
     const linkables = new LinkableDictionary();
@@ -72,21 +70,19 @@ test('it fills missing pda seed values with default values', () => {
 
 test('it fills nested pda value nodes', () => {
     // Given a pdaNode with three variable seeds.
+    const pda = pdaNode({
+        name: 'myPda',
+        seeds: [
+            variablePdaSeedNode('seed1', numberTypeNode('u64')),
+            variablePdaSeedNode('seed2', numberTypeNode('u64')),
+            variablePdaSeedNode('seed3', publicKeyTypeNode()),
+        ],
+    });
     const program = programNode({
         name: 'myProgram',
-        pdas: [
-            pdaNode({
-                name: 'myPda',
-                seeds: [
-                    variablePdaSeedNode('seed1', numberTypeNode('u64')),
-                    variablePdaSeedNode('seed2', numberTypeNode('u64')),
-                    variablePdaSeedNode('seed3', publicKeyTypeNode()),
-                ],
-            }),
-        ],
+        pdas: [pda],
         publicKey: '1111',
     });
-    const pda = program.pdas[0];
 
     // And a linkable dictionary that recorded this PDA.
     const linkables = new LinkableDictionary();
@@ -129,21 +125,19 @@ test('it fills nested pda value nodes', () => {
 
 test('it ignores default seeds missing from the instruction', () => {
     // Given a pdaNode with three variable seeds.
+    const pda = pdaNode({
+        name: 'myPda',
+        seeds: [
+            variablePdaSeedNode('seed1', numberTypeNode('u64')),
+            variablePdaSeedNode('seed2', numberTypeNode('u64')),
+            variablePdaSeedNode('seed3', publicKeyTypeNode()),
+        ],
+    });
     const program = programNode({
         name: 'myProgram',
-        pdas: [
-            pdaNode({
-                name: 'myPda',
-                seeds: [
-                    variablePdaSeedNode('seed1', numberTypeNode('u64')),
-                    variablePdaSeedNode('seed2', numberTypeNode('u64')),
-                    variablePdaSeedNode('seed3', publicKeyTypeNode()),
-                ],
-            }),
-        ],
+        pdas: [pda],
         publicKey: '1111',
     });
-    const pda = program.pdas[0];
 
     // And a linkable dictionary that recorded this PDA.
     const linkables = new LinkableDictionary();

--- a/packages/visitors/test/setStructDefaultValuesVisitor.test.ts
+++ b/packages/visitors/test/setStructDefaultValuesVisitor.test.ts
@@ -48,10 +48,10 @@ test('it adds new default values to struct fields', () => {
     // Then we expect the following tree changes.
     assertIsNode(result, 'definedTypeNode');
     assertIsNode(result.type, 'structTypeNode');
-    expect(result.type.fields[0].defaultValue).toEqual(numberValueNode(42));
-    expect(result.type.fields[0].defaultValueStrategy).toBeUndefined();
-    expect(result.type.fields[1].defaultValue).toEqual(noneValueNode());
-    expect(result.type.fields[1].defaultValueStrategy).toBeUndefined();
+    expect((result.type.fields ?? [])[0].defaultValue).toEqual(numberValueNode(42));
+    expect((result.type.fields ?? [])[0].defaultValueStrategy).toBeUndefined();
+    expect((result.type.fields ?? [])[1].defaultValue).toEqual(noneValueNode());
+    expect((result.type.fields ?? [])[1].defaultValueStrategy).toBeUndefined();
 });
 
 test('it adds new default values with custom strategies to struct fields', () => {
@@ -84,10 +84,10 @@ test('it adds new default values with custom strategies to struct fields', () =>
     // Then we expect the following tree changes.
     assertIsNode(result, 'accountNode');
     const data = resolveNestedTypeNode(result.data);
-    expect(data.fields[0].defaultValue).toEqual(numberValueNode(42));
-    expect(data.fields[0].defaultValueStrategy).toBe('omitted');
-    expect(data.fields[1].defaultValue).toEqual(noneValueNode());
-    expect(data.fields[1].defaultValueStrategy).toBe('optional');
+    expect((data.fields ?? [])[0].defaultValue).toEqual(numberValueNode(42));
+    expect((data.fields ?? [])[0].defaultValueStrategy).toBe('omitted');
+    expect((data.fields ?? [])[1].defaultValue).toEqual(noneValueNode());
+    expect((data.fields ?? [])[1].defaultValueStrategy).toBe('optional');
 });
 
 test('it adds new default values to instruction arguments', () => {
@@ -119,8 +119,8 @@ test('it adds new default values to instruction arguments', () => {
 
     // Then we expect the following tree changes.
     assertIsNode(result, 'instructionNode');
-    expect(result.arguments[0].defaultValue).toEqual(numberValueNode(42));
-    expect(result.arguments[0].defaultValueStrategy).toBe('omitted');
-    expect(result.arguments[1].defaultValue).toEqual(numberValueNode(1));
-    expect(result.arguments[1].defaultValueStrategy).toBeUndefined();
+    expect((result.arguments ?? [])[0].defaultValue).toEqual(numberValueNode(42));
+    expect((result.arguments ?? [])[0].defaultValueStrategy).toBe('omitted');
+    expect((result.arguments ?? [])[1].defaultValue).toEqual(numberValueNode(1));
+    expect((result.arguments ?? [])[1].defaultValueStrategy).toBeUndefined();
 });

--- a/packages/visitors/test/unwrapDefinedTypesVisitor.test.ts
+++ b/packages/visitors/test/unwrapDefinedTypesVisitor.test.ts
@@ -34,7 +34,7 @@ test('it unwraps defined types by following links', () => {
 
     // Then we expect the following tree.
     assertIsNode(result, 'programNode');
-    expect(result.accounts[0].data).toStrictEqual(
+    expect((result.accounts ?? [])[0].data).toStrictEqual(
         structTypeNode([structFieldTypeNode({ name: 'value', type: numberTypeNode('u64') })]),
     );
 });
@@ -68,7 +68,7 @@ test('it follows linked nodes using the correct paths', () => {
 
     // Then we expect the final linkable to be resolved in programA.
     assertIsNode(result, 'rootNode');
-    expect(result.program.definedTypes[0]).toStrictEqual(
+    expect((result.program.definedTypes ?? [])[0]).toStrictEqual(
         definedTypeNode({ name: 'typeA', type: numberTypeNode('u64') }),
     );
 });

--- a/packages/visitors/test/updateAccountsVisitor.test.ts
+++ b/packages/visitors/test/updateAccountsVisitor.test.ts
@@ -35,7 +35,7 @@ test('it updates the name of an account', () => {
 
     // Then we expect the following tree changes.
     assertIsNode(result, 'programNode');
-    expect(result.accounts[0].name).toBe('myNewAccount' as CamelCaseString);
+    expect((result.accounts ?? [])[0].name).toBe('myNewAccount' as CamelCaseString);
 });
 
 test('it updates the name of an account within a specific program', () => {
@@ -65,10 +65,10 @@ test('it updates the name of an account within a specific program', () => {
 
     // Then we expect the first account to have been renamed.
     assertIsNode(result, 'rootNode');
-    expect(result.program.accounts[0].name).toBe('newCandyMachine' as CamelCaseString);
+    expect((result.program.accounts ?? [])[0].name).toBe('newCandyMachine' as CamelCaseString);
 
     // But not the second account.
-    expect(result.additionalPrograms[0].accounts[0].name).toBe('candyMachine' as CamelCaseString);
+    expect(((result.additionalPrograms ?? [])[0].accounts ?? [])[0].name).toBe('candyMachine' as CamelCaseString);
 });
 
 test("it renames the fields of an account's data", () => {
@@ -91,7 +91,7 @@ test("it renames the fields of an account's data", () => {
     // Then we expect the following tree changes.
     assertIsNode(result, 'accountNode');
     const data = resolveNestedTypeNode(result.data);
-    expect(data.fields[0].name).toBe('myNewData' as CamelCaseString);
+    expect((data.fields ?? [])[0].name).toBe('myNewData' as CamelCaseString);
 });
 
 test('it updates the name of associated PDA nodes', () => {
@@ -114,10 +114,10 @@ test('it updates the name of associated PDA nodes', () => {
 
     // Then we expect the associated PDA node to have been renamed.
     assertIsNode(result, 'programNode');
-    expect(result.pdas[0].name).toBe('myNewAccount' as CamelCaseString);
+    expect((result.pdas ?? [])[0].name).toBe('myNewAccount' as CamelCaseString);
 
     // But not the other PDA node.
-    expect(result.pdas[1].name).toBe('myOtherAccount' as CamelCaseString);
+    expect((result.pdas ?? [])[1].name).toBe('myOtherAccount' as CamelCaseString);
 });
 
 test('it creates a new PDA node when providing seeds to an account with no linked PDA', () => {
@@ -143,12 +143,12 @@ test('it creates a new PDA node when providing seeds to an account with no linke
     assertIsNode(result, 'rootNode');
 
     // Then we expect a new PDA node to have been created on the program.
-    expect(result.program.pdas.length).toBe(1);
-    expect(result.additionalPrograms[0].pdas.length).toBe(0);
-    expect(result.program.pdas[0]).toEqual(pdaNode({ name: 'myAccount', seeds }));
+    expect((result.program.pdas ?? []).length).toBe(1);
+    expect(((result.additionalPrograms ?? [])[0].pdas ?? []).length).toBe(0);
+    expect((result.program.pdas ?? [])[0]).toEqual(pdaNode({ name: 'myAccount', seeds }));
 
     // And the account now links to the new PDA node.
-    expect(result.program.accounts[0].pda).toEqual(pdaLinkNode('myAccount'));
+    expect((result.program.accounts ?? [])[0].pda).toEqual(pdaLinkNode('myAccount'));
 });
 
 test('it updates the PDA node when the updated account name matches an existing PDA node', () => {
@@ -172,11 +172,11 @@ test('it updates the PDA node when the updated account name matches an existing 
     assertIsNode(result, 'programNode');
 
     // Then we expect the PDA node with the same name to have been updated.
-    expect(result.pdas.length).toBe(1);
-    expect(result.pdas[0]).toEqual(pdaNode({ name: 'myAccount', seeds }));
+    expect((result.pdas ?? []).length).toBe(1);
+    expect((result.pdas ?? [])[0]).toEqual(pdaNode({ name: 'myAccount', seeds }));
 
     // And the account now links to this PDA node.
-    expect(result.accounts[0].pda).toEqual(pdaLinkNode('myAccount'));
+    expect((result.accounts ?? [])[0].pda).toEqual(pdaLinkNode('myAccount'));
 });
 
 test('it updates the PDA node with the provided seeds when an account is linked to a PDA', () => {
@@ -200,11 +200,11 @@ test('it updates the PDA node with the provided seeds when an account is linked 
     assertIsNode(result, 'programNode');
 
     // Then we expect the linked PDA node to have been updated.
-    expect(result.pdas.length).toBe(1);
-    expect(result.pdas[0]).toEqual(pdaNode({ name: 'myPda', seeds }));
+    expect((result.pdas ?? []).length).toBe(1);
+    expect((result.pdas ?? [])[0]).toEqual(pdaNode({ name: 'myPda', seeds }));
 
     // And the account still links to the PDA node.
-    expect(result.accounts[0].pda).toEqual(pdaLinkNode('myPda'));
+    expect((result.accounts ?? [])[0].pda).toEqual(pdaLinkNode('myPda'));
 });
 
 test('it creates a new PDA node when updating an account with seeds and a new linked PDA that does not exist', () => {
@@ -229,11 +229,11 @@ test('it creates a new PDA node when updating an account with seeds and a new li
     assertIsNode(result, 'programNode');
 
     // Then we expect the linked PDA node to have been created.
-    expect(result.pdas.length).toBe(1);
-    expect(result.pdas[0]).toEqual(pdaNode({ name: 'myPda', seeds }));
+    expect((result.pdas ?? []).length).toBe(1);
+    expect((result.pdas ?? [])[0]).toEqual(pdaNode({ name: 'myPda', seeds }));
 
     // And the account now links to the PDA node.
-    expect(result.accounts[0].pda).toEqual(pdaLinkNode('myPda'));
+    expect((result.accounts ?? [])[0].pda).toEqual(pdaLinkNode('myPda'));
 });
 
 test('it updates a PDA node when updating an account with seeds and a new linked PDA that exists', () => {
@@ -259,11 +259,11 @@ test('it updates a PDA node when updating an account with seeds and a new linked
     assertIsNode(result, 'programNode');
 
     // Then we expect the existing PDA node to have been updated.
-    expect(result.pdas.length).toBe(1);
-    expect(result.pdas[0]).toEqual(pdaNode({ name: 'myPda', seeds }));
+    expect((result.pdas ?? []).length).toBe(1);
+    expect((result.pdas ?? [])[0]).toEqual(pdaNode({ name: 'myPda', seeds }));
 
     // And the account now links to this PDA node.
-    expect(result.accounts[0].pda).toEqual(pdaLinkNode('myPda'));
+    expect((result.accounts ?? [])[0].pda).toEqual(pdaLinkNode('myPda'));
 });
 
 test('it can update the seeds and name of an account at the same time', () => {
@@ -288,12 +288,12 @@ test('it can update the seeds and name of an account at the same time', () => {
     assertIsNode(result, 'programNode');
 
     // Then we expect the account name to have been updated.
-    expect(result.accounts[0].name).toBe('myNewAccount' as CamelCaseString);
+    expect((result.accounts ?? [])[0].name).toBe('myNewAccount' as CamelCaseString);
 
     // And a new PDA node to have been created with that new name and the provided seeds.
-    expect(result.pdas.length).toBe(1);
-    expect(result.pdas[0]).toEqual(pdaNode({ name: 'myNewAccount', seeds }));
+    expect((result.pdas ?? []).length).toBe(1);
+    expect((result.pdas ?? [])[0]).toEqual(pdaNode({ name: 'myNewAccount', seeds }));
 
     // And the account to now link to the PDA node.
-    expect(result.accounts[0].pda).toEqual(pdaLinkNode('myNewAccount'));
+    expect((result.accounts ?? [])[0].pda).toEqual(pdaLinkNode('myNewAccount'));
 });

--- a/packages/visitors/test/updateInstructionsVisitor.test.ts
+++ b/packages/visitors/test/updateInstructionsVisitor.test.ts
@@ -40,7 +40,7 @@ test('it updates the name of an instruction', () => {
 
     // Then we expect the following tree changes.
     assertIsNode(result, 'programNode');
-    expect(result.instructions[0].name).toBe('myNewInstruction' as CamelCaseString);
+    expect((result.instructions ?? [])[0].name).toBe('myNewInstruction' as CamelCaseString);
 });
 
 test('it updates the name of an instruction within a specific program', () => {
@@ -70,10 +70,10 @@ test('it updates the name of an instruction within a specific program', () => {
 
     // Then we expect the first instruction to have been renamed.
     assertIsNode(result, 'rootNode');
-    expect(result.program.instructions[0].name).toBe('newTransfer' as CamelCaseString);
+    expect((result.program.instructions ?? [])[0].name).toBe('newTransfer' as CamelCaseString);
 
     // But not the second instruction.
-    expect(result.additionalPrograms[0].instructions[0].name).toBe('transfer' as CamelCaseString);
+    expect(((result.additionalPrograms ?? [])[0].instructions ?? [])[0].name).toBe('transfer' as CamelCaseString);
 });
 
 test('it updates the name of an instruction account', () => {
@@ -103,7 +103,7 @@ test('it updates the name of an instruction account', () => {
 
     // Then we expect the following tree changes.
     assertIsNode(result, 'instructionNode');
-    expect(result.accounts[0].name).toBe('myNewAccount' as CamelCaseString);
+    expect((result.accounts ?? [])[0].name).toBe('myNewAccount' as CamelCaseString);
 });
 
 test('it updates the name of an instruction argument', () => {
@@ -132,7 +132,7 @@ test('it updates the name of an instruction argument', () => {
 
     // Then we expect the following tree changes.
     assertIsNode(result, 'instructionNode');
-    expect(result.arguments[0].name).toBe('myNewArgument' as CamelCaseString);
+    expect((result.arguments ?? [])[0].name).toBe('myNewArgument' as CamelCaseString);
 });
 
 test('it updates the default value of an instruction argument', () => {
@@ -161,8 +161,8 @@ test('it updates the default value of an instruction argument', () => {
 
     // Then we expect the following tree changes.
     assertIsNode(result, 'instructionNode');
-    expect(result.arguments[0].defaultValue).toEqual(numberValueNode(1));
-    expect(result.arguments[0].defaultValueStrategy).toBeUndefined();
+    expect((result.arguments ?? [])[0].defaultValue).toEqual(numberValueNode(1));
+    expect((result.arguments ?? [])[0].defaultValueStrategy).toBeUndefined();
 });
 
 test('it updates the default value strategy of an instruction argument', () => {
@@ -202,10 +202,10 @@ test('it updates the default value strategy of an instruction argument', () => {
 
     // Then we expect the following tree changes.
     assertIsNode(result, 'instructionNode');
-    expect(result.arguments[0].defaultValue).toEqual(numberValueNode(42));
-    expect(result.arguments[0].defaultValueStrategy).toBe('omitted');
-    expect(result.arguments[1].defaultValue).toEqual(numberValueNode(1));
-    expect(result.arguments[1].defaultValueStrategy).toBe('optional');
+    expect((result.arguments ?? [])[0].defaultValue).toEqual(numberValueNode(42));
+    expect((result.arguments ?? [])[0].defaultValueStrategy).toBe('omitted');
+    expect((result.arguments ?? [])[1].defaultValue).toEqual(numberValueNode(1));
+    expect((result.arguments ?? [])[1].defaultValueStrategy).toBe('optional');
 });
 
 test('it updates the byteDeltas of an instruction', () => {


### PR DESCRIPTION
This PR makes every node array attribute skip-when-empty and default to `[]` when absent, implementing the array convention documented in `@codama/spec`. The node-types and nodes generators are updated so array attributes are typed as optional on the interfaces (e.g. `ProgramNode.accounts` is now `readonly accounts?: AccountNode[]`), their type-parameter constraints carry `| undefined`, and the factory functions omit an array from the built node when it is empty or absent, including when an explicit empty array is passed. The `node-types`, `nodes`, and `visitors-core` generated output is regenerated accordingly. Every downstream reader of a formerly-required array is guarded to normalise absent arrays to `[]`, so behaviour is unchanged at runtime and reading stays backwards-compatible with IDLs that still serialise empty arrays. Tests are updated for the slimmer output, new tests cover the omit-on-write and tolerate-on-read invariants, and array reads on factory-built nodes are tidied to reference the constructed nodes directly rather than re-reading them through the optionally-typed graph. The full build, lint, and test suites pass across all packages.