### PR TITLE
Fix `@codama/cli` build and tests after optional-array node change

### DIFF
--- a/packages/cli/src/parsedConfig.ts
+++ b/packages/cli/src/parsedConfig.ts
@@ -72,7 +72,7 @@ function mergeRootNodes(rootNodes: readonly RootNode[]): RootNode {
         return head;
     }
     // Preserve the main root node's other fields (e.g. `standard`, `version`).
-    return { ...head, additionalPrograms: [...head.additionalPrograms, ...tail.flatMap(getAllPrograms)] };
+    return { ...head, additionalPrograms: [...(head.additionalPrograms ?? []), ...tail.flatMap(getAllPrograms)] };
 }
 
 function parseIdlPath(

--- a/packages/cli/test/parsedConfig.test.ts
+++ b/packages/cli/test/parsedConfig.test.ts
@@ -34,17 +34,20 @@ test('merges additionalIdls programs into the root node additionalPrograms', asy
     const parsed = await getParsedConfig({});
 
     expect(parsed.rootNode.program.name).toBe('main');
-    expect(parsed.rootNode.additionalPrograms.map(p => p.name)).toEqual(['a', 'b']);
+    expect((parsed.rootNode.additionalPrograms ?? []).map(p => p.name)).toEqual(['a', 'b']);
     // The main root node's other fields are preserved by the merge.
     expect(parsed.rootNode.standard).toBe('codama');
     expect(parsed.rootNode.version).toBe('9.9.9');
 });
 
 test('leaves the root node unchanged when no additionalIdls are provided', async () => {
+    const mainRootNode = rootNodeWith('main');
     getConfigMock.mockResolvedValue([{ idl: 'main.json' }, '/root/codama.json']);
-    getRootNodeFromIdlMock.mockResolvedValue(rootNodeWith('main'));
+    getRootNodeFromIdlMock.mockResolvedValue(mainRootNode);
 
     const parsed = await getParsedConfig({});
 
-    expect(parsed.rootNode.additionalPrograms).toEqual([]);
+    // The single root node is returned untouched, so its empty `additionalPrograms` stays omitted.
+    expect(parsed.rootNode).toBe(mainRootNode);
+    expect(parsed.rootNode.additionalPrograms).toBeUndefined();
 });


### PR DESCRIPTION
This PR fixes the `main` branch, which broke when the `additionalIdls` feature (#1018) met the optional node-array type change (#1025). Since `RootNode.additionalPrograms` is now typed `ProgramNode[] | undefined`, `mergeRootNodes` gains a `?? []` guard matching the existing `getAllPrograms` convention. The accompanying tests are updated too: one guards its `.map` call, and the "unchanged root node" test now correctly expects `additionalPrograms` to be omitted (`undefined`) rather than `[]`, asserting the root node is returned untouched. Verified locally with a clean build, lint, and test run.