### PR TITLE
fix(nodes): uppercased snake case not correctly converted to snake case

### DIFF
--- a/.changeset/proud-dots-knock.md
+++ b/.changeset/proud-dots-knock.md
@@ -1,0 +1,7 @@
+---
+"@codama/fragments": patch
+"@codama/nodes-from-anchor": patch
+"@codama/nodes": patch
+---
+
+fix(nodes): uppercased snake case not correctly converted to snake case

--- a/packages/fragments/src/core/casing.ts
+++ b/packages/fragments/src/core/casing.ts
@@ -29,9 +29,14 @@ export function capitalize(str: string): string {
  * Normalise an arbitrary string into Title Case — a space-separated
  * sequence of {@link capitalize}d words. Inserts a space before each
  * uppercase letter, then splits on any run of non-alphanumeric
- * characters and re-joins with single spaces.
+ * characters and re-joins with single spaces. Uppercased snake_case
+ * inputs (e.g. `FROM_UPPERCASED_SNAKE_CASE`) are treated as
+ * underscore-delimited words rather than letter-by-letter.
  */
 export function titleCase(str: string): string {
+    if (/^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/.test(str)) {
+        return str.toLowerCase().split('_').map(capitalize).join(' ');
+    }
     return str
         .replace(/([A-Z])/g, ' $1')
         .split(/[^a-zA-Z0-9]+/)
@@ -42,16 +47,9 @@ export function titleCase(str: string): string {
 
 /**
  * Normalise an arbitrary string into PascalCase by stripping the
- * spaces from its {@link titleCase} form. Uppercased snake_case
- * inputs (e.g. `FROM_UPPERCASED_SNAKE_CASE`) are treated as
- * underscore-delimited words rather than letter-by-letter.
+ * spaces from its {@link titleCase} form.
  */
 export function pascalCase(str: string): string {
-    if (/^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/.test(str)) {
-        return str
-            .toLowerCase()
-            .replace(/(?:^|_)([a-z0-9])/g, (_, character: string) => character.toUpperCase());
-    }
     return titleCase(str).split(' ').join('');
 }
 

--- a/packages/fragments/src/core/casing.ts
+++ b/packages/fragments/src/core/casing.ts
@@ -42,9 +42,16 @@ export function titleCase(str: string): string {
 
 /**
  * Normalise an arbitrary string into PascalCase by stripping the
- * spaces from its {@link titleCase} form.
+ * spaces from its {@link titleCase} form. Uppercased snake_case
+ * inputs (e.g. `FROM_UPPERCASED_SNAKE_CASE`) are treated as
+ * underscore-delimited words rather than letter-by-letter.
  */
 export function pascalCase(str: string): string {
+    if (/^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/.test(str)) {
+        return str
+            .toLowerCase()
+            .replace(/(?:^|_)([a-z0-9])/g, (_, character: string) => character.toUpperCase());
+    }
     return titleCase(str).split(' ').join('');
 }
 

--- a/packages/fragments/test/core/casing.test.ts
+++ b/packages/fragments/test/core/casing.test.ts
@@ -146,7 +146,7 @@ describe('camelCase', () => {
     test('from snake case', () => {
         expect(camelCase('from_lowercased_snake_case')).toBe('fromLowercasedSnakeCase');
         expect(camelCase('From_Capitalized_Snake_Case')).toBe('fromCapitalizedSnakeCase');
-        expect(camelCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('fROMUPPERCASEDSNAKECASE');
+        expect(camelCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('fromUppercasedSnakeCase');
         expect(camelCase('fr0m_5nak3_c4s3_w1th_42n_numb3r5')).toBe('fr0m5nak3C4s3W1th42nNumb3r5');
         expect(camelCase('frøm_snake_case_w:th_$peçia!_ch*rs')).toBe('frMSnakeCaseWThPeIaChRs');
         expect(camelCase(camelCase('frøm_d0ubl3_Snake_c*se'))).toBe('frMD0ubl3SnakeCSe');
@@ -190,6 +190,7 @@ describe('pascalCase', () => {
     test('joins title-cased words without separators', () => {
         expect(pascalCase('from snake case')).toBe('FromSnakeCase');
         expect(pascalCase('from_snake_case')).toBe('FromSnakeCase');
+        expect(pascalCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('FromUppercasedSnakeCase');
         expect(pascalCase('from-kebab-case')).toBe('FromKebabCase');
         expect(pascalCase('fromCamelCase')).toBe('FromCamelCase');
         expect(pascalCase('AlreadyPascal')).toBe('AlreadyPascal');

--- a/packages/fragments/test/core/casing.test.ts
+++ b/packages/fragments/test/core/casing.test.ts
@@ -40,7 +40,7 @@ describe('snakeCase', () => {
     test('from snake case', () => {
         expect(snakeCase('from_lowercased_snake_case')).toBe('from_lowercased_snake_case');
         expect(snakeCase('From_Capitalized_Snake_Case')).toBe('from_capitalized_snake_case');
-        expect(snakeCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('f_r_o_m_u_p_p_e_r_c_a_s_e_d_s_n_a_k_e_c_a_s_e');
+        expect(snakeCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('from_uppercased_snake_case');
         expect(snakeCase('fr0m_5nak3_c4s3_w1th_42n_numb3r5')).toBe('fr0m_5nak3_c4s3_w1th_42n_numb3r5');
         expect(snakeCase('frøm_snake_case_w:th_$peçia!_ch*rs')).toBe('fr_m_snake_case_w_th_pe_ia_ch_rs');
         expect(snakeCase(snakeCase('frøm_d0ubl3_Snake_c*se'))).toBe('fr_m_d0ubl3_snake_c_se');
@@ -93,7 +93,7 @@ describe('titleCase', () => {
     test('from snake case', () => {
         expect(titleCase('from_lowercased_snake_case')).toBe('From Lowercased Snake Case');
         expect(titleCase('From_Capitalized_Snake_Case')).toBe('From Capitalized Snake Case');
-        expect(titleCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('F R O M U P P E R C A S E D S N A K E C A S E');
+        expect(titleCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('From Uppercased Snake Case');
         expect(titleCase('fr0m_5nak3_c4s3_w1th_42n_numb3r5')).toBe('Fr0m 5nak3 C4s3 W1th 42n Numb3r5');
         expect(titleCase('frøm_snake_case_w:th_$peçia!_ch*rs')).toBe('Fr M Snake Case W Th Pe Ia Ch Rs');
         expect(titleCase(titleCase('frøm_d0ubl3_Snake_c*se'))).toBe('Fr M D0ubl3 Snake C Se');
@@ -217,6 +217,7 @@ describe('kebabCase', () => {
     test('joins title-cased words with dashes and lowercases', () => {
         expect(kebabCase('from snake case')).toBe('from-snake-case');
         expect(kebabCase('from_snake_case')).toBe('from-snake-case');
+        expect(kebabCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('from-uppercased-snake-case');
         expect(kebabCase('FromCamelCase')).toBe('from-camel-case');
         expect(kebabCase('FromPascalCase')).toBe('from-pascal-case');
     });

--- a/packages/nodes-from-anchor/test/v01/ConstantNode.test.ts
+++ b/packages/nodes-from-anchor/test/v01/ConstantNode.test.ts
@@ -21,7 +21,7 @@ const generics = {} as GenericsV01;
 test('it parses constant with number type and value', () => {
     const node = constantNodeFromAnchorV01(
         {
-            name: 'max_size',
+            name: 'MAX_SIZE',
             type: 'u64',
             value: '1000',
         },
@@ -29,6 +29,7 @@ test('it parses constant with number type and value', () => {
     );
 
     expect(node).toEqual(constantNode('maxSize', numberTypeNode('u64'), numberValueNode(1000)));
+    expect(node.name).toBe('maxSize');
 });
 
 test('it parses constant with bytes type and value', () => {

--- a/packages/nodes/src/shared/stringCases.ts
+++ b/packages/nodes/src/shared/stringCases.ts
@@ -26,6 +26,11 @@ export function pascalCase(str: string): PascalCaseString {
 
 export function camelCase(str: string): CamelCaseString {
     if (str.length === 0) return str as CamelCaseString;
+    if (/^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/.test(str)) {
+        return str
+            .toLowerCase()
+            .replace(/_([a-z0-9])/g, (_, character: string) => character.toUpperCase()) as CamelCaseString;
+    }
     const pascalStr = pascalCase(str);
     return (pascalStr.charAt(0).toLowerCase() + pascalStr.slice(1)) as CamelCaseString;
 }

--- a/packages/nodes/src/shared/stringCases.ts
+++ b/packages/nodes/src/shared/stringCases.ts
@@ -21,16 +21,16 @@ export function titleCase(str: string): TitleCaseString {
 }
 
 export function pascalCase(str: string): PascalCaseString {
+    if (/^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/.test(str)) {
+        return str
+            .toLowerCase()
+            .replace(/(?:^|_)([a-z0-9])/g, (_, character: string) => character.toUpperCase()) as PascalCaseString;
+    }
     return titleCase(str).split(' ').join('') as PascalCaseString;
 }
 
 export function camelCase(str: string): CamelCaseString {
     if (str.length === 0) return str as CamelCaseString;
-    if (/^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/.test(str)) {
-        return str
-            .toLowerCase()
-            .replace(/_([a-z0-9])/g, (_, character: string) => character.toUpperCase()) as CamelCaseString;
-    }
     const pascalStr = pascalCase(str);
     return (pascalStr.charAt(0).toLowerCase() + pascalStr.slice(1)) as CamelCaseString;
 }

--- a/packages/nodes/src/shared/stringCases.ts
+++ b/packages/nodes/src/shared/stringCases.ts
@@ -12,6 +12,9 @@ export function capitalize(str: string): string {
 }
 
 export function titleCase(str: string): TitleCaseString {
+    if (/^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/.test(str)) {
+        return str.toLowerCase().split('_').map(capitalize).join(' ') as TitleCaseString;
+    }
     return str
         .replace(/([A-Z])/g, ' $1')
         .split(/[^a-zA-Z0-9]+/)
@@ -21,11 +24,6 @@ export function titleCase(str: string): TitleCaseString {
 }
 
 export function pascalCase(str: string): PascalCaseString {
-    if (/^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/.test(str)) {
-        return str
-            .toLowerCase()
-            .replace(/(?:^|_)([a-z0-9])/g, (_, character: string) => character.toUpperCase()) as PascalCaseString;
-    }
     return titleCase(str).split(' ').join('') as PascalCaseString;
 }
 

--- a/packages/nodes/test/shared/stringCases.test.ts
+++ b/packages/nodes/test/shared/stringCases.test.ts
@@ -23,7 +23,7 @@ describe('snakeCase', () => {
     test('from snake case', () => {
         expect(snakeCase('from_lowercased_snake_case')).toBe('from_lowercased_snake_case');
         expect(snakeCase('From_Capitalized_Snake_Case')).toBe('from_capitalized_snake_case');
-        expect(snakeCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('f_r_o_m_u_p_p_e_r_c_a_s_e_d_s_n_a_k_e_c_a_s_e');
+        expect(snakeCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('from_uppercased_snake_case');
         expect(snakeCase('fr0m_5nak3_c4s3_w1th_42n_numb3r5')).toBe('fr0m_5nak3_c4s3_w1th_42n_numb3r5');
         expect(snakeCase('frøm_snake_case_w:th_$peçia!_ch*rs')).toBe('fr_m_snake_case_w_th_pe_ia_ch_rs');
         expect(snakeCase(snakeCase('frøm_d0ubl3_Snake_c*se'))).toBe('fr_m_d0ubl3_snake_c_se');
@@ -76,7 +76,7 @@ describe('titleCase', () => {
     test('from snake case', () => {
         expect(titleCase('from_lowercased_snake_case')).toBe('From Lowercased Snake Case');
         expect(titleCase('From_Capitalized_Snake_Case')).toBe('From Capitalized Snake Case');
-        expect(titleCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('F R O M U P P E R C A S E D S N A K E C A S E');
+        expect(titleCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('From Uppercased Snake Case');
         expect(titleCase('fr0m_5nak3_c4s3_w1th_42n_numb3r5')).toBe('Fr0m 5nak3 C4s3 W1th 42n Numb3r5');
         expect(titleCase('frøm_snake_case_w:th_$peçia!_ch*rs')).toBe('Fr M Snake Case W Th Pe Ia Ch Rs');
         expect(titleCase(titleCase('frøm_d0ubl3_Snake_c*se'))).toBe('Fr M D0ubl3 Snake C Se');

--- a/packages/nodes/test/shared/stringCases.test.ts
+++ b/packages/nodes/test/shared/stringCases.test.ts
@@ -129,7 +129,7 @@ describe('camelCase', () => {
     test('from snake case', () => {
         expect(camelCase('from_lowercased_snake_case')).toBe('fromLowercasedSnakeCase');
         expect(camelCase('From_Capitalized_Snake_Case')).toBe('fromCapitalizedSnakeCase');
-        expect(camelCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('fROMUPPERCASEDSNAKECASE');
+        expect(camelCase('FROM_UPPERCASED_SNAKE_CASE')).toBe('fromUppercasedSnakeCase');
         expect(camelCase('fr0m_5nak3_c4s3_w1th_42n_numb3r5')).toBe('fr0m5nak3C4s3W1th42nNumb3r5');
         expect(camelCase('frøm_snake_case_w:th_$peçia!_ch*rs')).toBe('frMSnakeCaseWThPeIaChRs');
         expect(camelCase(camelCase('frøm_d0ubl3_Snake_c*se'))).toBe('frMD0ubl3SnakeCSe');


### PR DESCRIPTION
Anchor constant names are almost expected to come in SCREAMING_SNAKE_CASE due to Rust standards.

Updated `camelCase` to correctly handle the conversion.