### PR TITLE
docs: correct @codama/renderers-js package name in CLI README

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -181,7 +181,7 @@ In the example below, we remove the `mint` account, the `initializeMint` instruc
 
 Generates a JavaScript client for the IDL at the specified output path.
 
-See [`@codama/renderer-js`](https://github.com/codama-idl/renderers-js).
+See [`@codama/renderers-js`](https://github.com/codama-idl/renderers-js).
 
 ```json
 {


### PR DESCRIPTION
The CLI README refers to the JavaScript renderer as `@codama/renderer-js`, but the package is `@codama/renderers-js` (plural) — which is also the repo the link already points to (`codama-idl/renderers-js`). This corrects the package name in the link text.
