### PR TITLE
Unwrap option values in instruction displays

### DIFF
--- a/.changeset/tall-lemons-leave.md
+++ b/.changeset/tall-lemons-leave.md
@@ -1,0 +1,5 @@
+---
+'@codama/dynamic-instructions': patch
+---
+
+Unwrap `Option` values when displaying instructions. Display metadata now applies to the value inside `optionTypeNode`, `zeroableOptionTypeNode` and `remainderOptionTypeNode` wrappers — e.g. a `COption<u64>` lamports amount renders as `1.5 SOL` instead of `{"__option":"Some","value":"1500000000"}` — and absent (`None`) values render as `none`. Flattened option-wrapped structs flatten their inner fields when present and render a single `none` field when absent.

--- a/packages/dynamic-instructions/src/display/format-argument-value.ts
+++ b/packages/dynamic-instructions/src/display/format-argument-value.ts
@@ -2,6 +2,7 @@ import { type EnumTypeNode, isNode, isScalarEnum, type NodePath, pascalCase, tit
 
 import { isObjectRecord } from '../shared/util';
 import { formatAmountValue, formatDateTimeValue, formatDurationValue, formatStringValue } from './format-value';
+import { unwrapOptionValue } from './option-value';
 import { resolveDisplayType } from './resolve-display-type';
 import type { DisplayContext } from './types';
 
@@ -10,8 +11,10 @@ import type { DisplayContext } from './types';
  *
  * Numbers, strings, and enum variants are rendered through their value-display nodes when
  * present; `definedTypeLinkNode`s are followed via the context's link resolver so linked
- * enums resolve to their variants. Any value without applicable display metadata — and any
- * value whose formatter cannot resolve its inputs — falls back to a raw string form.
+ * enums resolve to their variants; `Option` values are unwrapped so presentation applies to
+ * the inner value (`None` renders as `"none"`). Any value without applicable display
+ * metadata — and any value whose formatter cannot resolve its inputs — falls back to a raw
+ * string form.
  *
  * `ownerPath` is the path to the node owning `type` (e.g. an instruction argument), used to
  * resolve any link the type follows against the correct program.
@@ -22,22 +25,26 @@ export async function formatArgumentValue(
     value: unknown,
     displayContext: Omit<DisplayContext, 'consumedMemberNames'>,
 ): Promise<string> {
+    const unwrapped = unwrapOptionValue(value);
+    if (unwrapped.none) return 'none';
+    const innerValue = unwrapped.value;
+
     const resolved = resolveDisplayType(type, ownerPath, displayContext);
 
-    if (isNode(resolved.type, 'numberTypeNode') && resolved.type.display && isNumeric(value)) {
-        const formatted = await formatNumber(resolved.type.display, value, displayContext);
+    if (isNode(resolved.type, 'numberTypeNode') && resolved.type.display && isNumeric(innerValue)) {
+        const formatted = await formatNumber(resolved.type.display, innerValue, displayContext);
         if (formatted !== null) return formatted;
     }
 
-    if (isNode(resolved.type, 'stringTypeNode') && resolved.type.display && typeof value === 'string') {
-        return formatStringValue(value, resolved.type.display);
+    if (isNode(resolved.type, 'stringTypeNode') && resolved.type.display && typeof innerValue === 'string') {
+        return formatStringValue(innerValue, resolved.type.display);
     }
 
     if (isNode(resolved.type, 'enumTypeNode')) {
-        return formatEnumValue(resolved.type, value);
+        return formatEnumValue(resolved.type, innerValue);
     }
 
-    return rawValue(value);
+    return rawValue(innerValue);
 }
 
 /** Dispatches a number to the matching number-display formatter. */

--- a/packages/dynamic-instructions/src/display/list-fallback.ts
+++ b/packages/dynamic-instructions/src/display/list-fallback.ts
@@ -10,6 +10,7 @@ import {
 
 import { isObjectRecord } from '../shared/util';
 import { formatArgumentValue } from './format-argument-value';
+import { unwrapOptionValue } from './option-value';
 import { resolveDisplayType } from './resolve-display-type';
 import type { DisplayContext, DisplayField } from './types';
 
@@ -41,11 +42,19 @@ async function argumentFields(
     const ownerPath: NodePath = [...displayContext.parsedInstruction.path, argument];
     const resolved = resolveDisplayType(argument.type, ownerPath, displayContext);
 
-    if (argument.display?.flatten && isNode(resolved.type, 'structTypeNode') && isObjectRecord(value)) {
+    // Flattening reads the struct's fields, so option wrappers are unwrapped first; an absent
+    // (`None`) struct cannot be flattened and renders as a single `none` field instead.
+    const unwrapped = unwrapOptionValue(value);
+    if (
+        argument.display?.flatten &&
+        !unwrapped.none &&
+        isNode(resolved.type, 'structTypeNode') &&
+        isObjectRecord(unwrapped.value)
+    ) {
         return await flattenedFields(
             resolved.type,
             resolved.ownerPath,
-            value,
+            unwrapped.value,
             argument.display.flattenPrefix,
             displayContext,
         );

--- a/packages/dynamic-instructions/src/display/option-value.ts
+++ b/packages/dynamic-instructions/src/display/option-value.ts
@@ -1,0 +1,18 @@
+import { isObjectRecord } from '../shared/util';
+
+/** An unwrapped decoded value: either a present inner value or an absent (`None`) one. */
+export type UnwrappedOptionValue = { none: false; value: unknown } | { none: true };
+
+/**
+ * Recursively unwraps Kit `Option` wrappers (`{ __option: 'Some', value }` / `{ __option: 'None' }`)
+ * from a decoded value. Non-option values pass through unchanged. The counterpart of
+ * `resolveDisplayType` unwrapping option *types*: together they let presentation metadata attach to
+ * the value inside the option.
+ */
+export function unwrapOptionValue(value: unknown): UnwrappedOptionValue {
+    if (isObjectRecord(value) && typeof value.__option === 'string') {
+        if (value.__option === 'None') return { none: true };
+        return unwrapOptionValue(value.value);
+    }
+    return { none: false, value };
+}

--- a/packages/dynamic-instructions/src/display/resolve-display-type.ts
+++ b/packages/dynamic-instructions/src/display/resolve-display-type.ts
@@ -13,32 +13,53 @@ import type { DisplayContext } from './types';
 export type ResolvedDisplayType = {
     /** The path locating the resolved type's owner, used to resolve any links nested within it. */
     readonly ownerPath: NodePath;
-    /** The resolved type, with wrappers stripped and any top-level link followed. */
+    /** The resolved type, with wrappers stripped and links followed. */
     readonly type: TypeNode;
 };
 
 /**
- * Resolves nested type wrappers and follows a single `definedTypeLinkNode` to its underlying type.
- * Shared by the value formatter, the fallback list, and consumed-member collection so links resolve
- * identically everywhere.
+ * Resolves nested type wrappers, follows `definedTypeLinkNode`s to their underlying types, and
+ * unwraps option types to their item — presentation belongs to the value inside the option, and
+ * the value formatter unwraps the corresponding `Option` values symmetrically. Shared by the value
+ * formatter, the fallback list, and consumed-member collection so links resolve identically
+ * everywhere.
  *
- * The link is resolved by its full path (`ownerPath` plus the link), so the linkable dictionary
- * targets the program the link appears in. When a link is followed, the returned `ownerPath` is
+ * Links are resolved by their full path (`ownerPath` plus the link), so the linkable dictionary
+ * targets the program each link appears in. When a link is followed, the returned `ownerPath` is
  * rebased onto the resolved defined type so links nested within it — possibly in another program —
- * resolve from the correct location.
+ * resolve from the correct location. Since links and options can now interleave (e.g. a recursive
+ * type reaching itself through an option), already-followed links are tracked to terminate cycles.
  */
 export function resolveDisplayType(
     type: TypeNode,
     ownerPath: NodePath,
     displayContext: Omit<DisplayContext, 'consumedMemberNames'>,
 ): ResolvedDisplayType {
-    const resolved = resolveNestedTypeNode(type);
-    if (isNode(resolved, 'definedTypeLinkNode')) {
-        const definedTypePath = displayContext.resolveDefinedType([...ownerPath, resolved]);
-        if (definedTypePath) {
-            const definedType = getLastNodeFromPath<DefinedTypeNode>(definedTypePath);
-            return { ownerPath: definedTypePath, type: resolveNestedTypeNode(definedType.type) };
+    let resolvedType = resolveNestedTypeNode(type);
+    let resolvedOwnerPath = ownerPath;
+    const followedLinks = new Set<DefinedTypeNode>();
+
+    for (;;) {
+        if (
+            isNode(resolvedType, 'optionTypeNode') ||
+            isNode(resolvedType, 'remainderOptionTypeNode') ||
+            isNode(resolvedType, 'zeroableOptionTypeNode')
+        ) {
+            resolvedType = resolveNestedTypeNode(resolvedType.item);
+            continue;
         }
+        if (isNode(resolvedType, 'definedTypeLinkNode')) {
+            const definedTypePath = displayContext.resolveDefinedType([...resolvedOwnerPath, resolvedType]);
+            if (!definedTypePath) break;
+            const definedType = getLastNodeFromPath<DefinedTypeNode>(definedTypePath);
+            if (followedLinks.has(definedType)) break;
+            followedLinks.add(definedType);
+            resolvedOwnerPath = definedTypePath;
+            resolvedType = resolveNestedTypeNode(definedType.type);
+            continue;
+        }
+        break;
     }
-    return { ownerPath, type: resolved };
+
+    return { ownerPath: resolvedOwnerPath, type: resolvedType };
 }

--- a/packages/dynamic-instructions/test/display/format-argument-value.test.ts
+++ b/packages/dynamic-instructions/test/display/format-argument-value.test.ts
@@ -11,9 +11,12 @@ import {
     injectedValueNode,
     numberTypeNode,
     numberValueNode,
+    optionTypeNode,
     stringDisplayNode,
     stringTypeNode,
+    stringValueNode,
     type TypeNode,
+    zeroableOptionTypeNode,
 } from 'codama';
 import { describe, expect, test } from 'vitest';
 
@@ -148,5 +151,90 @@ describe('formatArgumentValue', () => {
 
         // Then we expect the linked variant label.
         expect(result).toBe('Sell');
+    });
+
+    test('it unwraps a present option value through the item display', async () => {
+        // Given an option of a u64 typed with an amount display.
+        const type = optionTypeNode(
+            numberTypeNode('u64', 'le', {
+                display: amountNumberDisplayNode({ decimals: numberValueNode(9), unit: stringValueNode('SOL') }),
+            }),
+        );
+
+        // When we format a `Some` value.
+        const result = await formatArgumentValue(
+            type,
+            [],
+            { __option: 'Some', value: 1_500_000_000n },
+            displayContext(),
+        );
+
+        // Then we expect the inner value rendered through the item's display.
+        expect(result).toBe('1.5 SOL');
+    });
+
+    test('it renders an absent option value as none', async () => {
+        // Given an option of a displayed number type.
+        const type = optionTypeNode(
+            numberTypeNode('u64', 'le', { display: amountNumberDisplayNode({ decimals: numberValueNode(9) }) }),
+        );
+
+        // When we format a `None` value.
+        const result = await formatArgumentValue(type, [], { __option: 'None' }, displayContext());
+
+        // Then we expect the human-readable absence marker.
+        expect(result).toBe('none');
+    });
+
+    test('it unwraps a zeroable option value through the item display', async () => {
+        // Given a zeroable option of a displayed number type.
+        const type = zeroableOptionTypeNode(
+            numberTypeNode('u64', 'le', { display: amountNumberDisplayNode({ decimals: numberValueNode(6) }) }),
+        );
+
+        // When we format a `Some` value.
+        const result = await formatArgumentValue(type, [], { __option: 'Some', value: 1_500_000n }, displayContext());
+
+        // Then we expect the inner value rendered through the item's display.
+        expect(result).toBe('1.5');
+    });
+
+    test('it unwraps an option of a linked enum to the variant label', async () => {
+        // Given an option of a link to a defined enum.
+        const orderType: DefinedTypeNode = definedTypeNode({
+            name: 'orderType',
+            type: enumTypeNode([
+                enumEmptyVariantTypeNode('buy', undefined, { display: enumVariantDisplayNode({ label: 'Buy' }) }),
+                enumEmptyVariantTypeNode('sell'),
+            ]),
+        });
+        const type = optionTypeNode(definedTypeLinkNode('orderType'));
+
+        // When we format a `Some` variant name.
+        const result = await formatArgumentValue(
+            type,
+            [],
+            { __option: 'Some', value: 'buy' },
+            displayContext({ resolveDefinedType: mockResolveDefinedType(orderType) }),
+        );
+
+        // Then we expect the linked variant label.
+        expect(result).toBe('Buy');
+    });
+
+    test('it unwraps nested option values', async () => {
+        // Given an option of an option of a plain number.
+        const type = optionTypeNode(optionTypeNode(numberTypeNode('u64')));
+
+        // When we format a doubly-wrapped value.
+        const result = await formatArgumentValue(
+            type,
+            [],
+            { __option: 'Some', value: { __option: 'Some', value: 42n } },
+            displayContext(),
+        );
+
+        // Then we expect the innermost value.
+        expect(result).toBe('42');
     });
 });

--- a/packages/dynamic-instructions/test/display/list-fallback.test.ts
+++ b/packages/dynamic-instructions/test/display/list-fallback.test.ts
@@ -7,6 +7,7 @@ import {
     instructionArgumentNode,
     instructionNode,
     numberTypeNode,
+    optionTypeNode,
     structFieldDisplayNode,
     structFieldTypeNode,
     structTypeNode,
@@ -192,5 +193,71 @@ describe('listFallback', () => {
             { label: 'args.Price', value: '100' },
             { label: 'args.Size', value: '5' },
         ]);
+    });
+
+    test('it flattens a present option-wrapped struct argument', async () => {
+        // Given a flattened argument whose type is an option of a linked struct.
+        const orderArgs = definedTypeNode({
+            name: 'orderArgs',
+            type: structTypeNode([
+                structFieldTypeNode({ name: 'price', type: numberTypeNode('u64') }),
+                structFieldTypeNode({ name: 'size', type: numberTypeNode('u64') }),
+            ]),
+        });
+        const instruction = instructionNode({
+            accounts: [],
+            arguments: [
+                instructionArgumentNode({
+                    display: structFieldDisplayNode({ flatten: true }),
+                    name: 'args',
+                    type: optionTypeNode(definedTypeLinkNode('orderArgs')),
+                }),
+            ],
+            name: 'placeOrder',
+        });
+
+        // When we build the fallback list with a `Some` value.
+        const result = await listFallback(
+            displayContext({
+                parsedInstruction: parsedInstruction({
+                    data: { args: { __option: 'Some', value: { price: 100n, size: 5n } } },
+                    instruction,
+                }),
+                resolveDefinedType: mockResolveDefinedType(orderArgs),
+            }),
+        );
+
+        // Then we expect the inner struct's fields lifted into the list.
+        expect(result).toEqual([
+            { label: 'Price', value: '100' },
+            { label: 'Size', value: '5' },
+        ]);
+    });
+
+    test('it renders an absent option-wrapped struct argument as a single none field', async () => {
+        // Given a flattened argument whose type is an option of a struct.
+        const instruction = instructionNode({
+            accounts: [],
+            arguments: [
+                instructionArgumentNode({
+                    display: structFieldDisplayNode({ flatten: true }),
+                    name: 'args',
+                    type: optionTypeNode(
+                        structTypeNode([structFieldTypeNode({ name: 'price', type: numberTypeNode('u64') })]),
+                    ),
+                }),
+            ],
+            name: 'placeOrder',
+        });
+
+        // When we build the fallback list with a `None` value.
+        const result = await listFallback(
+            displayContext({
+                parsedInstruction: parsedInstruction({ data: { args: { __option: 'None' } }, instruction }),
+            }),
+        );
+
+        // Then we expect a single field marking the absence, not a flattened struct.
+        expect(result).toEqual([{ label: 'Args', value: 'none' }]);
     });
 });


### PR DESCRIPTION
Option-typed values decoded from instructions surface as Kit `Option` objects and previously fell through to the raw JSON form in both the fallback list and interpolated sentences. `resolveDisplayType` now unwraps option types to their item (iteratively with link resolution, guarded against recursive defined-type cycles), and `formatArgumentValue` unwraps the values symmetrically, so presentation metadata attaches to the inner value and `None` renders as `none`. The flatten path unwraps before reading struct fields. This also lets the offline-dictionary planner see displays inside options, since it shares `resolveDisplayType`.