### PR TITLE
Match enum variants from every decoded shape in displays

### DIFF
--- a/.changeset/six-sloths-bow.md
+++ b/.changeset/six-sloths-bow.md
@@ -1,0 +1,5 @@
+---
+'@codama/dynamic-instructions': patch
+---
+
+Match enum variants from every decoded shape when displaying instructions. Scalar enums decoded as numeric discriminators (explicit or positional) now render their variant label instead of the bare index — e.g. `Authority Type: Freeze Account` instead of `Authority Type: 1` — and `{ __kind }` values match variants regardless of casing.

--- a/packages/dynamic-instructions/src/display/format-argument-value.ts
+++ b/packages/dynamic-instructions/src/display/format-argument-value.ts
@@ -1,4 +1,4 @@
-import { type EnumTypeNode, isNode, isScalarEnum, type NodePath, pascalCase, titleCase, type TypeNode } from 'codama';
+import { type EnumTypeNode, isNode, type NodePath, pascalCase, titleCase, type TypeNode } from 'codama';
 
 import { isObjectRecord } from '../shared/util';
 import { formatAmountValue, formatDateTimeValue, formatDurationValue, formatStringValue } from './format-value';
@@ -65,18 +65,32 @@ async function formatNumber(
 
 /**
  * Formats an enum value using the matched variant's display label.
- * Scalar enums decode to the variant name; data enums decode to `{ __kind: 'PascalVariant', ... }`.
+ *
+ * Decoded enum values arrive in several shapes depending on the codec: a numeric discriminator
+ * (scalar enums through the dynamic codecs), the variant name as a string, or a
+ * `{ __kind: <variant> }` object whose casing varies (raw camelCase or PascalCase). All are
+ * matched to the variant; anything unmatched falls back to the raw form.
  */
 function formatEnumValue(enumType: EnumTypeNode, value: unknown): string {
+    const variants = enumType.variants ?? [];
+
+    // Numeric decode: match the variant's discriminator, explicit or inferred from position.
+    if (typeof value === 'number' || typeof value === 'bigint') {
+        const target = Number(value);
+        const variant = variants.find((candidate, index) => (candidate.discriminator ?? index) === target);
+        return variant ? variantLabel(variant) : rawValue(value);
+    }
+
     const decodedName = enumVariantName(value);
     if (decodedName === null) return rawValue(value);
 
-    // Scalar enums decode to the variant name as-is; data enum `__kind` is the PascalCase form.
-    const variant = (enumType.variants ?? []).find(candidate =>
-        isScalarEnum(enumType) ? candidate.name === decodedName : pascalCase(candidate.name) === decodedName,
-    );
-    if (!variant) return rawValue(value);
+    // Codecs disagree on name casing, so compare through a common PascalCase form.
+    const variant = variants.find(candidate => pascalCase(candidate.name) === pascalCase(decodedName));
+    return variant ? variantLabel(variant) : rawValue(value);
+}
 
+/** The label shown for a variant: its display label, or its title-cased name. */
+function variantLabel(variant: NonNullable<EnumTypeNode['variants']>[number]): string {
     return variant.display?.label ?? titleCase(variant.name);
 }
 

--- a/packages/dynamic-instructions/test/display/format-argument-value.test.ts
+++ b/packages/dynamic-instructions/test/display/format-argument-value.test.ts
@@ -6,6 +6,7 @@ import {
     definedTypeNode,
     durationNumberDisplayNode,
     enumEmptyVariantTypeNode,
+    enumTupleVariantTypeNode,
     enumTypeNode,
     enumVariantDisplayNode,
     injectedValueNode,
@@ -15,6 +16,7 @@ import {
     stringDisplayNode,
     stringTypeNode,
     stringValueNode,
+    tupleTypeNode,
     type TypeNode,
     zeroableOptionTypeNode,
 } from 'codama';
@@ -220,6 +222,59 @@ describe('formatArgumentValue', () => {
 
         // Then we expect the linked variant label.
         expect(result).toBe('Buy');
+    });
+
+    test('it labels a scalar enum variant decoded as a numeric index', async () => {
+        // Given a scalar enum with positional discriminators.
+        const type = enumTypeNode([
+            enumEmptyVariantTypeNode('buy', undefined, { display: enumVariantDisplayNode({ label: 'Buy' }) }),
+            enumEmptyVariantTypeNode('sell', undefined, { display: enumVariantDisplayNode({ label: 'Sell' }) }),
+        ]);
+
+        // When we format the numeric index the dynamic codecs decode to.
+        const result = await formatArgumentValue(type, [], 1, displayContext());
+
+        // Then we expect the matching variant's label, not the bare index.
+        expect(result).toBe('Sell');
+    });
+
+    test('it labels a scalar enum variant decoded as an explicit discriminator value', async () => {
+        // Given a scalar enum whose variants declare explicit discriminators.
+        const type = enumTypeNode([enumEmptyVariantTypeNode('legacy', 5), enumEmptyVariantTypeNode('current', 7)]);
+
+        // When we format an explicit discriminator value.
+        const result = await formatArgumentValue(type, [], 7, displayContext());
+
+        // Then we expect the variant matching that discriminator, not the position.
+        expect(result).toBe('Current');
+    });
+
+    test('it falls back to the raw index when no variant matches', async () => {
+        // Given a scalar enum with two variants.
+        const type = enumTypeNode([enumEmptyVariantTypeNode('buy'), enumEmptyVariantTypeNode('sell')]);
+
+        // When we format an out-of-range index.
+        const result = await formatArgumentValue(type, [], 9, displayContext());
+
+        // Then we expect the raw value.
+        expect(result).toBe('9');
+    });
+
+    test('it matches a data enum kind regardless of casing', async () => {
+        // Given an enum whose decoded `__kind` arrives in raw camelCase (codecs disagree on casing).
+        const type = enumTypeNode([
+            enumEmptyVariantTypeNode('name'),
+            enumEmptyVariantTypeNode('symbol'),
+            enumTupleVariantTypeNode('key', tupleTypeNode([stringTypeNode('utf8')])),
+        ]);
+
+        // When we format both casings of a variant kind.
+        const rawCased = await formatArgumentValue(type, [], { __kind: 'symbol' }, displayContext());
+        const pascalCased = await formatArgumentValue(type, [], { __kind: 'Symbol' }, displayContext());
+
+        // Then we expect both to match the variant.
+        expect(rawCased).toBe('Symbol');
+        expect(pascalCased).toBe('Symbol');
     });
 
     test('it unwraps nested option values', async () => {


### PR DESCRIPTION
The dynamic codecs decode scalar enums to their numeric discriminator, and data-enum `__kind` casing varies between codecs (raw camelCase vs PascalCase), so `formatEnumValue` frequently failed to match a variant and fell back to the raw form. It now matches numeric values against each variant's discriminator (explicit, or inferred from position), and name-shaped values through a common PascalCase comparison. Unmatched values still fall back to the raw form. This is the display-layer half of the enum-shape question; normalising decoded shapes at the parser level is deliberately left to a future additive opt-in (e.g. `simplifyParsedData`) so the default Kit-canonical decode stays untouched.