### PR TITLE
Mark unresolved amount scales instead of degrading silently

### DIFF
--- a/.changeset/eleven-canyons-invite.md
+++ b/.changeset/eleven-canyons-invite.md
@@ -1,0 +1,5 @@
+---
+'@codama/dynamic-instructions': patch
+---
+
+Mark unresolved amount scales instead of degrading silently. When an `amountNumberDisplayNode` is present but its `decimals` cannot be resolved (e.g. no `fetchAccount` for an account-injected scale), the field list now renders the value explicitly marked — `1500000 (raw)` — and any interpolated sentence referencing it returns `null`, falling back to the field list. Previously the bare integer rendered unmarked in both, reading exactly like a scaled amount. Amount displays authored without a `decimals` attribute are unaffected: they remain valid unscaled amounts.

--- a/packages/dynamic-instructions/README.md
+++ b/packages/dynamic-instructions/README.md
@@ -158,7 +158,7 @@ if (parsed) {
 
 ### Options
 
-Some display values live in on-chain account state (e.g. a token's `decimals`/`symbol` injected into an amount, or interpolation paths that read an account field). Supply `fetchAccount` to resolve them; without it, such values degrade gracefully (amounts stay raw, `whenInjected` fields remain visible).
+Some display values live in on-chain account state (e.g. a token's `decimals`/`symbol` injected into an amount, or interpolation paths that read an account field). Supply `fetchAccount` to resolve them; without it, such values degrade gracefully and visibly: an amount whose scale cannot be resolved renders marked as raw in the field list (e.g. `1500000 (raw)`) so it cannot be mistaken for a scaled amount, any sentence referencing it is suppressed (`interpolatedIntent` becomes `null`, falling back to the fields), and `whenInjected` members remain visible.
 
 `fetchAccount` returns Kit's `MaybeEncodedAccount` — an `exists` flag plus, when the account exists, its raw bytes. No decoding is required on your side: the display layer decodes the bytes itself using the referenced account's `accountLink` from the IDL, which already describes the layout. This makes `fetchEncodedAccount` a drop-in.
 

--- a/packages/dynamic-instructions/src/display/format-argument-value.ts
+++ b/packages/dynamic-instructions/src/display/format-argument-value.ts
@@ -7,6 +7,20 @@ import { resolveDisplayType } from './resolve-display-type';
 import type { DisplayContext } from './types';
 
 /**
+ * A formatted value paired with whether its presentation degraded.
+ *
+ * `degraded` is `true` only when an `amountNumberDisplayNode` was present but its scale could
+ * not be resolved: the raw integer then reads exactly like a scaled amount, so callers must
+ * either mark it (fallback list) or refuse to present it as prose (interpolated intents).
+ * Other unpresented values — missing display metadata, invalid date-times — are not degraded:
+ * their raw forms carry no false confidence.
+ */
+export type FormattedArgumentValue = {
+    degraded: boolean;
+    text: string;
+};
+
+/**
  * Formats a single decoded value according to the presentation metadata on its type.
  *
  * Numbers, strings, and enum variants are rendered through their value-display nodes when
@@ -14,7 +28,8 @@ import type { DisplayContext } from './types';
  * enums resolve to their variants; `Option` values are unwrapped so presentation applies to
  * the inner value (`None` renders as `"none"`). Any value without applicable display
  * metadata — and any value whose formatter cannot resolve its inputs — falls back to a raw
- * string form.
+ * string form, flagged as `degraded` when the failed presentation was an amount scale (see
+ * {@link FormattedArgumentValue}).
  *
  * `ownerPath` is the path to the node owning `type` (e.g. an instruction argument), used to
  * resolve any link the type follows against the correct program.
@@ -24,27 +39,30 @@ export async function formatArgumentValue(
     ownerPath: NodePath,
     value: unknown,
     displayContext: Omit<DisplayContext, 'consumedMemberNames'>,
-): Promise<string> {
+): Promise<FormattedArgumentValue> {
     const unwrapped = unwrapOptionValue(value);
-    if (unwrapped.none) return 'none';
+    if (unwrapped.none) return { degraded: false, text: 'none' };
     const innerValue = unwrapped.value;
 
     const resolved = resolveDisplayType(type, ownerPath, displayContext);
 
     if (isNode(resolved.type, 'numberTypeNode') && resolved.type.display && isNumeric(innerValue)) {
         const formatted = await formatNumber(resolved.type.display, innerValue, displayContext);
-        if (formatted !== null) return formatted;
+        if (formatted !== null) return { degraded: false, text: formatted };
+        if (resolved.type.display.kind === 'amountNumberDisplayNode') {
+            return { degraded: true, text: rawValue(innerValue) };
+        }
     }
 
     if (isNode(resolved.type, 'stringTypeNode') && resolved.type.display && typeof innerValue === 'string') {
-        return formatStringValue(innerValue, resolved.type.display);
+        return { degraded: false, text: formatStringValue(innerValue, resolved.type.display) };
     }
 
     if (isNode(resolved.type, 'enumTypeNode')) {
-        return formatEnumValue(resolved.type, innerValue);
+        return { degraded: false, text: formatEnumValue(resolved.type, innerValue) };
     }
 
-    return rawValue(innerValue);
+    return { degraded: false, text: rawValue(innerValue) };
 }
 
 /** Dispatches a number to the matching number-display formatter. */

--- a/packages/dynamic-instructions/src/display/interpolate-intent.ts
+++ b/packages/dynamic-instructions/src/display/interpolate-intent.ts
@@ -13,9 +13,12 @@ const PLACEHOLDER_PATTERN = /\$\{\s*(data|accounts)\.([a-zA-Z0-9_]+)\s*\}/g;
  * replaced by the referent's own presentation: arguments through their value-display nodes,
  * accounts by their address.
  *
- * Returns `null` when the instruction has no `interpolatedIntent`, or when any placeholder
- * cannot be resolved (an unknown name, or a value whose formatting fails). A `null` result
- * signals the caller to fall back to the structured field list.
+ * Returns `null` when the instruction has no `interpolatedIntent`, when any placeholder
+ * cannot be resolved (an unknown name), or when a referenced amount's scale could not be
+ * resolved — prose implies confidence, and an unscaled integer reads exactly like a scaled
+ * amount, so a degraded value belongs in the field list (where it is marked `(raw)`), never
+ * in the sentence. A `null` result signals the caller to fall back to the structured field
+ * list.
  */
 export async function interpolateIntent(displayContext: DisplayContext): Promise<string | null> {
     const instruction = getLastNodeFromPath(displayContext.parsedInstruction.path);
@@ -47,7 +50,8 @@ async function resolvePlaceholder(root: string, name: string, displayContext: Di
         const decodedData = data as Record<string, unknown>;
         if (!argument || !(name in decodedData)) return null;
         const ownerPath = [...path, argument];
-        return await formatArgumentValue(argument.type, ownerPath, decodedData[name], displayContext);
+        const formatted = await formatArgumentValue(argument.type, ownerPath, decodedData[name], displayContext);
+        return formatted.degraded ? null : formatted.text;
     }
 
     // root === 'accounts'

--- a/packages/dynamic-instructions/src/display/list-fallback.ts
+++ b/packages/dynamic-instructions/src/display/list-fallback.ts
@@ -9,7 +9,7 @@ import {
 } from 'codama';
 
 import { isObjectRecord } from '../shared/util';
-import { formatArgumentValue } from './format-argument-value';
+import { formatArgumentValue, type FormattedArgumentValue } from './format-argument-value';
 import { unwrapOptionValue } from './option-value';
 import { resolveDisplayType } from './resolve-display-type';
 import type { DisplayContext, DisplayField } from './types';
@@ -61,7 +61,8 @@ async function argumentFields(
     }
 
     const label = argument.display?.label ?? titleCase(argument.name);
-    return [{ label, value: await formatArgumentValue(argument.type, ownerPath, value, displayContext) }];
+    const formatted = await formatArgumentValue(argument.type, ownerPath, value, displayContext);
+    return [{ label, value: markIfDegraded(formatted) }];
 }
 
 /** Lifts a struct's fields into the parent list, prefixing each label and reading nested values. */
@@ -84,9 +85,17 @@ async function flattenedFields(
                 value[field.name],
                 displayContext,
             );
-            return { label, value: formatted };
+            return { label, value: markIfDegraded(formatted) };
         }),
     );
+}
+
+/**
+ * Renders a formatted value, marking amounts whose scale failed to resolve so a raw integer
+ * cannot be mistaken for a scaled amount (see `FormattedArgumentValue`).
+ */
+function markIfDegraded(formatted: FormattedArgumentValue): string {
+    return formatted.degraded ? `${formatted.text} (raw)` : formatted.text;
 }
 
 /** Produces the display fields for the instruction's accounts. */

--- a/packages/dynamic-instructions/test/display/format-argument-value.test.ts
+++ b/packages/dynamic-instructions/test/display/format-argument-value.test.ts
@@ -36,7 +36,7 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], 1_500_000_000n, displayContext());
 
         // Then we expect the scaled value.
-        expect(result).toBe('1.5');
+        expect(result.text).toBe('1.5');
     });
 
     test('it formats a number with a date-time display node', async () => {
@@ -47,7 +47,7 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], 1_761_365_183, displayContext());
 
         // Then we expect the ISO 8601 form.
-        expect(result).toBe('2025-10-25T04:06:23.000Z');
+        expect(result.text).toBe('2025-10-25T04:06:23.000Z');
     });
 
     test('it formats a number with a duration display node', async () => {
@@ -58,7 +58,7 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], 3600n, displayContext());
 
         // Then we expect the HH:mm:ss form.
-        expect(result).toBe('01:00:00');
+        expect(result.text).toBe('01:00:00');
     });
 
     test('it slices a string with a string display node', async () => {
@@ -69,10 +69,10 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], 'SOLANA', displayContext());
 
         // Then we expect the sliced substring.
-        expect(result).toBe('SOL');
+        expect(result.text).toBe('SOL');
     });
 
-    test('it falls back to raw when amount decimals cannot be resolved', async () => {
+    test('it falls back to raw and flags degradation when amount decimals cannot be resolved', async () => {
         // Given an amount whose injected decimals have no provider.
         const type = numberTypeNode('u64', 'le', {
             display: amountNumberDisplayNode({ decimals: injectedValueNode({ key: 'decimals' }) }),
@@ -81,8 +81,32 @@ describe('formatArgumentValue', () => {
         // When we format the amount.
         const result = await formatArgumentValue(type, [], 1_000_000n, displayContext());
 
-        // Then we expect the raw value as a string.
-        expect(result).toBe('1000000');
+        // Then we expect the raw value, flagged as degraded: it reads exactly like a scaled amount.
+        expect(result).toEqual({ degraded: true, text: '1000000' });
+    });
+
+    test('it does not flag an amount with absent decimals as degraded', async () => {
+        // Given an amount display with a unit but no decimals attribute (a valid "no scaling" authoring).
+        const type = numberTypeNode('u64', 'le', {
+            display: amountNumberDisplayNode({ unit: stringValueNode('base units') }),
+        });
+
+        // When we format the amount.
+        const result = await formatArgumentValue(type, [], 1_500_000n, displayContext());
+
+        // Then we expect the unscaled value with its unit, not a degradation.
+        expect(result).toEqual({ degraded: false, text: '1500000 base units' });
+    });
+
+    test('it does not flag an unpresentable date-time as degraded', async () => {
+        // Given a date-time display and a tick value that cannot form a valid date.
+        const type = numberTypeNode('u64', 'le', { display: dateTimeNumberDisplayNode({}) });
+
+        // When we format an absurd timestamp.
+        const result = await formatArgumentValue(type, [], 999_999_999_999_999n, displayContext());
+
+        // Then we expect the raw fallback without degradation: a raw timestamp carries no false scale.
+        expect(result).toEqual({ degraded: false, text: '999999999999999' });
     });
 
     test('it renders a raw number when the type has no display node', async () => {
@@ -93,7 +117,7 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], 42n, displayContext());
 
         // Then we expect the raw string.
-        expect(result).toBe('42');
+        expect(result.text).toBe('42');
     });
 
     test('it renders an empty string for an undefined value rather than the string "undefined"', async () => {
@@ -104,7 +128,7 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], undefined, displayContext());
 
         // Then we expect an empty string, not `JSON.stringify(undefined)`.
-        expect(result).toBe('');
+        expect(result.text).toBe('');
     });
 
     test('it labels a scalar enum variant using its display label', async () => {
@@ -118,7 +142,7 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], 'buy', displayContext());
 
         // Then we expect the variant label.
-        expect(result).toBe('Buy');
+        expect(result.text).toBe('Buy');
     });
 
     test('it title-cases a scalar enum variant without a display label', async () => {
@@ -129,7 +153,7 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], 'buyNow', displayContext());
 
         // Then we expect the title-cased variant name.
-        expect(result).toBe('Buy Now');
+        expect(result.text).toBe('Buy Now');
     });
 
     test('it resolves a defined-type link to a linked enum', async () => {
@@ -152,7 +176,7 @@ describe('formatArgumentValue', () => {
         );
 
         // Then we expect the linked variant label.
-        expect(result).toBe('Sell');
+        expect(result.text).toBe('Sell');
     });
 
     test('it unwraps a present option value through the item display', async () => {
@@ -172,7 +196,7 @@ describe('formatArgumentValue', () => {
         );
 
         // Then we expect the inner value rendered through the item's display.
-        expect(result).toBe('1.5 SOL');
+        expect(result.text).toBe('1.5 SOL');
     });
 
     test('it renders an absent option value as none', async () => {
@@ -185,7 +209,7 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], { __option: 'None' }, displayContext());
 
         // Then we expect the human-readable absence marker.
-        expect(result).toBe('none');
+        expect(result.text).toBe('none');
     });
 
     test('it unwraps a zeroable option value through the item display', async () => {
@@ -198,7 +222,7 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], { __option: 'Some', value: 1_500_000n }, displayContext());
 
         // Then we expect the inner value rendered through the item's display.
-        expect(result).toBe('1.5');
+        expect(result.text).toBe('1.5');
     });
 
     test('it unwraps an option of a linked enum to the variant label', async () => {
@@ -221,7 +245,7 @@ describe('formatArgumentValue', () => {
         );
 
         // Then we expect the linked variant label.
-        expect(result).toBe('Buy');
+        expect(result.text).toBe('Buy');
     });
 
     test('it labels a scalar enum variant decoded as a numeric index', async () => {
@@ -235,7 +259,7 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], 1, displayContext());
 
         // Then we expect the matching variant's label, not the bare index.
-        expect(result).toBe('Sell');
+        expect(result.text).toBe('Sell');
     });
 
     test('it labels a scalar enum variant decoded as an explicit discriminator value', async () => {
@@ -246,7 +270,7 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], 7, displayContext());
 
         // Then we expect the variant matching that discriminator, not the position.
-        expect(result).toBe('Current');
+        expect(result.text).toBe('Current');
     });
 
     test('it falls back to the raw index when no variant matches', async () => {
@@ -257,7 +281,7 @@ describe('formatArgumentValue', () => {
         const result = await formatArgumentValue(type, [], 9, displayContext());
 
         // Then we expect the raw value.
-        expect(result).toBe('9');
+        expect(result.text).toBe('9');
     });
 
     test('it matches a data enum kind regardless of casing', async () => {
@@ -273,8 +297,8 @@ describe('formatArgumentValue', () => {
         const pascalCased = await formatArgumentValue(type, [], { __kind: 'Symbol' }, displayContext());
 
         // Then we expect both to match the variant.
-        expect(rawCased).toBe('Symbol');
-        expect(pascalCased).toBe('Symbol');
+        expect(rawCased.text).toBe('Symbol');
+        expect(pascalCased.text).toBe('Symbol');
     });
 
     test('it unwraps nested option values', async () => {
@@ -290,6 +314,6 @@ describe('formatArgumentValue', () => {
         );
 
         // Then we expect the innermost value.
-        expect(result).toBe('42');
+        expect(result.text).toBe('42');
     });
 });

--- a/packages/dynamic-instructions/test/display/get-instruction-display.test.ts
+++ b/packages/dynamic-instructions/test/display/get-instruction-display.test.ts
@@ -129,11 +129,13 @@ describe('getInstructionDisplayFromParsedInstruction', () => {
             { label: 'To', value: DESTINATION },
         ]);
 
-        // When offline, the amount stays raw and the mint reappears as a backup (arguments first).
+        // When offline, the unresolvable amount suppresses the sentence — an unscaled integer in
+        // prose would read as a scaled amount — and the field list carries it marked as raw, with
+        // the mint reappearing as a backup (arguments first).
         const offline = await getInstructionDisplayFromParsedInstruction(root, parsed);
-        expect(offline.interpolatedIntent).toBe(`Transfer 1500000 to ${DESTINATION}`);
+        expect(offline.interpolatedIntent).toBeNull();
         expect(offline.fields).toEqual([
-            { label: 'Amount', value: '1500000' },
+            { label: 'Amount', value: '1500000 (raw)' },
             { label: 'Token Mint', value: MINT },
             { label: 'To', value: DESTINATION },
         ]);

--- a/packages/dynamic-instructions/test/display/interpolate-intent.test.ts
+++ b/packages/dynamic-instructions/test/display/interpolate-intent.test.ts
@@ -8,6 +8,7 @@ import {
     instructionNode,
     numberTypeNode,
     numberValueNode,
+    stringValueNode,
 } from 'codama';
 import { describe, expect, test } from 'vitest';
 
@@ -105,7 +106,7 @@ describe('interpolateIntent', () => {
         expect(result).toBeNull();
     });
 
-    test('it returns null when a value formatter cannot resolve its inputs', async () => {
+    test('it returns null when a referenced amount scale cannot be resolved', async () => {
         // Given an amount whose injected decimals cannot be resolved.
         const instruction = instructionNode({
             accounts: [],
@@ -122,10 +123,36 @@ describe('interpolateIntent', () => {
         });
 
         // When we interpolate the intent.
-        // Then it still resolves: an unresolved amount falls back to its raw value rather than failing.
+        // Then we expect null: an unscaled integer in prose reads exactly like a scaled amount, so
+        // the sentence is suppressed in favour of the field list, which marks the value as raw.
         const result = await interpolateIntent(
             displayContext({ parsedInstruction: parsedInstruction({ data: { amount: 1_000_000n }, instruction }) }),
         );
-        expect(result).toBe('Transfer 1000000');
+        expect(result).toBeNull();
+    });
+
+    test('it keeps the sentence when a referenced amount has no decimals attribute', async () => {
+        // Given an amount display authored with a unit and no decimals (a valid unscaled amount).
+        const instruction = instructionNode({
+            accounts: [],
+            arguments: [
+                instructionArgumentNode({
+                    name: 'amount',
+                    type: numberTypeNode('u64', 'le', {
+                        display: amountNumberDisplayNode({ unit: stringValueNode('base units') }),
+                    }),
+                }),
+            ],
+            display: instructionDisplayNode({ interpolatedIntent: 'Transfer ${data.amount}' }),
+            name: 'transfer',
+        });
+
+        // When we interpolate the intent.
+        const result = await interpolateIntent(
+            displayContext({ parsedInstruction: parsedInstruction({ data: { amount: 1_500_000n }, instruction }) }),
+        );
+
+        // Then we expect the sentence with the authored unscaled rendering.
+        expect(result).toBe('Transfer 1500000 base units');
     });
 });

--- a/packages/dynamic-instructions/test/display/list-fallback.test.ts
+++ b/packages/dynamic-instructions/test/display/list-fallback.test.ts
@@ -1,7 +1,9 @@
 import type { Address } from '@solana/addresses';
 import {
+    amountNumberDisplayNode,
     definedTypeLinkNode,
     definedTypeNode,
+    injectedValueNode,
     instructionAccountDisplayNode,
     instructionAccountNode,
     instructionArgumentNode,
@@ -193,6 +195,30 @@ describe('listFallback', () => {
             { label: 'args.Price', value: '100' },
             { label: 'args.Size', value: '5' },
         ]);
+    });
+
+    test('it marks an amount whose scale cannot be resolved as raw', async () => {
+        // Given an amount whose injected decimals have no provider.
+        const instruction = instructionNode({
+            accounts: [],
+            arguments: [
+                instructionArgumentNode({
+                    name: 'amount',
+                    type: numberTypeNode('u64', 'le', {
+                        display: amountNumberDisplayNode({ decimals: injectedValueNode({ key: 'decimals' }) }),
+                    }),
+                }),
+            ],
+            name: 'transfer',
+        });
+
+        // When we build the fallback list.
+        const result = await listFallback(
+            displayContext({ parsedInstruction: parsedInstruction({ data: { amount: 1_000_000n }, instruction }) }),
+        );
+
+        // Then we expect the raw value explicitly marked, so it cannot read as a scaled amount.
+        expect(result).toEqual([{ label: 'Amount', value: '1000000 (raw)' }]);
     });
 
     test('it flattens a present option-wrapped struct argument', async () => {


### PR DESCRIPTION
An amount whose injected `decimals` fail to resolve previously fell back to an unmarked raw integer in both presentation modes — `Mint 1500000 USDC` for an actual 1.5 — indistinguishable from a resolved amount. `formatArgumentValue` now returns `{ text, degraded }`, where `degraded` is set exclusively by a present-but-unresolvable amount scale: the fallback list marks such values (`1500000 (raw)`), and `interpolateIntent` treats them as placeholder failure, suppressing the sentence in favour of the marked field list — prose implies confidence, tables can carry caveats. Amounts authored without `decimals` (unit-only, e.g. `base units`, `bytes`, `CUs`) and unpresentable date-times are deliberately not degraded.