### PR TITLE
Render remaining accounts in the fallback display

### DIFF
--- a/.changeset/bright-dryers-ring.md
+++ b/.changeset/bright-dryers-ring.md
@@ -1,0 +1,5 @@
+---
+'@codama/dynamic-parsers': minor
+---
+
+Capture trailing account metas on parsed instructions. `ParsedInstruction` gains an optional `remainingAccounts` attribute carrying the concrete metas beyond the instruction's named accounts (e.g. multisig signers), which `parseInstruction` now always populates.

--- a/.changeset/real-bugs-run.md
+++ b/.changeset/real-bugs-run.md
@@ -1,0 +1,5 @@
+---
+'@codama/dynamic-instructions': patch
+---
+
+Render remaining accounts in the fallback display. Trailing account metas now appear in the field list under their group's display label (or a label derived from the group's value name), numbered when a group holds several accounts, and honouring the group's `skip` strategy. When an instruction declares several remaining-accounts groups, each non-final group consumes the run of metas matching its `isSigner` flag and the final group takes the rest.

--- a/packages/dynamic-instructions/src/display/list-fallback.ts
+++ b/packages/dynamic-instructions/src/display/list-fallback.ts
@@ -1,3 +1,4 @@
+import { AccountRole } from '@solana/instructions';
 import {
     type DisplaySkip,
     getLastNodeFromPath,
@@ -16,7 +17,7 @@ import type { DisplayContext, DisplayField } from './types';
 
 /**
  * Builds the fallback display: a flat, ordered list of labelled fields for an instruction's
- * arguments and accounts.
+ * arguments, accounts, and remaining accounts.
  *
  * Honours each member's display metadata — `skip` (hidden when `'always'`, or when
  * `'whenInjected'` and the value was surfaced through the provide/inject graph), `label`
@@ -28,7 +29,7 @@ export async function listFallback(displayContext: DisplayContext): Promise<Disp
     const argumentFieldGroups = await Promise.all(
         (instruction.arguments ?? []).map(argument => argumentFields(argument, displayContext)),
     );
-    return [...argumentFieldGroups.flat(), ...accountFields(displayContext)];
+    return [...argumentFieldGroups.flat(), ...accountFields(displayContext), ...remainingAccountFields(displayContext)];
 }
 
 /** Produces the display fields for a single instruction argument (one field, or many when flattened). */
@@ -108,6 +109,47 @@ function accountFields(displayContext: DisplayContext): DisplayField[] {
         const label = account.display?.label ?? titleCase(account.name);
         return [{ label, value: address }];
     });
+}
+
+/**
+ * Produces the display fields for the instruction's remaining accounts.
+ *
+ * The instruction node describes remaining accounts as ordered groups
+ * (`instructionRemainingAccountsNode`); the parsed instruction carries the concrete trailing
+ * metas unsplit. Each non-final group consumes the run of metas whose signer role matches its
+ * `isSigner` flag; the final group takes everything left. Each group honours its display
+ * metadata (`label` override, `skip`) and numbers its entries when it holds more than one.
+ */
+function remainingAccountFields(displayContext: DisplayContext): DisplayField[] {
+    const instruction = getLastNodeFromPath(displayContext.parsedInstruction.path);
+    const groups = instruction.remainingAccounts ?? [];
+    const metas = displayContext.parsedInstruction.remainingAccounts ?? [];
+    if (groups.length === 0 || metas.length === 0) return [];
+
+    let cursor = 0;
+    return groups.flatMap((group, groupIndex) => {
+        const taken: string[] = [];
+        const isLastGroup = groupIndex === groups.length - 1;
+        while (cursor < metas.length && (isLastGroup || signerMatches(group.isSigner, metas[cursor].role))) {
+            taken.push(metas[cursor].address);
+            cursor += 1;
+        }
+
+        const name = isNode(group.value, 'argumentValueNode') ? group.value.name : undefined;
+        if (isSkipped(group.display?.skip, name ?? '', displayContext)) return [];
+        const label = group.display?.label ?? (name ? titleCase(name) : 'Remaining Accounts');
+        return taken.map((address, index) => ({
+            label: taken.length > 1 ? `${label} #${index + 1}` : label,
+            value: address,
+        }));
+    });
+}
+
+/** Whether an account meta's role satisfies a remaining-accounts group's `isSigner` flag. */
+function signerMatches(isSigner: boolean | 'either' | undefined, role: AccountRole): boolean {
+    if (isSigner === 'either') return true;
+    const signs = role === AccountRole.READONLY_SIGNER || role === AccountRole.WRITABLE_SIGNER;
+    return (isSigner ?? false) === signs;
 }
 
 /**

--- a/packages/dynamic-instructions/test/display/list-fallback.test.ts
+++ b/packages/dynamic-instructions/test/display/list-fallback.test.ts
@@ -1,6 +1,8 @@
 import type { Address } from '@solana/addresses';
+import { AccountRole } from '@solana/instructions';
 import {
     amountNumberDisplayNode,
+    argumentValueNode,
     definedTypeLinkNode,
     definedTypeNode,
     injectedValueNode,
@@ -8,6 +10,7 @@ import {
     instructionAccountNode,
     instructionArgumentNode,
     instructionNode,
+    instructionRemainingAccountsNode,
     numberTypeNode,
     optionTypeNode,
     structFieldDisplayNode,
@@ -20,6 +23,10 @@ import { listFallback } from '../../src/display/list-fallback';
 import { displayContext, mockResolveDefinedType, parsedInstruction } from '../test-utils';
 
 const AUTHORITY = '86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY' as Address;
+const SIGNER_A = '3Wnd5Df69KitZfUoPYZU438eFRNwGHkhLnSAWL65PxJX' as Address;
+const SIGNER_B = '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM' as Address;
+const SOURCE_A = 'Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS' as Address;
+const SOURCE_B = 'DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy' as Address;
 
 describe('listFallback', () => {
     test('it lists arguments and accounts with derived labels', async () => {
@@ -194,6 +201,135 @@ describe('listFallback', () => {
         expect(result).toEqual([
             { label: 'args.Price', value: '100' },
             { label: 'args.Size', value: '5' },
+        ]);
+    });
+
+    test('it renders remaining accounts under their group label', async () => {
+        // Given a memo-shaped instruction with a labelled signers group. The label is distinct
+        // from the derived `titleCase('signers')` form so this test cannot pass via derivation.
+        const instruction = instructionNode({
+            accounts: [],
+            arguments: [],
+            name: 'addMemo',
+            remainingAccounts: [
+                instructionRemainingAccountsNode(argumentValueNode('signers'), {
+                    display: instructionAccountDisplayNode({ label: 'Memo Signers' }),
+                    isOptional: true,
+                    isSigner: true,
+                }),
+            ],
+        });
+
+        // When we build the fallback list with two trailing signer metas.
+        const result = await listFallback(
+            displayContext({
+                parsedInstruction: parsedInstruction({
+                    instruction,
+                    remainingAccounts: [
+                        [SIGNER_A, AccountRole.READONLY_SIGNER],
+                        [SIGNER_B, AccountRole.READONLY_SIGNER],
+                    ],
+                }),
+            }),
+        );
+
+        // Then we expect one numbered field per trailing account.
+        expect(result).toEqual([
+            { label: 'Memo Signers #1', value: SIGNER_A },
+            { label: 'Memo Signers #2', value: SIGNER_B },
+        ]);
+    });
+
+    test('it derives the remaining accounts label from the group value name', async () => {
+        // Given a remaining-accounts group with no display label.
+        const instruction = instructionNode({
+            accounts: [],
+            arguments: [],
+            name: 'transfer',
+            remainingAccounts: [
+                instructionRemainingAccountsNode(argumentValueNode('multiSigners'), { isSigner: true }),
+            ],
+        });
+
+        // When we build the fallback list with one trailing meta.
+        const result = await listFallback(
+            displayContext({
+                parsedInstruction: parsedInstruction({
+                    instruction,
+                    remainingAccounts: [[SIGNER_A, AccountRole.READONLY_SIGNER]],
+                }),
+            }),
+        );
+
+        // Then we expect the title-cased value name as label, unnumbered for a single account.
+        expect(result).toEqual([{ label: 'Multi Signers', value: SIGNER_A }]);
+    });
+
+    test('it hides remaining accounts whose group is skipped', async () => {
+        // Given a remaining-accounts group marked skip always.
+        const instruction = instructionNode({
+            accounts: [],
+            arguments: [],
+            name: 'transfer',
+            remainingAccounts: [
+                instructionRemainingAccountsNode(argumentValueNode('multiSigners'), {
+                    display: instructionAccountDisplayNode({ skip: 'always' }),
+                    isSigner: true,
+                }),
+            ],
+        });
+
+        // When we build the fallback list with a trailing meta.
+        const result = await listFallback(
+            displayContext({
+                parsedInstruction: parsedInstruction({
+                    instruction,
+                    remainingAccounts: [[SIGNER_A, AccountRole.READONLY_SIGNER]],
+                }),
+            }),
+        );
+
+        // Then we expect no fields.
+        expect(result).toEqual([]);
+    });
+
+    test('it partitions trailing metas between groups by signer role', async () => {
+        // Given two remaining-accounts groups: signers first, then non-signing sources.
+        const instruction = instructionNode({
+            accounts: [],
+            arguments: [],
+            name: 'withdrawWithheldTokensFromAccounts',
+            remainingAccounts: [
+                instructionRemainingAccountsNode(argumentValueNode('multiSigners'), {
+                    display: instructionAccountDisplayNode({ label: 'Multisig Signers' }),
+                    isSigner: true,
+                }),
+                instructionRemainingAccountsNode(argumentValueNode('sources'), {
+                    display: instructionAccountDisplayNode({ label: 'Source Accounts' }),
+                    isSigner: false,
+                }),
+            ],
+        });
+
+        // When we build the fallback list with one signer then two non-signer metas.
+        const result = await listFallback(
+            displayContext({
+                parsedInstruction: parsedInstruction({
+                    instruction,
+                    remainingAccounts: [
+                        [SIGNER_A, AccountRole.READONLY_SIGNER],
+                        [SOURCE_A, AccountRole.WRITABLE],
+                        [SOURCE_B, AccountRole.WRITABLE],
+                    ],
+                }),
+            }),
+        );
+
+        // Then we expect the signer run under the first group and the rest under the final group.
+        expect(result).toEqual([
+            { label: 'Multisig Signers', value: SIGNER_A },
+            { label: 'Source Accounts #1', value: SOURCE_A },
+            { label: 'Source Accounts #2', value: SOURCE_B },
         ]);
     });
 

--- a/packages/dynamic-instructions/test/test-utils.ts
+++ b/packages/dynamic-instructions/test/test-utils.ts
@@ -97,6 +97,7 @@ export function parsedInstruction(
         accounts?: ReadonlyArray<readonly [name: string, address: Address]>;
         data?: Record<string, unknown>;
         instruction?: InstructionNode;
+        remainingAccounts?: ReadonlyArray<readonly [address: Address, role: AccountRole]>;
     } = {},
 ): ParsedInstruction {
     const instruction = overrides.instruction ?? DEFAULT_INSTRUCTION;
@@ -109,6 +110,7 @@ export function parsedInstruction(
         })),
         data: overrides.data ?? {},
         path: [root, root.program, instruction] as NodePath<InstructionNode>,
+        remainingAccounts: (overrides.remainingAccounts ?? []).map(([address, role]) => ({ address, role })),
     };
 }
 

--- a/packages/dynamic-parsers/src/parsers.ts
+++ b/packages/dynamic-parsers/src/parsers.ts
@@ -68,8 +68,16 @@ export type ParsedInstructionAccounts = ReadonlyArray<AccountMeta & { name: Came
 
 /**
  * A parsed instruction: its decoded data and node path, plus its resolved {@link ParsedInstructionAccounts}.
+ *
+ * `remainingAccounts` carries the concrete account metas beyond the instruction's named
+ * accounts — the ones described by the instruction node's `remainingAccounts` groups (e.g.
+ * multisig signers). Optional so hand-built values remain valid; `parseInstruction` always
+ * sets it.
  */
-export type ParsedInstruction = ParsedData<InstructionNode> & { accounts: ParsedInstructionAccounts };
+export type ParsedInstruction = ParsedData<InstructionNode> & {
+    accounts: ParsedInstructionAccounts;
+    remainingAccounts?: readonly (AccountLookupMeta | AccountMeta)[];
+};
 
 export function parseInstruction(
     root: RootNode,
@@ -80,10 +88,12 @@ export function parseInstruction(
     const parsedData = parseInstructionData(root, instruction.data, { programAddress: instruction.programAddress });
     if (!parsedData) return undefined;
     const instructionNode = getLastNodeFromPath(parsedData.path);
-    const accounts: ParsedInstructionAccounts = (instructionNode.accounts ?? []).flatMap((account, index) => {
+    const namedAccounts = instructionNode.accounts ?? [];
+    const accounts: ParsedInstructionAccounts = namedAccounts.flatMap((account, index) => {
         const accountMeta = instruction.accounts[index];
         if (!accountMeta) return [];
         return [{ ...accountMeta, name: account.name }];
     });
-    return { ...parsedData, accounts };
+    const remainingAccounts = instruction.accounts.slice(namedAccounts.length);
+    return { ...parsedData, accounts, remainingAccounts };
 }

--- a/packages/dynamic-parsers/test/parsers.test.ts
+++ b/packages/dynamic-parsers/test/parsers.test.ts
@@ -1,5 +1,6 @@
 import {
     accountNode,
+    argumentValueNode,
     bytesTypeNode,
     constantDiscriminatorNode,
     constantValueNode,
@@ -11,6 +12,7 @@ import {
     instructionAccountNode,
     instructionArgumentNode,
     instructionNode,
+    instructionRemainingAccountsNode,
     numberTypeNode,
     numberValueNode,
     programNode,
@@ -348,7 +350,38 @@ describe('parseInstruction', () => {
             accounts: [{ address: '1111', name: 'signer', role: AccountRole.READONLY_SIGNER }],
             data: { message: 'Hello' },
             path: [root, root.program, memoInstruction],
+            remainingAccounts: [],
         });
+    });
+
+    test('it captures account metas beyond the named accounts as remaining accounts', () => {
+        // Given an instruction with one named account and a remaining-accounts group.
+        const instruction = instructionNode({
+            accounts: [instructionAccountNode({ isSigner: false, isWritable: true, name: 'source' })],
+            arguments: [instructionArgumentNode({ name: 'amount', type: numberTypeNode('u8') })],
+            name: 'transfer',
+            remainingAccounts: [
+                instructionRemainingAccountsNode(argumentValueNode('multiSigners'), { isSigner: true }),
+            ],
+        });
+        const root = rootNode(programNode({ instructions: [instruction], name: 'myProgram', publicKey: '1111' }));
+
+        // When we parse a concrete instruction carrying two metas beyond the named account.
+        const result = parseInstruction(root, {
+            accounts: [
+                { address: 'source11', role: AccountRole.WRITABLE },
+                { address: 'signerA1', role: AccountRole.READONLY_SIGNER },
+                { address: 'signerB1', role: AccountRole.READONLY_SIGNER },
+            ],
+            data: hex('2a'),
+            programAddress: '1111',
+        } as unknown as Parameters<typeof parseInstruction>[1]);
+
+        // Then we expect the trailing metas captured as remaining accounts.
+        expect(result?.remainingAccounts).toStrictEqual([
+            { address: 'signerA1', role: AccountRole.READONLY_SIGNER },
+            { address: 'signerB1', role: AccountRole.READONLY_SIGNER },
+        ]);
     });
 
     test('it parses an instruction from an additional program using the program address', () => {
@@ -411,6 +444,7 @@ describe('parseInstruction', () => {
             ],
             data: { discriminator: 1 },
             path: [root, additionalProgram, additionalInstruction],
+            remainingAccounts: [],
         });
     });
     test('it does not parse an instruction whose program is not part of the root', () => {


### PR DESCRIPTION
The fallback list only rendered named arguments and accounts; `instructionRemainingAccountsNode.display` was defined by the schema but never consulted, and `parseInstruction` dropped trailing metas entirely. `ParsedInstruction` now carries the trailing metas (optional attribute, always populated by `parseInstruction`), and `listFallback` renders them after the named accounts: one field per account under the group's label (`display.label`, else the title-cased value name), numbered when a group holds more than one, honouring `skip`. Multiple groups (e.g. token-2022's `multiSigners` + `sources`) are partitioned by matching each non-final group's `isSigner` flag against the metas' roles in order, with the final group taking the remainder — the split is not otherwise recoverable from the bytes.