### PR TITLE
Render array values properly in instruction displays

### DIFF
--- a/.changeset/giant-lies-argue.md
+++ b/.changeset/giant-lies-argue.md
@@ -1,0 +1,5 @@
+---
+'@codama/dynamic-instructions': patch
+---
+
+Render array values properly in instruction displays. Address arrays expand into one field per element in the fallback list (`New Addresses #1`, `New Addresses #2`, …), matching how named and remaining accounts each get their own individually-verifiable line. All other arrays render as a single comma-joined field whose elements go through their item type's presentation (`1.5 SOL, 0.5 SOL` instead of a JSON blob), with degraded amount elements marked inline and flagging the whole array. The ` (raw)` marker for unresolved amount scales now lives in the formatted text itself.

--- a/packages/dynamic-instructions/src/display/format-argument-value.ts
+++ b/packages/dynamic-instructions/src/display/format-argument-value.ts
@@ -10,10 +10,11 @@ import type { DisplayContext } from './types';
  * A formatted value paired with whether its presentation degraded.
  *
  * `degraded` is `true` only when an `amountNumberDisplayNode` was present but its scale could
- * not be resolved: the raw integer then reads exactly like a scaled amount, so callers must
- * either mark it (fallback list) or refuse to present it as prose (interpolated intents).
- * Other unpresented values — missing display metadata, invalid date-times — are not degraded:
- * their raw forms carry no false confidence.
+ * not be resolved: the raw integer then reads exactly like a scaled amount. Degraded values
+ * carry an explicit ` (raw)` marker in their `text` (applied per element inside arrays), and
+ * interpolated intents refuse to present them as prose. Other unpresented values — missing
+ * display metadata, invalid date-times — are not degraded: their raw forms carry no false
+ * confidence.
  */
 export type FormattedArgumentValue = {
     degraded: boolean;
@@ -46,11 +47,25 @@ export async function formatArgumentValue(
 
     const resolved = resolveDisplayType(type, ownerPath, displayContext);
 
+    // Arrays render compactly through their item type — one comma-joined line whose elements
+    // each carry their own presentation (and their own ` (raw)` marker when degraded). The
+    // fallback list expands address arrays into per-element fields before reaching here.
+    if (isNode(resolved.type, 'arrayTypeNode') && Array.isArray(innerValue)) {
+        const itemType = resolved.type.item;
+        const elements = await Promise.all(
+            innerValue.map(element => formatArgumentValue(itemType, resolved.ownerPath, element, displayContext)),
+        );
+        return {
+            degraded: elements.some(element => element.degraded),
+            text: elements.map(element => element.text).join(', '),
+        };
+    }
+
     if (isNode(resolved.type, 'numberTypeNode') && resolved.type.display && isNumeric(innerValue)) {
         const formatted = await formatNumber(resolved.type.display, innerValue, displayContext);
         if (formatted !== null) return { degraded: false, text: formatted };
         if (resolved.type.display.kind === 'amountNumberDisplayNode') {
-            return { degraded: true, text: rawValue(innerValue) };
+            return { degraded: true, text: `${rawValue(innerValue)} (raw)` };
         }
     }
 

--- a/packages/dynamic-instructions/src/display/list-fallback.ts
+++ b/packages/dynamic-instructions/src/display/list-fallback.ts
@@ -7,10 +7,11 @@ import {
     type NodePath,
     type StructTypeNode,
     titleCase,
+    type TypeNode,
 } from 'codama';
 
 import { isObjectRecord } from '../shared/util';
-import { formatArgumentValue, type FormattedArgumentValue } from './format-argument-value';
+import { formatArgumentValue } from './format-argument-value';
 import { unwrapOptionValue } from './option-value';
 import { resolveDisplayType } from './resolve-display-type';
 import type { DisplayContext, DisplayField } from './types';
@@ -62,8 +63,7 @@ async function argumentFields(
     }
 
     const label = argument.display?.label ?? titleCase(argument.name);
-    const formatted = await formatArgumentValue(argument.type, ownerPath, value, displayContext);
-    return [{ label, value: markIfDegraded(formatted) }];
+    return await memberFields(label, argument.type, ownerPath, value, displayContext);
 }
 
 /** Lifts a struct's fields into the parent list, prefixing each label and reading nested values. */
@@ -77,26 +77,48 @@ async function flattenedFields(
     const visibleFields = (struct.fields ?? []).filter(
         field => !isSkipped(field.display?.skip, field.name, displayContext),
     );
-    return await Promise.all(
+    const fieldGroups = await Promise.all(
         visibleFields.map(async field => {
             const label = `${prefix ?? ''}${field.display?.label ?? titleCase(field.name)}`;
-            const formatted = await formatArgumentValue(
-                field.type,
-                [...structPath, field],
-                value[field.name],
-                displayContext,
-            );
-            return { label, value: markIfDegraded(formatted) };
+            return await memberFields(label, field.type, [...structPath, field], value[field.name], displayContext);
         }),
     );
+    return fieldGroups.flat();
 }
 
 /**
- * Renders a formatted value, marking amounts whose scale failed to resolve so a raw integer
- * cannot be mistaken for a scaled amount (see `FormattedArgumentValue`).
+ * Produces the display fields for one labelled member.
+ *
+ * Address arrays expand into one field per element — addresses are individually verified on
+ * signing screens, matching how named and remaining accounts each get their own field — with
+ * `#n`-numbered labels when there are several. Everything else renders as a single field
+ * through {@link formatArgumentValue} (which renders non-address arrays compactly and marks
+ * degraded amounts).
  */
-function markIfDegraded(formatted: FormattedArgumentValue): string {
-    return formatted.degraded ? `${formatted.text} (raw)` : formatted.text;
+async function memberFields(
+    label: string,
+    type: TypeNode,
+    ownerPath: NodePath,
+    value: unknown,
+    displayContext: DisplayContext,
+): Promise<DisplayField[]> {
+    const resolved = resolveDisplayType(type, ownerPath, displayContext);
+    const unwrapped = unwrapOptionValue(value);
+    if (!unwrapped.none && isNode(resolved.type, 'arrayTypeNode') && Array.isArray(unwrapped.value)) {
+        const itemType = resolved.type.item;
+        const item = resolveDisplayType(itemType, resolved.ownerPath, displayContext);
+        if (isNode(item.type, 'publicKeyTypeNode')) {
+            const elements = unwrapped.value;
+            return await Promise.all(
+                elements.map(async (element, index) => ({
+                    label: elements.length > 1 ? `${label} #${index + 1}` : label,
+                    value: (await formatArgumentValue(itemType, resolved.ownerPath, element, displayContext)).text,
+                })),
+            );
+        }
+    }
+    const formatted = await formatArgumentValue(type, ownerPath, value, displayContext);
+    return [{ label, value: formatted.text }];
 }
 
 /** Produces the display fields for the instruction's accounts. */

--- a/packages/dynamic-instructions/test/display/format-argument-value.test.ts
+++ b/packages/dynamic-instructions/test/display/format-argument-value.test.ts
@@ -1,5 +1,6 @@
 import {
     amountNumberDisplayNode,
+    arrayTypeNode,
     dateTimeNumberDisplayNode,
     definedTypeLinkNode,
     type DefinedTypeNode,
@@ -13,6 +14,7 @@ import {
     numberTypeNode,
     numberValueNode,
     optionTypeNode,
+    remainderCountNode,
     stringDisplayNode,
     stringTypeNode,
     stringValueNode,
@@ -81,8 +83,9 @@ describe('formatArgumentValue', () => {
         // When we format the amount.
         const result = await formatArgumentValue(type, [], 1_000_000n, displayContext());
 
-        // Then we expect the raw value, flagged as degraded: it reads exactly like a scaled amount.
-        expect(result).toEqual({ degraded: true, text: '1000000' });
+        // Then we expect the raw value explicitly marked and flagged as degraded: unmarked, it
+        // would read exactly like a scaled amount.
+        expect(result).toEqual({ degraded: true, text: '1000000 (raw)' });
     });
 
     test('it does not flag an amount with absent decimals as degraded', async () => {
@@ -299,6 +302,38 @@ describe('formatArgumentValue', () => {
         // Then we expect both to match the variant.
         expect(rawCased.text).toBe('Symbol');
         expect(pascalCased.text).toBe('Symbol');
+    });
+
+    test('it renders arrays compactly through their item display', async () => {
+        // Given an array of amounts scaled to 9 decimals.
+        const type = arrayTypeNode(
+            numberTypeNode('u64', 'le', {
+                display: amountNumberDisplayNode({ decimals: numberValueNode(9), unit: stringValueNode('SOL') }),
+            }),
+            remainderCountNode(),
+        );
+
+        // When we format an array value.
+        const result = await formatArgumentValue(type, [], [1_500_000_000n, 500_000_000n], displayContext());
+
+        // Then we expect a comma-joined line with each element presented.
+        expect(result).toEqual({ degraded: false, text: '1.5 SOL, 0.5 SOL' });
+    });
+
+    test('it marks degraded array elements inline and flags the array', async () => {
+        // Given an array of amounts whose injected decimals have no provider.
+        const type = arrayTypeNode(
+            numberTypeNode('u64', 'le', {
+                display: amountNumberDisplayNode({ decimals: injectedValueNode({ key: 'decimals' }) }),
+            }),
+            remainderCountNode(),
+        );
+
+        // When we format an array value.
+        const result = await formatArgumentValue(type, [], [1_000_000n, 500_000n], displayContext());
+
+        // Then we expect each element marked raw and the whole array flagged as degraded.
+        expect(result).toEqual({ degraded: true, text: '1000000 (raw), 500000 (raw)' });
     });
 
     test('it unwraps nested option values', async () => {

--- a/packages/dynamic-instructions/test/display/list-fallback.test.ts
+++ b/packages/dynamic-instructions/test/display/list-fallback.test.ts
@@ -3,6 +3,7 @@ import { AccountRole } from '@solana/instructions';
 import {
     amountNumberDisplayNode,
     argumentValueNode,
+    arrayTypeNode,
     definedTypeLinkNode,
     definedTypeNode,
     injectedValueNode,
@@ -13,6 +14,8 @@ import {
     instructionRemainingAccountsNode,
     numberTypeNode,
     optionTypeNode,
+    publicKeyTypeNode,
+    remainderCountNode,
     structFieldDisplayNode,
     structFieldTypeNode,
     structTypeNode,
@@ -331,6 +334,82 @@ describe('listFallback', () => {
             { label: 'Source Accounts #1', value: SOURCE_A },
             { label: 'Source Accounts #2', value: SOURCE_B },
         ]);
+    });
+
+    test('it expands an address array into one field per element', async () => {
+        // Given a lookup-table-shaped instruction with an address-array argument.
+        const instruction = instructionNode({
+            accounts: [],
+            arguments: [
+                instructionArgumentNode({
+                    display: structFieldDisplayNode({ label: 'New Addresses' }),
+                    name: 'addresses',
+                    type: arrayTypeNode(publicKeyTypeNode(), remainderCountNode()),
+                }),
+            ],
+            name: 'extendLookupTable',
+        });
+
+        // When we build the fallback list with two addresses.
+        const result = await listFallback(
+            displayContext({
+                parsedInstruction: parsedInstruction({ data: { addresses: [SIGNER_A, SIGNER_B] }, instruction }),
+            }),
+        );
+
+        // Then we expect one numbered field per address, matching how accounts are rendered.
+        expect(result).toEqual([
+            { label: 'New Addresses #1', value: SIGNER_A },
+            { label: 'New Addresses #2', value: SIGNER_B },
+        ]);
+    });
+
+    test('it keeps a single-element address array unnumbered', async () => {
+        // Given an address-array argument holding one address.
+        const instruction = instructionNode({
+            accounts: [],
+            arguments: [
+                instructionArgumentNode({
+                    name: 'addresses',
+                    type: arrayTypeNode(publicKeyTypeNode(), remainderCountNode()),
+                }),
+            ],
+            name: 'extendLookupTable',
+        });
+
+        // When we build the fallback list.
+        const result = await listFallback(
+            displayContext({
+                parsedInstruction: parsedInstruction({ data: { addresses: [SIGNER_A] }, instruction }),
+            }),
+        );
+
+        // Then we expect a single unnumbered field.
+        expect(result).toEqual([{ label: 'Addresses', value: SIGNER_A }]);
+    });
+
+    test('it renders non-address arrays as one compact field', async () => {
+        // Given a numeric array argument.
+        const instruction = instructionNode({
+            accounts: [],
+            arguments: [
+                instructionArgumentNode({
+                    name: 'values',
+                    type: arrayTypeNode(numberTypeNode('u8'), remainderCountNode()),
+                }),
+            ],
+            name: 'setValues',
+        });
+
+        // When we build the fallback list.
+        const result = await listFallback(
+            displayContext({
+                parsedInstruction: parsedInstruction({ data: { values: [1, 2, 3] }, instruction }),
+            }),
+        );
+
+        // Then we expect a single comma-joined field, not one line per number.
+        expect(result).toEqual([{ label: 'Values', value: '1, 2, 3' }]);
     });
 
     test('it marks an amount whose scale cannot be resolved as raw', async () => {


### PR DESCRIPTION
Array-valued arguments previously fell through to `JSON.stringify` — `[\"CiDw…\",\"CiDw…\"]` — unreadable and unverifiable on a signing screen. Arrays now render through their item type: address arrays expand into numbered per-element fields in the fallback list (the `#n` convention shared with remaining accounts; unnumbered when single), and every other array renders as one comma-joined field whose elements carry their own presentation, including inline `(raw)` markers for degraded amounts, which flag the whole array so sentences referencing it are suppressed. Moving the degraded marker into `formatArgumentValue`'s text simplifies the fallback list and keeps element-level marking consistent. Arrays of structs/tuples keep their raw per-element form inside the join, and bytes rendering is left for a follow-up.