### PR TITLE
Return undefined when identified data cannot be decoded

### DIFF
--- a/.changeset/cozy-feet-wait.md
+++ b/.changeset/cozy-feet-wait.md
@@ -1,0 +1,5 @@
+---
+'@codama/dynamic-parsers': patch
+---
+
+Return `undefined` instead of throwing when identified data cannot be decoded. A discriminator can match while the full data does not conform (e.g. truncated or corrupt bytes); the `parse*` functions now treat that as "not parsable", mirroring the `undefined` returned when nothing is identified.

--- a/packages/dynamic-parsers/src/identify.ts
+++ b/packages/dynamic-parsers/src/identify.ts
@@ -5,6 +5,7 @@ import {
     getAllPrograms,
     GetNodeFromKind,
     InstructionNode,
+    isNode,
     isNodeFilter,
     ProgramNode,
     resolveNestedTypeNode,
@@ -107,30 +108,22 @@ export function getByteIdentificationVisitor<TKind extends IdentifiableNodeKind>
     const stack = options.stack ?? new NodeStack();
     const programAddress = options.programAddress;
 
+    // Accounts, events, and instructions identify identically: match the bytes against the
+    // candidate's discriminators over its data struct (arguments, for instructions).
+    const identifyCandidate = (node: AccountNode | EventNode | InstructionNode) => {
+        if (!node.discriminators) return undefined;
+        const struct = isNode(node, 'instructionNode')
+            ? structTypeNodeFromInstructionArgumentNodes(node.arguments ?? [])
+            : resolveNestedTypeNode(node.data);
+        const match = matchDiscriminators(bytes, node.discriminators, struct, codecAndValueVisitors);
+        return match ? stack.getPath(node.kind) : undefined;
+    };
+
     return pipe(
         {
-            visitAccount(node) {
-                if (!node.discriminators) return;
-                const struct = resolveNestedTypeNode(node.data);
-                const match = matchDiscriminators(bytes, node.discriminators, struct, codecAndValueVisitors);
-                return match ? stack.getPath(node.kind) : undefined;
-            },
-            visitEvent(node) {
-                if (!node.discriminators) return;
-                const match = matchDiscriminators(
-                    bytes,
-                    node.discriminators,
-                    resolveNestedTypeNode(node.data),
-                    codecAndValueVisitors,
-                );
-                return match ? stack.getPath(node.kind) : undefined;
-            },
-            visitInstruction(node) {
-                if (!node.discriminators) return;
-                const struct = structTypeNodeFromInstructionArgumentNodes(node.arguments ?? []);
-                const match = matchDiscriminators(bytes, node.discriminators, struct, codecAndValueVisitors);
-                return match ? stack.getPath(node.kind) : undefined;
-            },
+            visitAccount: identifyCandidate,
+            visitEvent: identifyCandidate,
+            visitInstruction: identifyCandidate,
             visitProgram(node) {
                 for (const candidate of getNodeCandidates(node, kind)) {
                     const result = visit(candidate, this);

--- a/packages/dynamic-parsers/src/parsers.ts
+++ b/packages/dynamic-parsers/src/parsers.ts
@@ -57,8 +57,14 @@ export function parseData<TKind extends ParsableNodeKind>(
     );
     if (!path) return undefined;
     const codec = getNodeCodec(path as NodePath<ParsableNode>);
-    const data = codec.decode(bytes);
-    return { data, path };
+    try {
+        return { data: codec.decode(bytes), path };
+    } catch {
+        // A discriminator can match while the full data does not conform (e.g. truncated or
+        // corrupt bytes). Parsing is total: data that cannot be decoded is not parsable,
+        // mirroring the `undefined` returned when nothing is identified.
+        return undefined;
+    }
 }
 
 /**

--- a/packages/dynamic-parsers/test/parsers.test.ts
+++ b/packages/dynamic-parsers/test/parsers.test.ts
@@ -447,6 +447,35 @@ describe('parseInstruction', () => {
             remainingAccounts: [],
         });
     });
+    test('it returns undefined when the identified data cannot be decoded', () => {
+        // Given an instruction whose discriminator matches one-byte data but whose full
+        // arguments require more bytes than provided.
+        const instruction = instructionNode({
+            arguments: [
+                instructionArgumentNode({
+                    defaultValue: numberValueNode(1),
+                    defaultValueStrategy: 'omitted',
+                    name: 'discriminator',
+                    type: numberTypeNode('u8'),
+                }),
+                instructionArgumentNode({ name: 'amount', type: numberTypeNode('u64') }),
+            ],
+            discriminators: [fieldDiscriminatorNode('discriminator')],
+            name: 'myInstruction',
+        });
+        const root = rootNode(programNode({ instructions: [instruction], name: 'myProgram', publicKey: '1111' }));
+
+        // When we parse truncated data: the discriminator matches but `amount` cannot decode.
+        const result = parseInstruction(root, {
+            accounts: [],
+            data: hex('01'),
+            programAddress: '1111',
+        } as unknown as Parameters<typeof parseInstruction>[1]);
+
+        // Then we expect undefined rather than a decode error: parsing is total.
+        expect(result).toBeUndefined();
+    });
+
     test('it does not parse an instruction whose program is not part of the root', () => {
         const root = rootNode(
             programNode({


### PR DESCRIPTION
`parseData` let `codec.decode` throw after a successful identification, so a discriminator match over truncated or corrupt bytes crashed the caller instead of reporting "not parsable" — the documented contract for everything else in this package. Decode failure now returns `undefined`, making the parsing layer total. Also merges the three near-identical identification visitor methods (`visitAccount`/`visitEvent`/`visitInstruction`) into a single candidate matcher, since they only differed in how the discriminated struct is derived.