### PR TITLE
Group Solana Kit and program dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,17 @@ updates:
       time: '01:00'
       timezone: America/Los_Angeles
     open-pull-requests-limit: 10
+    groups:
+      # Solana Kit packages (published from anza-xyz/kit) move in lockstep,
+      # so bump them together. Non-Kit @solana/* packages (e.g. the eslint
+      # and prettier configs) are deliberately not listed here.
+      solana-kit:
+        patterns:
+          - '@solana/accounts'
+          - '@solana/addresses'
+          - '@solana/codecs*'
+          - '@solana/instructions'
+          - '@solana/kit'
+      solana-program:
+        patterns:
+          - '@solana-program/*'


### PR DESCRIPTION
This PR adds two dependabot groups so related Solana dependencies are bumped in single PRs instead of one PR per package. The `solana-kit` group lists the Kit packages we depend on explicitly (`@solana/kit`, `@solana/accounts`, `@solana/addresses`, `@solana/codecs*`, `@solana/instructions`) rather than using an `@solana/*` wildcard, since that scope also contains non-Kit packages such as `@solana/eslint-config-solana` and `@solana/prettier-config-solana` which should keep updating independently. The `solana-program` group covers `@solana-program/*` (`token`, `token-2022`, `program-metadata`), which typically move in lockstep after Kit releases.