### PR TITLE
Run CI on Node 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   # Among other things, opts out of Turborepo telemetry. See https://consoledonottrack.com/.
   DO_NOT_TRACK: '1'
-  NODE_VERSION: 20
+  NODE_VERSION: 24
   CODAMA_VERSION: 1.x
 
 jobs:


### PR DESCRIPTION
This PR fixes the failing Release job on main. Dependabot bumped `@changesets/cli` to v3 (#1070), whose CLI calls `module.enableCompileCache()` at startup and requires Node >= 22.11, while the workflow still pinned Node 20 - so the changesets step crashed with `TypeError: enableCompileCache is not a function` before it could open a Release PR or publish. Bumping `NODE_VERSION` to 24 (matching the codama-idl/spec repo; Node 20 is deprecated on GitHub runners) unblocks the release flow. The root `engines` field (>= 20.18.0) is unaffected and the changesets v3 CLI was verified locally under Node 24.