### PR TITLE
Add writeIdlVisitor to @codama/renderers-core

### DIFF
--- a/.changeset/clean-queens-call.md
+++ b/.changeset/clean-queens-call.md
@@ -1,0 +1,16 @@
+---
+'@codama/renderers-core': minor
+---
+
+Add a `writeIdlVisitor` that writes the visited `RootNode` to a JSON file at the given path. Use it as a Codama CLI script to write the IDL back to a file after all `before` visitors have been applied.
+
+```ts
+// codama.mjs
+export default {
+    idl: 'interface-idl.json',
+    before: [...],
+    scripts: {
+        idl: { from: '@codama/renderers-core#writeIdlVisitor', args: ['idl.json'] },
+    },
+};
+```

--- a/packages/renderers-core/src/index.ts
+++ b/packages/renderers-core/src/index.ts
@@ -5,10 +5,11 @@
  * fragment primitives, casing helpers, path / filesystem helpers, and
  * the `RenderMap` data operations all live there so they can be shared
  * with code generators and other consumers outside the renderers
- * stack. This package layers the renderer-specific
- * {@link writeRenderMapVisitor} on top — the one piece that pulls in
- * the visitor + node infrastructure.
+ * stack. This package layers the renderer-specific visitors on top —
+ * {@link writeRenderMapVisitor} and {@link writeIdlVisitor} — the
+ * pieces that pull in the visitor + node infrastructure.
  */
 
 export * from '@codama/fragments';
 export * from './renderMap';
+export * from './writeIdlVisitor';

--- a/packages/renderers-core/src/writeIdlVisitor.ts
+++ b/packages/renderers-core/src/writeIdlVisitor.ts
@@ -1,0 +1,30 @@
+import { writeFile } from '@codama/fragments';
+import { rootNodeVisitor } from '@codama/visitors-core';
+
+/**
+ * Writes the visited `RootNode` to a JSON file at the given path,
+ * creating intermediate directories as needed.
+ *
+ * This is typically used as a Codama CLI script to write the IDL back
+ * to a file after all `before` visitors have been applied — e.g. to
+ * publish an IDL whose render-time transformations are resolved.
+ *
+ * ```ts
+ * // codama.mjs
+ * export default {
+ *     idl: 'interface-idl.json',
+ *     before: [...],
+ *     scripts: {
+ *         idl: { from: '@codama/renderers-core#writeIdlVisitor', args: ['idl.json'] },
+ *     },
+ * };
+ * ```
+ *
+ * Node-only: throws a structured `CodamaError` on non-Node platforms
+ * so accidental calls from a browser bundle fail loudly.
+ */
+export function writeIdlVisitor(path: string) {
+    return rootNodeVisitor(root => {
+        writeFile(path, JSON.stringify(root, null, 2));
+    });
+}

--- a/packages/renderers-core/test/index.test.ts
+++ b/packages/renderers-core/test/index.test.ts
@@ -1,15 +1,20 @@
 import { expect, test } from 'vitest';
 
-import { writeRenderMapVisitor } from '../src';
+import { writeIdlVisitor, writeRenderMapVisitor } from '../src';
 
 /**
  * `@codama/renderers-core` is now a thin layer over `@codama/fragments`
- * — every name except {@link writeRenderMapVisitor} is forwarded
- * straight through via `export *`. The fragments-side tests cover the
- * underlying primitives; this single assertion is the smoke check
- * that the renderer-specific addition is reachable through the
- * package entry point.
+ * — every name except {@link writeRenderMapVisitor} and
+ * {@link writeIdlVisitor} is forwarded straight through via
+ * `export *`. The fragments-side tests cover the underlying
+ * primitives; these assertions are the smoke check that the
+ * renderer-specific additions are reachable through the package entry
+ * point.
  */
 test('it exports writeRenderMapVisitor as a function', () => {
     expect(typeof writeRenderMapVisitor).toBe('function');
+});
+
+test('it exports writeIdlVisitor as a function', () => {
+    expect(typeof writeIdlVisitor).toBe('function');
 });

--- a/packages/renderers-core/test/writeIdlVisitor.test.ts
+++ b/packages/renderers-core/test/writeIdlVisitor.test.ts
@@ -1,0 +1,25 @@
+import { programNode, rootNode } from '@codama/nodes';
+import { visit } from '@codama/visitors-core';
+import { expect, test } from 'vitest';
+
+import { writeIdlVisitor } from '../src';
+
+// The non-Node fail-loud behaviour is covered by the `@codama/fragments`
+// filesystem tests, which own the underlying `writeFile` guard.
+test.runIf(__NODEJS__)('it writes the visited root node as JSON to the given path', async () => {
+    const { mkdtempSync, readFileSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+
+    // Given a root node and a path inside a directory that does not exist yet.
+    const node = rootNode(programNode({ name: 'myProgram', publicKey: '1111' }));
+    const directory = mkdtempSync(join(tmpdir(), 'writeIdlVisitor-'));
+    const path = join(directory, 'nested', 'idl.json');
+
+    // When we visit the root node using the writeIdlVisitor.
+    visit(node, writeIdlVisitor(path));
+
+    // Then the file contains the pretty-printed root node.
+    expect(readFileSync(path, 'utf-8')).toBe(JSON.stringify(node, null, 2));
+    rmSync(directory, { recursive: true });
+});


### PR DESCRIPTION
This PR adds a `writeIdlVisitor(path)` visitor to `@codama/renderers-core` that writes the visited `RootNode` as pretty-printed JSON to the given path, creating intermediate directories as needed.

Used as a Codama CLI script, it enables an "IDL loopback": the CLI applies the config's `before` visitors and the script writes the resulting IDL back to a file — e.g. publishing a consumer-facing `idl.json` whose render-time transformations are resolved, while the raw macro-generated IDL remains the config input:

```ts
// codama.mjs
export default {
    idl: 'interface-idl.json',
    before: [...],
    scripts: {
        idl: { from: '@codama/renderers-core#writeIdlVisitor', args: ['idl.json'] },
    },
};
```

## Design note

It lives in `renderers-core` alongside `writeRenderMapVisitor` — rather than `visitors-core` — so filesystem access stays in the fragments-backed output layer: `visitors-core` is bundled into the `codama` library's iife build, where `node:fs` imports cannot resolve, whereas the renderers stack already owns the `__NODEJS__`-guarded fail-loud `writeFile`.

## Verification

- Functional test (node): writes into a not-yet-existing nested directory and asserts exact pretty-printed content; skipped on browser/react-native where the fail-loud guard is covered by the `@codama/fragments` filesystem tests.
- Types, unit tests (all platforms), treeshakability and builds green for `renderers-core` and the `codama` library (including the iife bundle); repo lint clean.
- Manually verified end-to-end with the real CLI: `codama run idl` against a scratch config writes the post-`before`-visitor tree, leaving the input IDL untouched.