### PR TITLE
Read the release App Client ID from secrets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout


### PR DESCRIPTION
This PR fixes the release workflow's GitHub App authentication by reading `RELEASE_APP_CLIENT_ID` from the organisation secrets context, matching where the credential is configured.

The previous `vars` reference evaluated to an empty string and caused the App-token step to fail. Workflow YAML validates locally. No changeset is required because this is workflow-only.