### PR TITLE
Restore formatting and linting of generated files

### DIFF
--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -4,7 +4,6 @@ const solanaFmt = require('@solana-config/oxc/oxfmt');
 // Keep in sync with oxlint.config.ts.
 const ignorePatterns = [
     '**/dist/',
-    '**/generated/',
     '**/target/',
     '**/test-ledger/',
     '**/idls/',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -4,7 +4,6 @@ const solanaConfig = require('@solana-config/oxc/oxlint');
 // Keep in sync with oxfmt.config.ts.
 const ignorePatterns = [
     '**/dist/',
-    '**/generated/',
     '**/target/',
     '**/test-ledger/',
     '**/idls/',
@@ -25,6 +24,11 @@ module.exports = oxlint.defineConfig({
         // These packages define large, deliberately ordered node structures.
         {
             files: ['packages/cli/**', 'packages/node-types/**', 'packages/nodes/**'],
+            rules: { 'sort-keys': 'off' },
+        },
+        // Generated output is deliberately ordered and machine-written.
+        {
+            files: ['**/generated/**'],
             rules: { 'sort-keys': 'off' },
         },
     ],

--- a/packages/nodes/src/generated/AccountNode.ts
+++ b/packages/nodes/src/generated/AccountNode.ts
@@ -1,4 +1,5 @@
 import type { AccountNode, DiscriminatorNode, NestedTypeNode, PdaLinkNode, StructTypeNode } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../shared';
 import { structTypeNode } from './typeNodes/StructTypeNode';
 

--- a/packages/nodes/src/generated/ConstantNode.ts
+++ b/packages/nodes/src/generated/ConstantNode.ts
@@ -1,4 +1,5 @@
 import type { ConstantNode, TypeNode, ValueNode } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../shared';
 
 /** A named constant exposed by the program: a typed value associated with a name. */

--- a/packages/nodes/src/generated/DefinedTypeNode.ts
+++ b/packages/nodes/src/generated/DefinedTypeNode.ts
@@ -1,4 +1,5 @@
 import type { DefinedTypeNode, TypeNode } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../shared';
 
 export type DefinedTypeNodeInput<TType extends TypeNode = TypeNode> = Omit<

--- a/packages/nodes/src/generated/ErrorNode.ts
+++ b/packages/nodes/src/generated/ErrorNode.ts
@@ -1,4 +1,5 @@
 import type { ErrorNode } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../shared';
 
 export type ErrorNodeInput = Omit<ErrorNode, 'docs' | 'kind' | 'name'> & {

--- a/packages/nodes/src/generated/EventNode.ts
+++ b/packages/nodes/src/generated/EventNode.ts
@@ -1,4 +1,5 @@
 import type { DiscriminatorNode, EventNode, TypeNode } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../shared';
 
 export type EventNodeInput<

--- a/packages/nodes/src/generated/InstructionAccountNode.ts
+++ b/packages/nodes/src/generated/InstructionAccountNode.ts
@@ -4,6 +4,7 @@ import type {
     InstructionAccountNode,
     InstructionInputValueNode,
 } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../shared';
 
 export type InstructionAccountNodeInput<

--- a/packages/nodes/src/generated/InstructionArgumentNode.ts
+++ b/packages/nodes/src/generated/InstructionArgumentNode.ts
@@ -4,6 +4,7 @@ import type {
     StructFieldDisplayNode,
     TypeNode,
 } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../shared';
 
 export type InstructionArgumentNodeInput<

--- a/packages/nodes/src/generated/InstructionByteDeltaNode.ts
+++ b/packages/nodes/src/generated/InstructionByteDeltaNode.ts
@@ -1,4 +1,5 @@
 import type { InstructionByteDeltaNode, InstructionByteDeltaValue } from '@codama/node-types';
+
 import { isNode } from '../Node';
 
 /** A byte-size delta applied when computing rent or buffer size — typically used by instructions that resize accounts. */

--- a/packages/nodes/src/generated/InstructionNode.ts
+++ b/packages/nodes/src/generated/InstructionNode.ts
@@ -10,6 +10,7 @@ import type {
     PluginNode,
     ProvidedNode,
 } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../shared';
 
 export type InstructionNodeInput<

--- a/packages/nodes/src/generated/InstructionRemainingAccountsNode.ts
+++ b/packages/nodes/src/generated/InstructionRemainingAccountsNode.ts
@@ -3,6 +3,7 @@ import type {
     InstructionRemainingAccountsNode,
     InstructionRemainingAccountsValue,
 } from '@codama/node-types';
+
 import { DocsInput, parseDocs } from '../shared';
 
 /** A "remaining accounts" slot in an instruction — a variable-length tail of accounts derived from a value. */

--- a/packages/nodes/src/generated/PdaNode.ts
+++ b/packages/nodes/src/generated/PdaNode.ts
@@ -1,4 +1,5 @@
 import type { PdaNode, PdaSeedNode } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../shared';
 
 export type PdaNodeInput<TSeeds extends Array<PdaSeedNode> | undefined = Array<PdaSeedNode> | undefined> = Omit<

--- a/packages/nodes/src/generated/PluginNode.ts
+++ b/packages/nodes/src/generated/PluginNode.ts
@@ -1,4 +1,5 @@
 import type { PluginNode } from '@codama/node-types';
+
 import { camelCase } from '../shared';
 
 /**

--- a/packages/nodes/src/generated/ProgramNode.ts
+++ b/packages/nodes/src/generated/ProgramNode.ts
@@ -8,6 +8,7 @@ import type {
     PdaNode,
     ProgramNode,
 } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../shared';
 
 export type ProgramNodeInput<

--- a/packages/nodes/src/generated/ProvidedNode.ts
+++ b/packages/nodes/src/generated/ProvidedNode.ts
@@ -1,4 +1,5 @@
 import type { Node, ProvidedNode } from '@codama/node-types';
+
 import { camelCase } from '../shared';
 
 /**

--- a/packages/nodes/src/generated/RootNode.ts
+++ b/packages/nodes/src/generated/RootNode.ts
@@ -1,4 +1,5 @@
 import type { ProgramNode, RootNode } from '@codama/node-types';
+
 import { CODAMA_VERSION } from './codamaVersion';
 
 /**

--- a/packages/nodes/src/generated/contextualValueNodes/AccountBumpValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/AccountBumpValueNode.ts
@@ -1,4 +1,5 @@
 import type { AccountBumpValueNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 /** Refers to the bump seed of a named PDA-derived account in the surrounding instruction. */

--- a/packages/nodes/src/generated/contextualValueNodes/AccountFieldValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/AccountFieldValueNode.ts
@@ -1,4 +1,5 @@
 import type { AccountFieldValueNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 export type AccountFieldValueNodeInput = Omit<AccountFieldValueNode, 'account' | 'kind' | 'path'> & {

--- a/packages/nodes/src/generated/contextualValueNodes/AccountValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/AccountValueNode.ts
@@ -1,4 +1,5 @@
 import type { AccountValueNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 /** Refers to a named account in the surrounding instruction. */

--- a/packages/nodes/src/generated/contextualValueNodes/ArgumentValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/ArgumentValueNode.ts
@@ -1,4 +1,5 @@
 import type { ArgumentValueNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 /** Refers to a named argument of the surrounding instruction. */

--- a/packages/nodes/src/generated/contextualValueNodes/PdaSeedValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/PdaSeedValueNode.ts
@@ -1,4 +1,5 @@
 import type { PdaSeedValueNode, PdaSeedValueValue } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 /** Pairs a PDA seed name with the value to substitute when deriving the PDA. */

--- a/packages/nodes/src/generated/contextualValueNodes/PdaValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/PdaValueNode.ts
@@ -1,4 +1,5 @@
 import type { PdaSeedValueNode, PdaValueNode, PdaValuePda, PdaValueProgramId } from '@codama/node-types';
+
 import { pdaLinkNode } from '../linkNodes/PdaLinkNode';
 
 /** Resolves to a PDA derived from a list of seed values. */

--- a/packages/nodes/src/generated/contextualValueNodes/ResolverValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/ResolverValueNode.ts
@@ -1,4 +1,5 @@
 import type { ResolverDependency, ResolverValueNode } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../../shared';
 
 /**

--- a/packages/nodes/src/generated/discriminatorNodes/FieldDiscriminatorNode.ts
+++ b/packages/nodes/src/generated/discriminatorNodes/FieldDiscriminatorNode.ts
@@ -1,4 +1,5 @@
 import type { FieldDiscriminatorNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 /** Identifies a node by the value of a named field at a known byte offset. */

--- a/packages/nodes/src/generated/linkNodes/AccountLinkNode.ts
+++ b/packages/nodes/src/generated/linkNodes/AccountLinkNode.ts
@@ -1,4 +1,5 @@
 import type { AccountLinkNode, ProgramLinkNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 import { programLinkNode } from './ProgramLinkNode';
 

--- a/packages/nodes/src/generated/linkNodes/DefinedTypeLinkNode.ts
+++ b/packages/nodes/src/generated/linkNodes/DefinedTypeLinkNode.ts
@@ -1,4 +1,5 @@
 import type { DefinedTypeLinkNode, ProgramLinkNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 import { programLinkNode } from './ProgramLinkNode';
 

--- a/packages/nodes/src/generated/linkNodes/InstructionAccountLinkNode.ts
+++ b/packages/nodes/src/generated/linkNodes/InstructionAccountLinkNode.ts
@@ -1,4 +1,5 @@
 import type { InstructionAccountLinkNode, InstructionLinkNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 import { instructionLinkNode } from './InstructionLinkNode';
 

--- a/packages/nodes/src/generated/linkNodes/InstructionArgumentLinkNode.ts
+++ b/packages/nodes/src/generated/linkNodes/InstructionArgumentLinkNode.ts
@@ -1,4 +1,5 @@
 import type { InstructionArgumentLinkNode, InstructionLinkNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 import { instructionLinkNode } from './InstructionLinkNode';
 

--- a/packages/nodes/src/generated/linkNodes/InstructionLinkNode.ts
+++ b/packages/nodes/src/generated/linkNodes/InstructionLinkNode.ts
@@ -1,4 +1,5 @@
 import type { InstructionLinkNode, ProgramLinkNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 import { programLinkNode } from './ProgramLinkNode';
 

--- a/packages/nodes/src/generated/linkNodes/PdaLinkNode.ts
+++ b/packages/nodes/src/generated/linkNodes/PdaLinkNode.ts
@@ -1,4 +1,5 @@
 import type { PdaLinkNode, ProgramLinkNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 import { programLinkNode } from './ProgramLinkNode';
 

--- a/packages/nodes/src/generated/linkNodes/ProgramLinkNode.ts
+++ b/packages/nodes/src/generated/linkNodes/ProgramLinkNode.ts
@@ -1,4 +1,5 @@
 import type { ProgramLinkNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 /** A reference to a program by name. */

--- a/packages/nodes/src/generated/pdaSeedNodes/VariablePdaSeedNode.ts
+++ b/packages/nodes/src/generated/pdaSeedNodes/VariablePdaSeedNode.ts
@@ -1,4 +1,5 @@
 import type { TypeNode, VariablePdaSeedNode } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../../shared';
 
 /** A PDA seed whose value is provided at derivation time, identified by name. */

--- a/packages/nodes/src/generated/typeNodes/BooleanTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/BooleanTypeNode.ts
@@ -1,4 +1,5 @@
 import type { BooleanTypeNode, NestedTypeNode, NumberTypeNode } from '@codama/node-types';
+
 import { numberTypeNode } from './NumberTypeNode';
 
 /** A boolean serialised as a numeric value. The wrapped number type determines the byte width. */

--- a/packages/nodes/src/generated/typeNodes/EnumEmptyVariantTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/EnumEmptyVariantTypeNode.ts
@@ -1,4 +1,5 @@
 import type { EnumEmptyVariantTypeNode, EnumVariantDisplayNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 /** A unit-style variant of an enum that carries no payload. */

--- a/packages/nodes/src/generated/typeNodes/EnumStructVariantTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/EnumStructVariantTypeNode.ts
@@ -4,6 +4,7 @@ import type {
     NestedTypeNode,
     StructTypeNode,
 } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 /** A variant of an enum that carries a struct payload (named fields). */

--- a/packages/nodes/src/generated/typeNodes/EnumTupleVariantTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/EnumTupleVariantTypeNode.ts
@@ -4,6 +4,7 @@ import type {
     NestedTypeNode,
     TupleTypeNode,
 } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 /** A variant of an enum that carries a tuple payload (positional fields). */

--- a/packages/nodes/src/generated/typeNodes/EnumTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/EnumTypeNode.ts
@@ -1,4 +1,5 @@
 import type { EnumTypeNode, EnumVariantTypeNode, NestedTypeNode, NumberTypeNode } from '@codama/node-types';
+
 import { numberTypeNode } from './NumberTypeNode';
 
 /** A tagged union: a numeric discriminator followed by one of several variant payloads. */

--- a/packages/nodes/src/generated/typeNodes/OptionTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/OptionTypeNode.ts
@@ -1,4 +1,5 @@
 import type { NestedTypeNode, NumberTypeNode, OptionTypeNode, TypeNode } from '@codama/node-types';
+
 import { numberTypeNode } from './NumberTypeNode';
 
 /** A value that may be present or absent (Some/None), with an explicit numeric prefix indicating presence. */

--- a/packages/nodes/src/generated/typeNodes/StructFieldTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/StructFieldTypeNode.ts
@@ -1,4 +1,5 @@
 import type { StructFieldDisplayNode, StructFieldTypeNode, TypeNode, ValueNode } from '@codama/node-types';
+
 import { camelCase, DocsInput, parseDocs } from '../../shared';
 
 export type StructFieldTypeNodeInput<

--- a/packages/nodes/src/generated/valueNodes/EnumValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/EnumValueNode.ts
@@ -1,4 +1,5 @@
 import type { DefinedTypeLinkNode, EnumValueNode, EnumValuePayload } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 import { definedTypeLinkNode } from '../linkNodes/DefinedTypeLinkNode';
 

--- a/packages/nodes/src/generated/valueNodes/InjectedValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/InjectedValueNode.ts
@@ -1,4 +1,5 @@
 import type { InjectedValueNode, ValueNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 export type InjectedValueNodeInput<TFallback extends ValueNode | undefined = ValueNode | undefined> = Omit<

--- a/packages/nodes/src/generated/valueNodes/PublicKeyValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/PublicKeyValueNode.ts
@@ -1,4 +1,5 @@
 import type { PublicKeyValueNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 /** A concrete public key, with an optional symbolic identifier for the address. */

--- a/packages/nodes/src/generated/valueNodes/StructFieldValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/StructFieldValueNode.ts
@@ -1,4 +1,5 @@
 import type { StructFieldValueNode, ValueNode } from '@codama/node-types';
+
 import { camelCase } from '../../shared';
 
 /** A named field of a `structValueNode`. */

--- a/packages/spec-generators/package.json
+++ b/packages/spec-generators/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "build": "rimraf dist && tsup",
-        "generate": "pnpm build && node ./dist/generate.mjs && pnpm --filter @codama/node-types --filter @codama/nodes --filter @codama/visitors-core lint:fix",
+        "generate": "pnpm build && node ./dist/generate.mjs && pnpm -w lint:fix",
         "test": "pnpm test:types && pnpm test:unit",
         "test:types": "tsc --noEmit",
         "test:unit": "vitest run"

--- a/packages/visitors-core/src/generated/identityVisitor.ts
+++ b/packages/visitors-core/src/generated/identityVisitor.ts
@@ -78,6 +78,7 @@ import {
     variablePdaSeedNode,
     zeroableOptionTypeNode,
 } from '@codama/nodes';
+
 import { staticVisitor } from '../staticVisitor';
 import { type Visitor, visit as baseVisit } from '../visitor';
 

--- a/packages/visitors-core/src/generated/mergeVisitor.ts
+++ b/packages/visitors-core/src/generated/mergeVisitor.ts
@@ -1,4 +1,5 @@
 import { REGISTERED_NODE_KINDS, type Node, type NodeKind } from '@codama/nodes';
+
 import { staticVisitor } from '../staticVisitor';
 import { type Visitor, visit as baseVisit } from '../visitor';
 


### PR DESCRIPTION
This PR repairs the post-generation lint step of the spec-generation pipeline, which has been silently broken since the oxlint/oxfmt migration (#1081). That migration removed the package-level `lint:fix` scripts, so the `pnpm --filter ... lint:fix` step in `spec-generators`' `generate` script matched no scripts and no-oped, and it also ignored `**/generated/` in both oxc configs, so freshly generated output would land completely unformatted and unlinted. The `generate` script now runs the root `pnpm -w lint:fix`, and `**/generated/` is removed from both ignore lists, which stay in sync; rules that are inappropriate for machine-written output are instead disabled via a new oxlint override for `**/generated/**` (currently just `sort-keys`, which is auto-fixable and could otherwise silently reorder deliberately-ordered generated structures). Generated files were linted and formatted throughout the eslint/prettier era, so this is a return to form; oxlint reports zero violations on them under the full rule set. The committed generated files are reformatted accordingly, a 44-file whitespace-only delta. Verified by regenerating against the pinned `@codama/spec@1.8.0`: the pipeline now reproduces the committed files exactly and is idempotent, confirming there was no semantic drift.