### PR TITLE
Integrate @codama/spec@1.9.1

### DIFF
--- a/.changeset/calm-moons-carry.md
+++ b/.changeset/calm-moons-carry.md
@@ -1,0 +1,6 @@
+---
+'@codama/node-types': patch
+'@codama/nodes': patch
+---
+
+Update the generated node types and constructors to `@codama/spec@1.9.1`. Generated docblocks now carry the enriched spec documentation (strategy walkthroughs with buffer diagrams for the offset type nodes, serialisation caveats, and worked examples), the `CodamaVersion` type moves from `'1.8.0'` to `'1.9.1'`, and new documents created via `rootNode()` are stamped with version `1.9.1`.

--- a/packages/node-types/src/generated/AccountNode.ts
+++ b/packages/node-types/src/generated/AccountNode.ts
@@ -5,7 +5,11 @@ import type { PdaLinkNode } from './linkNodes/PdaLinkNode';
 import type { NestedTypeNode } from './typeNodes/NestedTypeNode';
 import type { StructTypeNode } from './typeNodes/StructTypeNode';
 
-/** An on-chain account: its name, data structure, optional fixed size, optional PDA, and optional discriminators. */
+/**
+ * An on-chain account: its name, data structure, optional fixed size, optional PDA, and optional discriminators.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/77974dad-212e-49b1-8e41-5d466c273a02)
+ */
 export interface AccountNode<
     TData extends NestedTypeNode<StructTypeNode> = NestedTypeNode<StructTypeNode>,
     TPda extends PdaLinkNode | undefined = PdaLinkNode | undefined,
@@ -22,7 +26,10 @@ export interface AccountNode<
     readonly docs?: Docs;
 
     // Children.
-    /** The struct describing the account data. */
+    /**
+     * The struct describing the account data.
+     * It must be a struct so its fields can be referenced by other nodes — e.g. `accountFieldValueNode`.
+     */
     readonly data: TData;
     /** A link to the PDA the account is derived from, if applicable. */
     readonly pda?: TPda;

--- a/packages/node-types/src/generated/DefinedTypeNode.ts
+++ b/packages/node-types/src/generated/DefinedTypeNode.ts
@@ -2,7 +2,11 @@ import type { CamelCaseString } from '../brands';
 import type { Docs } from '../Docs';
 import type { TypeNode } from './typeNodes/TypeNode';
 
-/** A reusable named type that can be referenced by `definedTypeLinkNode` from elsewhere in the IDL. */
+/**
+ * A reusable named type that can be referenced by `definedTypeLinkNode` from elsewhere in the IDL.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/6049cf77-9a70-4915-8276-dd571d2f8828)
+ */
 export interface DefinedTypeNode<TType extends TypeNode = TypeNode> {
     readonly kind: 'definedTypeNode';
 

--- a/packages/node-types/src/generated/ErrorNode.ts
+++ b/packages/node-types/src/generated/ErrorNode.ts
@@ -1,7 +1,11 @@
 import type { CamelCaseString } from '../brands';
 import type { Docs } from '../Docs';
 
-/** A program error — a numeric code paired with a name and human-readable message. */
+/**
+ * A program error — a numeric code paired with a name and human-readable message.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/0bde98ea-0327-404b-bf38-137d105826b0)
+ */
 export interface ErrorNode {
     readonly kind: 'errorNode';
 

--- a/packages/node-types/src/generated/InstructionAccountNode.ts
+++ b/packages/node-types/src/generated/InstructionAccountNode.ts
@@ -4,7 +4,11 @@ import type { InstructionInputValueNode } from './contextualValueNodes/Instructi
 import type { InstructionAccountDisplayNode } from './displayNodes/InstructionAccountDisplayNode';
 import type { AccountLinkNode } from './linkNodes/AccountLinkNode';
 
-/** An account participating in an instruction, with its name, signing/writability flags, and an optional default value. */
+/**
+ * An account participating in an instruction, with its name, signing/writability flags, and an optional default value.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/4656a08b-2f89-49c2-b428-5378cb1a0b9e)
+ */
 export interface InstructionAccountNode<
     TDefaultValue extends InstructionInputValueNode | undefined = InstructionInputValueNode | undefined,
     TAccountLink extends AccountLinkNode | undefined = AccountLinkNode | undefined,
@@ -22,7 +26,10 @@ export interface InstructionAccountNode<
      * The literal `"either"` indicates a slot that may or may not sign depending on context.
      */
     readonly isSigner: boolean | 'either';
-    /** Whether the account slot may be omitted by callers. */
+    /**
+     * Whether the account slot may be omitted by callers.
+     * When `true`, absent accounts are handled according to the `optionalAccountStrategy` attribute of the surrounding `instructionNode`. Defaults to `false`.
+     */
     readonly isOptional?: boolean;
     /** Markdown documentation for the account slot. */
     readonly docs?: Docs;

--- a/packages/node-types/src/generated/InstructionArgumentNode.ts
+++ b/packages/node-types/src/generated/InstructionArgumentNode.ts
@@ -5,7 +5,12 @@ import type { StructFieldDisplayNode } from './displayNodes/StructFieldDisplayNo
 import type { DefaultValueStrategy } from './shared/defaultValueStrategy';
 import type { TypeNode } from './typeNodes/TypeNode';
 
-/** A named argument of an instruction, with its type and an optional default value. */
+/**
+ * A named argument of an instruction, with its type and an optional default value.
+ * Serialised next to each other, the arguments of an instruction form its data.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/7e2def82-949a-4663-bdc3-ac599d39d2d2)
+ */
 export interface InstructionArgumentNode<
     TDefaultValue extends InstructionInputValueNode | undefined = InstructionInputValueNode | undefined,
     TType extends TypeNode = TypeNode,
@@ -16,7 +21,10 @@ export interface InstructionArgumentNode<
     // Data.
     /** The name of the argument. */
     readonly name: CamelCaseString;
-    /** How a configured default value is exposed in generated APIs. Required when `defaultValue` is set. */
+    /**
+     * How a configured default value is exposed in generated APIs.
+     * Only relevant when `defaultValue` is set; when absent, `optional` is assumed.
+     */
     readonly defaultValueStrategy?: DefaultValueStrategy;
     /** Markdown documentation for the argument. */
     readonly docs?: Docs;

--- a/packages/node-types/src/generated/InstructionByteDeltaNode.ts
+++ b/packages/node-types/src/generated/InstructionByteDeltaNode.ts
@@ -1,11 +1,17 @@
 import type { InstructionByteDeltaValue } from './InstructionByteDeltaValue';
 
-/** A byte-size delta applied when computing rent or buffer size — typically used by instructions that resize accounts. */
+/**
+ * A byte-size delta applied when computing rent or buffer size — typically used by instructions that resize accounts.
+ * For instance, if an instruction creates a new account of 42 bytes, this node can carry that information, enabling clients to allocate the right amount of lamports to cover the cost of executing the instruction.
+ */
 export interface InstructionByteDeltaNode<TValue extends InstructionByteDeltaValue = InstructionByteDeltaValue> {
     readonly kind: 'instructionByteDeltaNode';
 
     // Data.
-    /** Whether the delta includes the account header overhead. */
+    /**
+     * Whether the delta includes the account header overhead — i.e. 128 bytes.
+     * Defaults to `false` when the value is a `resolverValueNode` and `true` otherwise.
+     */
     readonly withHeader: boolean;
     /** When `true`, the delta is subtracted from the running size instead of added. Defaults to `false`. */
     readonly subtract?: boolean;

--- a/packages/node-types/src/generated/InstructionByteDeltaValue.ts
+++ b/packages/node-types/src/generated/InstructionByteDeltaValue.ts
@@ -3,5 +3,8 @@ import type { ResolverValueNode } from './contextualValueNodes/ResolverValueNode
 import type { AccountLinkNode } from './linkNodes/AccountLinkNode';
 import type { NumberValueNode } from './valueNodes/NumberValueNode';
 
-/** The value forms accepted by an `instructionByteDeltaNode`. */
+/**
+ * The value forms accepted by an `instructionByteDeltaNode`.
+ * An `accountLinkNode` uses the size of the linked account; an `argumentValueNode` uses the value of the referenced instruction argument; a `numberValueNode` uses that explicit number; and a `resolverValueNode` acts as a fallback for more complex values.
+ */
 export type InstructionByteDeltaValue = AccountLinkNode | ArgumentValueNode | NumberValueNode | ResolverValueNode;

--- a/packages/node-types/src/generated/InstructionNode.ts
+++ b/packages/node-types/src/generated/InstructionNode.ts
@@ -13,7 +13,11 @@ import type { OptionalAccountStrategy } from './shared/optionalAccountStrategy';
 
 type SelfInstructionNode = InstructionNode;
 
-/** A program instruction: its accounts, arguments, byte-delta hints, discriminators, optional status, and optional sub-instructions. */
+/**
+ * A program instruction: its accounts, arguments, byte-delta hints, discriminators, optional status, and optional sub-instructions.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/0d8edced-cfa4-4500-b80c-ebc56181a338)
+ */
 export interface InstructionNode<
     TAccounts extends Array<InstructionAccountNode> | undefined = Array<InstructionAccountNode> | undefined,
     TArguments extends Array<InstructionArgumentNode> | undefined = Array<InstructionArgumentNode> | undefined,
@@ -36,7 +40,10 @@ export interface InstructionNode<
     readonly name: CamelCaseString;
     /** Markdown documentation for the instruction. */
     readonly docs?: Docs;
-    /** How absent optional accounts are represented when serialising the instruction. */
+    /**
+     * How absent optional accounts are represented when serialising the instruction.
+     * When absent, `programId` is assumed.
+     */
     readonly optionalAccountStrategy?: OptionalAccountStrategy;
 
     // Children.
@@ -44,11 +51,17 @@ export interface InstructionNode<
     readonly accounts?: TAccounts;
     /** The serialised arguments of the instruction, in order. */
     readonly arguments?: TArguments;
-    /** Additional arguments exposed in the generated client API but not serialised on the wire. */
+    /**
+     * Additional arguments exposed in the generated client API but not serialised on the wire.
+     * Typically useful for feeding the default values of other arguments or accounts.
+     */
     readonly extraArguments?: TExtraArguments;
     /** Variable-length tails of accounts appended after the named account slots. */
     readonly remainingAccounts?: TRemainingAccounts;
-    /** Byte-size adjustments applied when computing rent or buffer size — for instructions that resize accounts. */
+    /**
+     * Byte-size adjustments applied when computing rent or buffer size — for instructions that resize accounts.
+     * All deltas are added together, unless their `subtract` attribute is set.
+     */
     readonly byteDeltas?: TByteDeltas;
     /**
      * Discriminators that distinguish this instruction from others.
@@ -57,7 +70,7 @@ export interface InstructionNode<
     readonly discriminators?: TDiscriminators;
     /** The lifecycle status of the instruction. */
     readonly status?: TStatus;
-    /** Inner instructions invoked through CPI as part of executing this instruction. */
+    /** Nested instructions that split this instruction into distinct scenarios — e.g. one sub-instruction per version of the instruction. */
     readonly subInstructions?: TSubInstructions;
     /**
      * Named nodes exposed to consumers in the surrounding scope.

--- a/packages/node-types/src/generated/InstructionRemainingAccountsNode.ts
+++ b/packages/node-types/src/generated/InstructionRemainingAccountsNode.ts
@@ -10,11 +10,11 @@ export interface InstructionRemainingAccountsNode<
     readonly kind: 'instructionRemainingAccountsNode';
 
     // Data.
-    /** Whether the remaining-accounts tail may be empty. */
+    /** Whether the remaining-accounts tail may be empty. Defaults to `false`. */
     readonly isOptional?: boolean;
     /**
      * Whether each remaining account must sign the transaction.
-     * The literal `"either"` indicates a slot that may or may not sign depending on context.
+     * The literal `"either"` indicates that each account may or may not be a signer, independently of the others. Defaults to `false`.
      */
     readonly isSigner?: boolean | 'either';
     /** Whether the instruction may write to each remaining account. */

--- a/packages/node-types/src/generated/InstructionRemainingAccountsValue.ts
+++ b/packages/node-types/src/generated/InstructionRemainingAccountsValue.ts
@@ -1,5 +1,8 @@
 import type { ArgumentValueNode } from './contextualValueNodes/ArgumentValueNode';
 import type { ResolverValueNode } from './contextualValueNodes/ResolverValueNode';
 
-/** The value forms accepted by an `instructionRemainingAccountsNode`. */
+/**
+ * The value forms accepted by an `instructionRemainingAccountsNode`.
+ * An `argumentValueNode` represents the array of accounts as a new argument of the provided name; a `resolverValueNode` acts as a fallback for more complex scenarios.
+ */
 export type InstructionRemainingAccountsValue = ArgumentValueNode | ResolverValueNode;

--- a/packages/node-types/src/generated/InstructionStatusNode.ts
+++ b/packages/node-types/src/generated/InstructionStatusNode.ts
@@ -1,6 +1,9 @@
 import type { InstructionLifecycle } from './shared/instructionLifecycle';
 
-/** The lifecycle stage of an instruction (draft, live, deprecated, archived) with an optional accompanying message. */
+/**
+ * The lifecycle stage of an instruction (draft, live, deprecated, archived) with an optional accompanying message.
+ * An instruction without a status is considered live — a status node is typically only attached to signal another stage.
+ */
 export interface InstructionStatusNode {
     readonly kind: 'instructionStatusNode';
 

--- a/packages/node-types/src/generated/PdaNode.ts
+++ b/packages/node-types/src/generated/PdaNode.ts
@@ -2,7 +2,11 @@ import type { CamelCaseString } from '../brands';
 import type { Docs } from '../Docs';
 import type { PdaSeedNode } from './pdaSeedNodes/PdaSeedNode';
 
-/** A program-derived address: its name, optional program ID override, and the seeds used to derive it. */
+/**
+ * A program-derived address: its name, optional program ID override, and the seeds used to derive it.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/4f7c9718-1ffa-4f2c-aa45-71b3ce204219)
+ */
 export interface PdaNode<TSeeds extends Array<PdaSeedNode> | undefined = Array<PdaSeedNode> | undefined> {
     readonly kind: 'pdaNode';
 

--- a/packages/node-types/src/generated/ProgramNode.ts
+++ b/packages/node-types/src/generated/ProgramNode.ts
@@ -10,7 +10,11 @@ import type { InstructionNode } from './InstructionNode';
 import type { PdaNode } from './PdaNode';
 import type { ProgramOrigin } from './shared/programOrigin';
 
-/** A Solana program: its identity, version, accounts, instructions, defined types, PDAs, events, errors, and constants. */
+/**
+ * A Solana program: its identity, version, accounts, instructions, defined types, PDAs, events, errors, and constants.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/37ec38ea-66df-4c08-81c3-822ef4388580)
+ */
 export interface ProgramNode<
     TPdas extends Array<PdaNode> | undefined = Array<PdaNode> | undefined,
     TAccounts extends Array<AccountNode> | undefined = Array<AccountNode> | undefined,

--- a/packages/node-types/src/generated/RootNode.ts
+++ b/packages/node-types/src/generated/RootNode.ts
@@ -4,6 +4,8 @@ import type { CodamaVersion } from './shared/codamaVersion';
 /**
  * The root of a Codama IDL document.
  * Pairs a primary program with any number of additional programs and tags the document with the spec version.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/96c43c75-5925-4b6b-a1e0-8b8c61317cfe)
  */
 export interface RootNode<
     TProgram extends ProgramNode = ProgramNode,
@@ -12,7 +14,10 @@ export interface RootNode<
     readonly kind: 'rootNode';
 
     // Data.
-    /** A literal marker identifying the document as a Codama IDL. */
+    /**
+     * A literal marker identifying the document as a Codama IDL.
+     * This allows other communities to fork the Codama standard under a different marker.
+     */
     readonly standard: 'codama';
     /** The Codama spec version this document conforms to. */
     readonly version: CodamaVersion;

--- a/packages/node-types/src/generated/contextualValueNodes/ConditionalValueNode.ts
+++ b/packages/node-types/src/generated/contextualValueNodes/ConditionalValueNode.ts
@@ -19,11 +19,11 @@ export interface ConditionalValueNode<
     readonly condition: TCondition;
     /**
      * When present, the condition result is compared for equality against this value.
-     * Otherwise the result is treated as a boolean.
+     * When omitted, the condition passes if the referenced account or argument exists in the current context, regardless of its value.
      */
     readonly value?: TValue;
-    /** The value used when the condition resolves truthy (or matches `value`). */
+    /** The value used when the condition passes — i.e. it matches `value` or, without a `value`, exists. */
     readonly ifTrue?: TIfTrue;
-    /** The value used when the condition resolves falsy (or does not match `value`). */
+    /** The value used when the condition fails — i.e. it does not match `value` or, without a `value`, does not exist. */
     readonly ifFalse?: TIfFalse;
 }

--- a/packages/node-types/src/generated/contextualValueNodes/IdentityValueNode.ts
+++ b/packages/node-types/src/generated/contextualValueNodes/IdentityValueNode.ts
@@ -1,4 +1,8 @@
-/** Refers to the wallet identity providing the instruction context. */
+/**
+ * Refers to the wallet identity providing the instruction context — the main wallet that should own things.
+ * For instance, in a web application the identity would be the connected wallet; in a terminal, the wallet identified by `solana address`.
+ * A similar node exists for the main wallet that should pay for things — `payerValueNode`. In practice the identity and the payer are often the same, but offering the distinction can be useful should they differ.
+ */
 export interface IdentityValueNode {
     readonly kind: 'identityValueNode';
 }

--- a/packages/node-types/src/generated/contextualValueNodes/PayerValueNode.ts
+++ b/packages/node-types/src/generated/contextualValueNodes/PayerValueNode.ts
@@ -1,4 +1,8 @@
-/** Refers to the wallet paying for the surrounding transaction. */
+/**
+ * Refers to the wallet paying for the surrounding transaction — the main wallet that should pay for things, such as rent for account storage.
+ * For instance, in a web application the payer would be the connected wallet; in a terminal, the wallet identified by `solana address`.
+ * A similar node exists for the main wallet that should own things — `identityValueNode`. In practice the identity and the payer are often the same, but offering the distinction can be useful should they differ.
+ */
 export interface PayerValueNode {
     readonly kind: 'payerValueNode';
 }

--- a/packages/node-types/src/generated/contextualValueNodes/PdaSeedValueNode.ts
+++ b/packages/node-types/src/generated/contextualValueNodes/PdaSeedValueNode.ts
@@ -6,7 +6,7 @@ export interface PdaSeedValueNode<TValue extends PdaSeedValueValue = PdaSeedValu
     readonly kind: 'pdaSeedValueNode';
 
     // Data.
-    /** The name of the seed being filled in. */
+    /** The name of the seed being filled in — a `variablePdaSeedNode` of the PDA definition. */
     readonly name: CamelCaseString;
 
     // Children.

--- a/packages/node-types/src/generated/contextualValueNodes/ProgramIdValueNode.ts
+++ b/packages/node-types/src/generated/contextualValueNodes/ProgramIdValueNode.ts
@@ -1,4 +1,4 @@
-/** Refers to the program ID of the surrounding instruction. */
+/** Refers to the program ID of the surrounding instruction — that is, the address of the `programNode` this node descends from. */
 export interface ProgramIdValueNode {
     readonly kind: 'programIdValueNode';
 }

--- a/packages/node-types/src/generated/contextualValueNodes/ResolverValueNode.ts
+++ b/packages/node-types/src/generated/contextualValueNodes/ResolverValueNode.ts
@@ -5,6 +5,7 @@ import type { ResolverDependency } from './ResolverDependency';
 /**
  * A custom resolver: a named function provided by the consumer that produces a value.
  * May optionally depend on other accounts and arguments resolved at instruction-build time.
+ * This node acts as a fallback for any value or logic that cannot easily be described by the other nodes — renderers treat resolvers as functions that can be injected into the generated code.
  */
 export interface ResolverValueNode<
     TDependsOn extends Array<ResolverDependency> | undefined = Array<ResolverDependency> | undefined,
@@ -12,7 +13,10 @@ export interface ResolverValueNode<
     readonly kind: 'resolverValueNode';
 
     // Data.
-    /** The name of the resolver function. */
+    /**
+     * A unique name for the resolver.
+     * This is typically the name of the function that renderers will invoke.
+     */
     readonly name: CamelCaseString;
     /** Markdown documentation for the resolver. */
     readonly docs?: Docs;

--- a/packages/node-types/src/generated/countNodes/FixedCountNode.ts
+++ b/packages/node-types/src/generated/countNodes/FixedCountNode.ts
@@ -1,4 +1,7 @@
-/** A count strategy that fixes the number of items at a constant value. */
+/**
+ * A count strategy that fixes the number of items at a constant value.
+ * This enables nodes such as `arrayTypeNode` to represent collections of a fixed length.
+ */
 export interface FixedCountNode {
     readonly kind: 'fixedCountNode';
 

--- a/packages/node-types/src/generated/countNodes/PrefixedCountNode.ts
+++ b/packages/node-types/src/generated/countNodes/PrefixedCountNode.ts
@@ -1,7 +1,10 @@
 import type { NestedTypeNode } from '../typeNodes/NestedTypeNode';
 import type { NumberTypeNode } from '../typeNodes/NumberTypeNode';
 
-/** A count strategy where the number of items is read from a numeric prefix. */
+/**
+ * A count strategy where the number of items is read from a numeric prefix.
+ * This enables nodes such as `arrayTypeNode` to represent collections whose length is stored as a prefix.
+ */
 export interface PrefixedCountNode<TPrefix extends NestedTypeNode<NumberTypeNode> = NestedTypeNode<NumberTypeNode>> {
     readonly kind: 'prefixedCountNode';
 

--- a/packages/node-types/src/generated/countNodes/RemainderCountNode.ts
+++ b/packages/node-types/src/generated/countNodes/RemainderCountNode.ts
@@ -1,4 +1,8 @@
-/** A count strategy where items are read until the buffer is exhausted. */
+/**
+ * A count strategy where items are read until the buffer is exhausted.
+ * When encoding, items are serialised as-is and the total count is never stored; when decoding, items are read one by one until the end of the buffer.
+ * This strategy is therefore only meaningful for the last variable-size region of a buffer.
+ */
 export interface RemainderCountNode {
     readonly kind: 'remainderCountNode';
 }

--- a/packages/node-types/src/generated/discriminatorNodes/FieldDiscriminatorNode.ts
+++ b/packages/node-types/src/generated/discriminatorNodes/FieldDiscriminatorNode.ts
@@ -5,7 +5,7 @@ export interface FieldDiscriminatorNode {
     readonly kind: 'fieldDiscriminatorNode';
 
     // Data.
-    /** The name of the discriminating field. */
+    /** The name of the discriminating field — a `structFieldTypeNode` of the account data or an argument of the instruction. */
     readonly name: CamelCaseString;
     /** The byte offset of the field. */
     readonly offset: number;

--- a/packages/node-types/src/generated/linkNodes/InstructionAccountLinkNode.ts
+++ b/packages/node-types/src/generated/linkNodes/InstructionAccountLinkNode.ts
@@ -12,6 +12,9 @@ export interface InstructionAccountLinkNode<
     readonly name: CamelCaseString;
 
     // Children.
-    /** The instruction the referenced account belongs to. When omitted, the surrounding instruction is assumed. */
+    /**
+     * The instruction the referenced account belongs to. When omitted, the surrounding instruction is assumed.
+     * The instruction link may itself point to a different program if needed.
+     */
     readonly instruction?: TInstruction;
 }

--- a/packages/node-types/src/generated/linkNodes/InstructionArgumentLinkNode.ts
+++ b/packages/node-types/src/generated/linkNodes/InstructionArgumentLinkNode.ts
@@ -12,6 +12,9 @@ export interface InstructionArgumentLinkNode<
     readonly name: CamelCaseString;
 
     // Children.
-    /** The instruction the referenced argument belongs to. When omitted, the surrounding instruction is assumed. */
+    /**
+     * The instruction the referenced argument belongs to. When omitted, the surrounding instruction is assumed.
+     * The instruction link may itself point to a different program if needed.
+     */
     readonly instruction?: TInstruction;
 }

--- a/packages/node-types/src/generated/shared/codamaVersion.ts
+++ b/packages/node-types/src/generated/shared/codamaVersion.ts
@@ -3,4 +3,4 @@
  * version of the spec at generation time; documents conforming to this
  * version of the spec carry this exact string.
  */
-export type CodamaVersion = '1.8.0';
+export type CodamaVersion = '1.9.1';

--- a/packages/node-types/src/generated/shared/numberFormat.ts
+++ b/packages/node-types/src/generated/shared/numberFormat.ts
@@ -14,7 +14,7 @@ export type NumberFormat =
     | 'i64'
     /** Signed 8-bit integer. */
     | 'i8'
-    /** Solana compact-u16 encoding: a variable-length unsigned integer occupying 1 to 3 bytes. */
+    /** Solana compact-u16 encoding: a variable-length unsigned integer occupying 1 to 3 bytes. Values up to `0x7f` are stored as-is in a single byte; above that, the top bit of each byte is set and the remaining value continues in the next byte, with the third byte — when needed — using all 8 bits. */
     | 'shortU16'
     /** Unsigned 128-bit integer. */
     | 'u128'

--- a/packages/node-types/src/generated/shared/postOffsetStrategy.ts
+++ b/packages/node-types/src/generated/shared/postOffsetStrategy.ts
@@ -1,10 +1,13 @@
-/** How a post-offset modifier interprets its offset value after serialising the wrapped type. */
+/**
+ * How a post-offset modifier interprets its offset value after serialising the wrapped type.
+ * See `postOffsetTypeNode` for an illustrated walkthrough of each strategy.
+ */
 export type PostOffsetStrategy =
-    /** Move the cursor to the absolute byte position given by the offset. */
+    /** Move the cursor to the absolute byte position given by the offset; a negative offset counts backwards from the end of the buffer. */
     | 'absolute'
-    /** Pad with zero bytes from the current cursor up to the offset bytes ahead. */
+    /** Move the cursor like `relative` while growing the buffer by the offset amount; a negative offset moves the cursor backwards and shrinks the buffer. */
     | 'padded'
-    /** Restore the cursor to where it was before the wrapped type ran (cancelling its pre-offset). */
+    /** Move the cursor by the offset bytes relative to the pre-offset — where the wrapped type started — rather than where it ended; a negative offset moves it to the left of that position. */
     | 'preOffset'
-    /** Advance the cursor by the offset bytes relative to its current position. */
+    /** Advance the cursor by the offset bytes relative to its current position; a negative offset moves it backwards. */
     | 'relative';

--- a/packages/node-types/src/generated/shared/preOffsetStrategy.ts
+++ b/packages/node-types/src/generated/shared/preOffsetStrategy.ts
@@ -1,8 +1,11 @@
-/** How a pre-offset modifier interprets its offset value before serialising the wrapped type. */
+/**
+ * How a pre-offset modifier interprets its offset value before serialising the wrapped type.
+ * See `preOffsetTypeNode` for an illustrated walkthrough of each strategy.
+ */
 export type PreOffsetStrategy =
-    /** Move the cursor to the absolute byte position given by the offset. */
+    /** Move the cursor to the absolute byte position given by the offset; a negative offset counts backwards from the end of the buffer. */
     | 'absolute'
-    /** Pad with zero bytes from the current cursor up to the offset bytes ahead. */
+    /** Move the cursor like `relative` while growing the buffer by the offset amount; a negative offset moves the cursor backwards and shrinks the buffer. */
     | 'padded'
-    /** Advance the cursor by the offset bytes relative to its current position. */
+    /** Advance the cursor by the offset bytes relative to its current position; a negative offset moves it backwards. */
     | 'relative';

--- a/packages/node-types/src/generated/typeNodes/AmountTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/AmountTypeNode.ts
@@ -3,7 +3,7 @@ import type { NumberTypeNode } from './NumberTypeNode';
 
 /**
  * Wraps a number type to provide additional context such as decimal places and a unit.
- * Useful for amounts representing financial values.
+ * Particularly useful for representing financial values as integers, since floating-point numbers are notoriously unsafe for that purpose.
  */
 export interface AmountTypeNode<TNumber extends NestedTypeNode<NumberTypeNode> = NestedTypeNode<NumberTypeNode>> {
     readonly kind: 'amountTypeNode';

--- a/packages/node-types/src/generated/typeNodes/BooleanTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/BooleanTypeNode.ts
@@ -1,7 +1,10 @@
 import type { NestedTypeNode } from './NestedTypeNode';
 import type { NumberTypeNode } from './NumberTypeNode';
 
-/** A boolean serialised as a numeric value. The wrapped number type determines the byte width. */
+/**
+ * A boolean serialised as a numeric value. The wrapped number type determines the byte width.
+ * A decoded number of `1` yields `true`; any other value yields `false`.
+ */
 export interface BooleanTypeNode<TSize extends NestedTypeNode<NumberTypeNode> = NestedTypeNode<NumberTypeNode>> {
     readonly kind: 'booleanTypeNode';
 

--- a/packages/node-types/src/generated/typeNodes/EnumEmptyVariantTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/EnumEmptyVariantTypeNode.ts
@@ -10,7 +10,7 @@ export interface EnumEmptyVariantTypeNode<
     // Data.
     /** The name of the variant. */
     readonly name: CamelCaseString;
-    /** Explicit discriminator value. When omitted, the discriminator is inferred from the variant position. */
+    /** Explicit discriminator value. When omitted, the discriminator is the index of the variant in the enum, starting at 0. */
     readonly discriminator?: number;
 
     // Children.

--- a/packages/node-types/src/generated/typeNodes/EnumStructVariantTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/EnumStructVariantTypeNode.ts
@@ -13,7 +13,7 @@ export interface EnumStructVariantTypeNode<
     // Data.
     /** The name of the variant. */
     readonly name: CamelCaseString;
-    /** Explicit discriminator value. When omitted, the discriminator is inferred from the variant position. */
+    /** Explicit discriminator value. When omitted, the discriminator is the index of the variant in the enum, starting at 0. */
     readonly discriminator?: number;
 
     // Children.

--- a/packages/node-types/src/generated/typeNodes/EnumTupleVariantTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/EnumTupleVariantTypeNode.ts
@@ -13,7 +13,7 @@ export interface EnumTupleVariantTypeNode<
     // Data.
     /** The name of the variant. */
     readonly name: CamelCaseString;
-    /** Explicit discriminator value. When omitted, the discriminator is inferred from the variant position. */
+    /** Explicit discriminator value. When omitted, the discriminator is the index of the variant in the enum, starting at 0. */
     readonly discriminator?: number;
 
     // Children.

--- a/packages/node-types/src/generated/typeNodes/EnumTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/EnumTypeNode.ts
@@ -12,6 +12,9 @@ export interface EnumTypeNode<
     // Children.
     /** The variants of the enum, in declaration order. */
     readonly variants?: TVariants;
-    /** The numeric type used to serialise the discriminator. */
+    /**
+     * The numeric type used to serialise the discriminator.
+     * The discriminator prepends the serialised variant payload to identify which variant was selected. By default it is the index of the variant (starting at 0), unless the variant provides its own custom discriminator value.
+     */
     readonly size: TSize;
 }

--- a/packages/node-types/src/generated/typeNodes/HiddenPrefixTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/HiddenPrefixTypeNode.ts
@@ -1,7 +1,10 @@
 import type { ConstantValueNode } from '../valueNodes/ConstantValueNode';
 import type { TypeNode } from './TypeNode';
 
-/** Prefixes another type with a list of constant values that are written and read but not surfaced as fields to consumers. */
+/**
+ * Prefixes another type with a list of constant values that are written and read but not surfaced as fields to consumers.
+ * When decoding, the prefixed constants are consumed and checked against their expected values before being discarded.
+ */
 export interface HiddenPrefixTypeNode<
     TType extends TypeNode = TypeNode,
     TPrefix extends Array<ConstantValueNode> | undefined = Array<ConstantValueNode> | undefined,

--- a/packages/node-types/src/generated/typeNodes/HiddenSuffixTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/HiddenSuffixTypeNode.ts
@@ -1,7 +1,10 @@
 import type { ConstantValueNode } from '../valueNodes/ConstantValueNode';
 import type { TypeNode } from './TypeNode';
 
-/** Suffixes another type with a list of constant values that are written and read but not surfaced as fields to consumers. */
+/**
+ * Suffixes another type with a list of constant values that are written and read but not surfaced as fields to consumers.
+ * When decoding, the suffixed constants are consumed and checked against their expected values before being discarded.
+ */
 export interface HiddenSuffixTypeNode<
     TType extends TypeNode = TypeNode,
     TSuffix extends Array<ConstantValueNode> | undefined = Array<ConstantValueNode> | undefined,

--- a/packages/node-types/src/generated/typeNodes/MapTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/MapTypeNode.ts
@@ -4,6 +4,7 @@ import type { TypeNode } from './TypeNode';
 /**
  * A keyed map.
  * The key and value types are described by their respective type nodes; the entry count is determined by a count strategy.
+ * Entries are serialised one after the other, each key immediately followed by its value — e.g. key A, value A, key B, value B.
  */
 export interface MapTypeNode<
     TKey extends TypeNode = TypeNode,

--- a/packages/node-types/src/generated/typeNodes/NestedTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/NestedTypeNode.ts
@@ -10,6 +10,7 @@ import type { TypeNode } from './TypeNode';
 /**
  * A type, possibly wrapped in zero-or-more size, offset, sentinel, or hidden prefix/suffix modifiers.
  * The wrapping is recursive: each modifier wraps another `nestedTypeNode<T>` until the inner `T` is reached.
+ * For example, a `nestedTypeNode<stringTypeNode>` can be fulfilled by a plain `stringTypeNode`, by a `fixedSizeTypeNode` wrapping a `stringTypeNode`, or by any deeper nesting such as `hiddenPrefixTypeNode<preOffsetTypeNode<fixedSizeTypeNode<stringTypeNode>>>`.
  */
 export type NestedTypeNode<TType extends TypeNode> =
     | FixedSizeTypeNode<NestedTypeNode<TType>>

--- a/packages/node-types/src/generated/typeNodes/OptionTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/OptionTypeNode.ts
@@ -10,12 +10,18 @@ export interface OptionTypeNode<
     readonly kind: 'optionTypeNode';
 
     // Data.
-    /** When `true`, the absent variant still occupies the byte size of the present variant (zero-padded). Defaults to `false`. */
+    /**
+     * When `true`, the absent variant still occupies the byte size of the present variant (zero-padded). Defaults to `false`.
+     * Must only be set to `true` when the `item` type is of fixed size.
+     */
     readonly fixed?: boolean;
 
     // Children.
     /** The type carried by the option when present. */
     readonly item: TItem;
-    /** The numeric type used as the presence flag. */
+    /**
+     * The numeric type used as the presence flag.
+     * A prefix value of `1` means the item is present and follows the prefix; a value of `0` means the item is absent and nothing further is serialised.
+     */
     readonly prefix: TPrefix;
 }

--- a/packages/node-types/src/generated/typeNodes/PostOffsetTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/PostOffsetTypeNode.ts
@@ -1,7 +1,74 @@
 import type { PostOffsetStrategy } from '../shared/postOffsetStrategy';
 import type { TypeNode } from './TypeNode';
 
-/** After serialising the wrapped type, advance the cursor by `offset` bytes interpreted via the chosen strategy. */
+/**
+ * After serialising the wrapped type, advance the cursor by `offset` bytes interpreted via the chosen strategy.
+ *
+ * Since the offset is applied _after_ the wrapped type runs, this node is useful to move the cursor around once the wrapped type has been processed. See `preOffsetTypeNode` for the opposite behaviour.
+ *
+ * The strategies below are illustrated against the following buffer: the `99` byte represents the encoded value of the wrapped type and the `FF` byte represents the next bytes to be encoded after it, in order to show the _post_ cursor position.
+ *
+ * ```
+ * 0x00000099FF000000;
+ *         | └-- Initial post-offset
+ *         └-- Pre-offset
+ * ```
+ *
+ * **`relative`** — the cursor is moved to the right by the provided offset. A negative offset moves it to the left instead.
+ *
+ * ```
+ * offset = 2
+ * 0x000000990000FF00;
+ *               └-- Post-offset
+ *
+ * offset = -2
+ * 0x0000FF9900000000;
+ *       └-- Post-offset
+ * ```
+ *
+ * **`absolute`** — the cursor is moved to an absolute position in the buffer. A negative offset moves it backwards from the end of the buffer.
+ *
+ * ```
+ * offset = 0
+ * 0xFF00009900000000;
+ *   └-- Post-offset
+ *
+ * offset = -2
+ * 0x000000990000FF00;
+ *               └-- Post-offset
+ * ```
+ *
+ * **`padded`** — the cursor is moved to the right by the provided offset **and the buffer size is increased** by the offset amount, allowing padding bytes to be added. Reciprocally, a negative offset moves the cursor to the left and decreases the buffer size.
+ *
+ * ```
+ * offset = 2
+ * 0x000000990000FF000000; <- Size = 10 (initially 8)
+ *               └-- Post-offset
+ *
+ * offset = -2
+ * 0x0000FF990000; <- Size = 6 (initially 8)
+ *       └-- Post-offset
+ * ```
+ *
+ * **`preOffset`** — the cursor is moved to the right of the pre-offset — i.e. where the wrapped type started — by the provided offset. A negative offset moves it to the left of the pre-offset instead.
+ *
+ * ```
+ * offset = 2
+ * 0x0000009900FF0000;
+ *         |   └-- Post-offset = Pre-offset + 2
+ *         └-- Pre-offset
+ *
+ * offset = -2
+ * 0x00FF009900000000;
+ *     |   └-- Pre-offset
+ *     └-- Post-offset = Pre-offset - 2
+ * ```
+ *
+ * > [!IMPORTANT]
+ * > Some type nodes affect the buffer that is available to us: depending on where we are in the type tree, we may not have access to the entire buffer.
+ * > For instance, inside a `fixedSizeTypeNode`, the buffer is truncated or padded to match the provided fixed size once the wrapped content has been serialised — we are essentially "boxed" into a sub-buffer, and that sub-buffer is the one affected by the `absolute` strategy.
+ * > The type nodes that create sub-buffers are: `fixedSizeTypeNode`, `sentinelTypeNode`, and `sizePrefixTypeNode`.
+ */
 export interface PostOffsetTypeNode<TType extends TypeNode = TypeNode> {
     readonly kind: 'postOffsetTypeNode';
 

--- a/packages/node-types/src/generated/typeNodes/PreOffsetTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/PreOffsetTypeNode.ts
@@ -1,7 +1,59 @@
 import type { PreOffsetStrategy } from '../shared/preOffsetStrategy';
 import type { TypeNode } from './TypeNode';
 
-/** Before serialising the wrapped type, advance the cursor by `offset` bytes interpreted via the chosen strategy. */
+/**
+ * Before serialising the wrapped type, advance the cursor by `offset` bytes interpreted via the chosen strategy.
+ *
+ * Since the offset is applied _before_ the wrapped type runs, this node is useful to move the encoded value of the wrapped type itself. See `postOffsetTypeNode` for the opposite behaviour.
+ *
+ * The strategies below are illustrated against the following buffer: the `99` byte represents some previously encoded value for reference and the `FF` byte represents the encoded value of the wrapped type, which moves as its pre-offset changes.
+ *
+ * ```
+ * 0x00000099FF000000;
+ *           └-- Initial pre-offset
+ * ```
+ *
+ * **`relative`** — the cursor is moved to the right by the provided offset. A negative offset moves it to the left instead.
+ *
+ * ```
+ * offset = 2
+ * 0x000000990000FF00;
+ *               └-- Pre-offset
+ *
+ * offset = -2
+ * 0x0000FF9900000000;
+ *       └-- Pre-offset
+ * ```
+ *
+ * **`absolute`** — the cursor is moved to an absolute position in the buffer. A negative offset moves it backwards from the end of the buffer.
+ *
+ * ```
+ * offset = 0
+ * 0xFF00009900000000;
+ *   └-- Pre-offset
+ *
+ * offset = -2
+ * 0x000000990000FF00;
+ *               └-- Pre-offset
+ * ```
+ *
+ * **`padded`** — the cursor is moved to the right by the provided offset **and the buffer size is increased** by the offset amount, allowing padding bytes to be added. Reciprocally, a negative offset moves the cursor to the left and decreases the buffer size.
+ *
+ * ```
+ * offset = 2
+ * 0x000000990000FF000000; <- Size = 10 (initially 8)
+ *               └-- Pre-offset
+ *
+ * offset = -2
+ * 0x0000FF990000; <- Size = 6 (initially 8)
+ *       └-- Pre-offset
+ * ```
+ *
+ * > [!IMPORTANT]
+ * > Some type nodes affect the buffer that is available to us: depending on where we are in the type tree, we may not have access to the entire buffer.
+ * > For instance, inside a `fixedSizeTypeNode`, the buffer is truncated or padded to match the provided fixed size once the wrapped content has been serialised — we are essentially "boxed" into a sub-buffer, and that sub-buffer is the one affected by the `absolute` strategy.
+ * > The type nodes that create sub-buffers are: `fixedSizeTypeNode`, `sentinelTypeNode`, and `sizePrefixTypeNode`.
+ */
 export interface PreOffsetTypeNode<TType extends TypeNode = TypeNode> {
     readonly kind: 'preOffsetTypeNode';
 

--- a/packages/node-types/src/generated/typeNodes/SentinelTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/SentinelTypeNode.ts
@@ -1,7 +1,14 @@
 import type { ConstantValueNode } from '../valueNodes/ConstantValueNode';
 import type { TypeNode } from './TypeNode';
 
-/** Wraps another type and delimits it with a constant sentinel value written immediately after the wrapped type. */
+/**
+ * Wraps another type and delimits it with a constant sentinel value written immediately after the wrapped type.
+ *
+ * When decoding, the wrapped type is decoded until the sentinel value is encountered, at which point decoding stops and the sentinel is discarded.
+ *
+ * > [!IMPORTANT]
+ * > For this node to work, the sentinel value must never occur within the encoded bytes of the wrapped type.
+ */
 export interface SentinelTypeNode<
     TType extends TypeNode = TypeNode,
     TSentinel extends ConstantValueNode = ConstantValueNode,

--- a/packages/node-types/src/generated/typeNodes/SizePrefixTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/SizePrefixTypeNode.ts
@@ -2,7 +2,10 @@ import type { NestedTypeNode } from './NestedTypeNode';
 import type { NumberTypeNode } from './NumberTypeNode';
 import type { TypeNode } from './TypeNode';
 
-/** Wraps another type with a numeric prefix indicating the byte length of the wrapped type. */
+/**
+ * Wraps another type with a numeric prefix indicating the byte length of the wrapped type.
+ * When decoding, the size is read first and determines how many bytes the wrapped type may consume.
+ */
 export interface SizePrefixTypeNode<
     TType extends TypeNode = TypeNode,
     TPrefix extends NestedTypeNode<NumberTypeNode> = NestedTypeNode<NumberTypeNode>,

--- a/packages/node-types/src/generated/typeNodes/SolAmountTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/SolAmountTypeNode.ts
@@ -1,7 +1,10 @@
 import type { NestedTypeNode } from './NestedTypeNode';
 import type { NumberTypeNode } from './NumberTypeNode';
 
-/** A SOL amount expressed in lamports under the wrapped numeric type. */
+/**
+ * A SOL amount expressed in lamports under the wrapped numeric type.
+ * Equivalent to an `amountTypeNode` with 9 decimals and `SOL` as the unit.
+ */
 export interface SolAmountTypeNode<TNumber extends NestedTypeNode<NumberTypeNode> = NestedTypeNode<NumberTypeNode>> {
     readonly kind: 'solAmountTypeNode';
 

--- a/packages/node-types/src/generated/typeNodes/ZeroableOptionTypeNode.ts
+++ b/packages/node-types/src/generated/typeNodes/ZeroableOptionTypeNode.ts
@@ -9,7 +9,7 @@ export interface ZeroableOptionTypeNode<
     readonly kind: 'zeroableOptionTypeNode';
 
     // Children.
-    /** The type carried by the option when present. */
+    /** The type carried by the option when present. Must be of fixed size. */
     readonly item: TItem;
     /** The constant value that signals absence. When omitted, the all-zero byte pattern of the item type is used. */
     readonly zeroValue?: TZeroValue;

--- a/packages/node-types/src/generated/valueNodes/EnumValueNode.ts
+++ b/packages/node-types/src/generated/valueNodes/EnumValueNode.ts
@@ -14,7 +14,10 @@ export interface EnumValueNode<
     readonly variant: CamelCaseString;
 
     // Children.
-    /** A link to the defined enum type the value belongs to. */
+    /**
+     * A link to the defined enum type the value belongs to.
+     * The linked defined type must contain an `enumTypeNode`.
+     */
     readonly enum: TEnum;
     /**
      * The variant payload — a struct value for struct variants or a tuple value for tuple variants.

--- a/packages/node-types/src/generated/valueNodes/MapEntryValueNode.ts
+++ b/packages/node-types/src/generated/valueNodes/MapEntryValueNode.ts
@@ -1,6 +1,9 @@
 import type { ValueNode } from './ValueNode';
 
-/** A single (key, value) pair inside a `mapValueNode`. */
+/**
+ * A single (key, value) pair inside a `mapValueNode`.
+ * For example, the map `{ total: 42 }` has one entry whose key is the string `"total"` and whose value is the number `42`.
+ */
 export interface MapEntryValueNode<TKey extends ValueNode = ValueNode, TValue extends ValueNode = ValueNode> {
     readonly kind: 'mapEntryValueNode';
 

--- a/packages/node-types/src/generated/valueNodes/NoneValueNode.ts
+++ b/packages/node-types/src/generated/valueNodes/NoneValueNode.ts
@@ -1,4 +1,7 @@
-/** The "absent" value for an optional type. */
+/**
+ * The "absent" value for an optional type.
+ * For instance, this can be set as the default value of a field whose type is an `optionTypeNode`.
+ */
 export interface NoneValueNode {
     readonly kind: 'noneValueNode';
 }

--- a/packages/node-types/src/generated/valueNodes/PublicKeyValueNode.ts
+++ b/packages/node-types/src/generated/valueNodes/PublicKeyValueNode.ts
@@ -1,6 +1,6 @@
 import type { CamelCaseString } from '../../brands';
 
-/** A concrete public key, with an optional symbolic identifier for the address. */
+/** A concrete 32-byte public key, with an optional symbolic identifier for the address. */
 export interface PublicKeyValueNode {
     readonly kind: 'publicKeyValueNode';
 

--- a/packages/node-types/src/generated/valueNodes/SomeValueNode.ts
+++ b/packages/node-types/src/generated/valueNodes/SomeValueNode.ts
@@ -1,6 +1,9 @@
 import type { ValueNode } from './ValueNode';
 
-/** The "present" value for an optional type, wrapping a concrete value node. */
+/**
+ * The "present" value for an optional type, wrapping a concrete value node.
+ * For instance, this can be set as the default value of a field whose type is an `optionTypeNode`.
+ */
 export interface SomeValueNode<TValue extends ValueNode = ValueNode> {
     readonly kind: 'someValueNode';
 

--- a/packages/nodes/src/generated/AccountNode.ts
+++ b/packages/nodes/src/generated/AccountNode.ts
@@ -12,7 +12,11 @@ export type AccountNodeInput<
     readonly docs?: DocsInput;
 };
 
-/** An on-chain account: its name, data structure, optional fixed size, optional PDA, and optional discriminators. */
+/**
+ * An on-chain account: its name, data structure, optional fixed size, optional PDA, and optional discriminators.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/77974dad-212e-49b1-8e41-5d466c273a02)
+ */
 export function accountNode<
     const TData extends NestedTypeNode<StructTypeNode> = StructTypeNode<[]>,
     const TPda extends PdaLinkNode | undefined = undefined,

--- a/packages/nodes/src/generated/DefinedTypeNode.ts
+++ b/packages/nodes/src/generated/DefinedTypeNode.ts
@@ -10,7 +10,11 @@ export type DefinedTypeNodeInput<TType extends TypeNode = TypeNode> = Omit<
     readonly docs?: DocsInput;
 };
 
-/** A reusable named type that can be referenced by `definedTypeLinkNode` from elsewhere in the IDL. */
+/**
+ * A reusable named type that can be referenced by `definedTypeLinkNode` from elsewhere in the IDL.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/6049cf77-9a70-4915-8276-dd571d2f8828)
+ */
 export function definedTypeNode<const TType extends TypeNode>(
     input: DefinedTypeNodeInput<TType>,
 ): DefinedTypeNode<TType> {

--- a/packages/nodes/src/generated/ErrorNode.ts
+++ b/packages/nodes/src/generated/ErrorNode.ts
@@ -7,7 +7,11 @@ export type ErrorNodeInput = Omit<ErrorNode, 'docs' | 'kind' | 'name'> & {
     readonly docs?: DocsInput;
 };
 
-/** A program error — a numeric code paired with a name and human-readable message. */
+/**
+ * A program error — a numeric code paired with a name and human-readable message.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/0bde98ea-0327-404b-bf38-137d105826b0)
+ */
 export function errorNode(input: ErrorNodeInput): ErrorNode {
     const parsedDocs = parseDocs(input.docs);
     return Object.freeze({

--- a/packages/nodes/src/generated/InstructionAccountNode.ts
+++ b/packages/nodes/src/generated/InstructionAccountNode.ts
@@ -16,7 +16,11 @@ export type InstructionAccountNodeInput<
     readonly docs?: DocsInput;
 };
 
-/** An account participating in an instruction, with its name, signing/writability flags, and an optional default value. */
+/**
+ * An account participating in an instruction, with its name, signing/writability flags, and an optional default value.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/4656a08b-2f89-49c2-b428-5378cb1a0b9e)
+ */
 export function instructionAccountNode<
     const TDefaultValue extends InstructionInputValueNode | undefined = undefined,
     const TAccountLink extends AccountLinkNode | undefined = undefined,

--- a/packages/nodes/src/generated/InstructionArgumentNode.ts
+++ b/packages/nodes/src/generated/InstructionArgumentNode.ts
@@ -16,7 +16,12 @@ export type InstructionArgumentNodeInput<
     readonly docs?: DocsInput;
 };
 
-/** A named argument of an instruction, with its type and an optional default value. */
+/**
+ * A named argument of an instruction, with its type and an optional default value.
+ * Serialised next to each other, the arguments of an instruction form its data.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/7e2def82-949a-4663-bdc3-ac599d39d2d2)
+ */
 export function instructionArgumentNode<
     const TDefaultValue extends InstructionInputValueNode | undefined = undefined,
     const TType extends TypeNode = TypeNode,

--- a/packages/nodes/src/generated/InstructionByteDeltaNode.ts
+++ b/packages/nodes/src/generated/InstructionByteDeltaNode.ts
@@ -2,7 +2,10 @@ import type { InstructionByteDeltaNode, InstructionByteDeltaValue } from '@codam
 
 import { isNode } from '../Node';
 
-/** A byte-size delta applied when computing rent or buffer size — typically used by instructions that resize accounts. */
+/**
+ * A byte-size delta applied when computing rent or buffer size — typically used by instructions that resize accounts.
+ * For instance, if an instruction creates a new account of 42 bytes, this node can carry that information, enabling clients to allocate the right amount of lamports to cover the cost of executing the instruction.
+ */
 export function instructionByteDeltaNode<const TValue extends InstructionByteDeltaValue>(
     value: TValue,
     options: {

--- a/packages/nodes/src/generated/InstructionByteDeltaValue.ts
+++ b/packages/nodes/src/generated/InstructionByteDeltaValue.ts
@@ -1,4 +1,7 @@
-/** The value forms accepted by an `instructionByteDeltaNode`. */
+/**
+ * The value forms accepted by an `instructionByteDeltaNode`.
+ * An `accountLinkNode` uses the size of the linked account; an `argumentValueNode` uses the value of the referenced instruction argument; a `numberValueNode` uses that explicit number; and a `resolverValueNode` acts as a fallback for more complex values.
+ */
 export const INSTRUCTION_BYTE_DELTA_VALUE_KINDS = [
     'accountLinkNode' as const,
     'argumentValueNode' as const,

--- a/packages/nodes/src/generated/InstructionNode.ts
+++ b/packages/nodes/src/generated/InstructionNode.ts
@@ -49,7 +49,11 @@ export type InstructionNodeInput<
     readonly docs?: DocsInput;
 };
 
-/** A program instruction: its accounts, arguments, byte-delta hints, discriminators, optional status, and optional sub-instructions. */
+/**
+ * A program instruction: its accounts, arguments, byte-delta hints, discriminators, optional status, and optional sub-instructions.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/0d8edced-cfa4-4500-b80c-ebc56181a338)
+ */
 export function instructionNode<
     const TAccounts extends Array<InstructionAccountNode> | undefined = [],
     const TArguments extends Array<InstructionArgumentNode> | undefined = [],

--- a/packages/nodes/src/generated/InstructionRemainingAccountsValue.ts
+++ b/packages/nodes/src/generated/InstructionRemainingAccountsValue.ts
@@ -1,2 +1,5 @@
-/** The value forms accepted by an `instructionRemainingAccountsNode`. */
+/**
+ * The value forms accepted by an `instructionRemainingAccountsNode`.
+ * An `argumentValueNode` represents the array of accounts as a new argument of the provided name; a `resolverValueNode` acts as a fallback for more complex scenarios.
+ */
 export const INSTRUCTION_REMAINING_ACCOUNTS_VALUE_KINDS = ['argumentValueNode' as const, 'resolverValueNode' as const];

--- a/packages/nodes/src/generated/InstructionStatusNode.ts
+++ b/packages/nodes/src/generated/InstructionStatusNode.ts
@@ -1,6 +1,9 @@
 import type { InstructionLifecycle, InstructionStatusNode } from '@codama/node-types';
 
-/** The lifecycle stage of an instruction (draft, live, deprecated, archived) with an optional accompanying message. */
+/**
+ * The lifecycle stage of an instruction (draft, live, deprecated, archived) with an optional accompanying message.
+ * An instruction without a status is considered live — a status node is typically only attached to signal another stage.
+ */
 export function instructionStatusNode(lifecycle: InstructionLifecycle, message?: string): InstructionStatusNode {
     return Object.freeze({
         kind: 'instructionStatusNode',

--- a/packages/nodes/src/generated/PdaNode.ts
+++ b/packages/nodes/src/generated/PdaNode.ts
@@ -10,7 +10,11 @@ export type PdaNodeInput<TSeeds extends Array<PdaSeedNode> | undefined = Array<P
     readonly docs?: DocsInput;
 };
 
-/** A program-derived address: its name, optional program ID override, and the seeds used to derive it. */
+/**
+ * A program-derived address: its name, optional program ID override, and the seeds used to derive it.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/4f7c9718-1ffa-4f2c-aa45-71b3ce204219)
+ */
 export function pdaNode<const TSeeds extends Array<PdaSeedNode> | undefined>(
     input: PdaNodeInput<TSeeds>,
 ): PdaNode<TSeeds> {

--- a/packages/nodes/src/generated/ProgramNode.ts
+++ b/packages/nodes/src/generated/ProgramNode.ts
@@ -28,7 +28,11 @@ export type ProgramNodeInput<
     readonly publicKey: ProgramNode['publicKey'];
 };
 
-/** A Solana program: its identity, version, accounts, instructions, defined types, PDAs, events, errors, and constants. */
+/**
+ * A Solana program: its identity, version, accounts, instructions, defined types, PDAs, events, errors, and constants.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/37ec38ea-66df-4c08-81c3-822ef4388580)
+ */
 export function programNode<
     const TPdas extends Array<PdaNode> | undefined = [],
     const TAccounts extends Array<AccountNode> | undefined = [],

--- a/packages/nodes/src/generated/RootNode.ts
+++ b/packages/nodes/src/generated/RootNode.ts
@@ -5,6 +5,8 @@ import { CODAMA_VERSION } from './codamaVersion';
 /**
  * The root of a Codama IDL document.
  * Pairs a primary program with any number of additional programs and tags the document with the spec version.
+ *
+ * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/96c43c75-5925-4b6b-a1e0-8b8c61317cfe)
  */
 export function rootNode<
     const TProgram extends ProgramNode,

--- a/packages/nodes/src/generated/codamaVersion.ts
+++ b/packages/nodes/src/generated/codamaVersion.ts
@@ -8,4 +8,4 @@ import type { CodamaVersion } from '@codama/node-types';
  * that need to compare an IDL document's `version` against the spec
  * shape `@codama/nodes` understands.
  */
-export const CODAMA_VERSION: CodamaVersion = '1.8.0';
+export const CODAMA_VERSION: CodamaVersion = '1.9.1';

--- a/packages/nodes/src/generated/contextualValueNodes/IdentityValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/IdentityValueNode.ts
@@ -1,6 +1,10 @@
 import type { IdentityValueNode } from '@codama/node-types';
 
-/** Refers to the wallet identity providing the instruction context. */
+/**
+ * Refers to the wallet identity providing the instruction context — the main wallet that should own things.
+ * For instance, in a web application the identity would be the connected wallet; in a terminal, the wallet identified by `solana address`.
+ * A similar node exists for the main wallet that should pay for things — `payerValueNode`. In practice the identity and the payer are often the same, but offering the distinction can be useful should they differ.
+ */
 export function identityValueNode(): IdentityValueNode {
     return Object.freeze({
         kind: 'identityValueNode',

--- a/packages/nodes/src/generated/contextualValueNodes/PayerValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/PayerValueNode.ts
@@ -1,6 +1,10 @@
 import type { PayerValueNode } from '@codama/node-types';
 
-/** Refers to the wallet paying for the surrounding transaction. */
+/**
+ * Refers to the wallet paying for the surrounding transaction — the main wallet that should pay for things, such as rent for account storage.
+ * For instance, in a web application the payer would be the connected wallet; in a terminal, the wallet identified by `solana address`.
+ * A similar node exists for the main wallet that should own things — `identityValueNode`. In practice the identity and the payer are often the same, but offering the distinction can be useful should they differ.
+ */
 export function payerValueNode(): PayerValueNode {
     return Object.freeze({
         kind: 'payerValueNode',

--- a/packages/nodes/src/generated/contextualValueNodes/ProgramIdValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/ProgramIdValueNode.ts
@@ -1,6 +1,6 @@
 import type { ProgramIdValueNode } from '@codama/node-types';
 
-/** Refers to the program ID of the surrounding instruction. */
+/** Refers to the program ID of the surrounding instruction — that is, the address of the `programNode` this node descends from. */
 export function programIdValueNode(): ProgramIdValueNode {
     return Object.freeze({
         kind: 'programIdValueNode',

--- a/packages/nodes/src/generated/contextualValueNodes/ResolverValueNode.ts
+++ b/packages/nodes/src/generated/contextualValueNodes/ResolverValueNode.ts
@@ -5,6 +5,7 @@ import { camelCase, DocsInput, parseDocs } from '../../shared';
 /**
  * A custom resolver: a named function provided by the consumer that produces a value.
  * May optionally depend on other accounts and arguments resolved at instruction-build time.
+ * This node acts as a fallback for any value or logic that cannot easily be described by the other nodes — renderers treat resolvers as functions that can be injected into the generated code.
  */
 export function resolverValueNode<const TDependsOn extends Array<ResolverDependency> | undefined = undefined>(
     name: string,

--- a/packages/nodes/src/generated/countNodes/FixedCountNode.ts
+++ b/packages/nodes/src/generated/countNodes/FixedCountNode.ts
@@ -1,6 +1,9 @@
 import type { FixedCountNode } from '@codama/node-types';
 
-/** A count strategy that fixes the number of items at a constant value. */
+/**
+ * A count strategy that fixes the number of items at a constant value.
+ * This enables nodes such as `arrayTypeNode` to represent collections of a fixed length.
+ */
 export function fixedCountNode(value: number): FixedCountNode {
     return Object.freeze({
         kind: 'fixedCountNode',

--- a/packages/nodes/src/generated/countNodes/PrefixedCountNode.ts
+++ b/packages/nodes/src/generated/countNodes/PrefixedCountNode.ts
@@ -1,6 +1,9 @@
 import type { NestedTypeNode, NumberTypeNode, PrefixedCountNode } from '@codama/node-types';
 
-/** A count strategy where the number of items is read from a numeric prefix. */
+/**
+ * A count strategy where the number of items is read from a numeric prefix.
+ * This enables nodes such as `arrayTypeNode` to represent collections whose length is stored as a prefix.
+ */
 export function prefixedCountNode<const TPrefix extends NestedTypeNode<NumberTypeNode>>(
     prefix: TPrefix,
 ): PrefixedCountNode<TPrefix> {

--- a/packages/nodes/src/generated/countNodes/RemainderCountNode.ts
+++ b/packages/nodes/src/generated/countNodes/RemainderCountNode.ts
@@ -1,6 +1,10 @@
 import type { RemainderCountNode } from '@codama/node-types';
 
-/** A count strategy where items are read until the buffer is exhausted. */
+/**
+ * A count strategy where items are read until the buffer is exhausted.
+ * When encoding, items are serialised as-is and the total count is never stored; when decoding, items are read one by one until the end of the buffer.
+ * This strategy is therefore only meaningful for the last variable-size region of a buffer.
+ */
 export function remainderCountNode(): RemainderCountNode {
     return Object.freeze({
         kind: 'remainderCountNode',

--- a/packages/nodes/src/generated/typeNodes/AmountTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/AmountTypeNode.ts
@@ -2,7 +2,7 @@ import type { AmountTypeNode, NestedTypeNode, NumberTypeNode } from '@codama/nod
 
 /**
  * Wraps a number type to provide additional context such as decimal places and a unit.
- * Useful for amounts representing financial values.
+ * Particularly useful for representing financial values as integers, since floating-point numbers are notoriously unsafe for that purpose.
  */
 export function amountTypeNode<const TNumber extends NestedTypeNode<NumberTypeNode>>(
     number: TNumber,

--- a/packages/nodes/src/generated/typeNodes/BooleanTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/BooleanTypeNode.ts
@@ -2,7 +2,10 @@ import type { BooleanTypeNode, NestedTypeNode, NumberTypeNode } from '@codama/no
 
 import { numberTypeNode } from './NumberTypeNode';
 
-/** A boolean serialised as a numeric value. The wrapped number type determines the byte width. */
+/**
+ * A boolean serialised as a numeric value. The wrapped number type determines the byte width.
+ * A decoded number of `1` yields `true`; any other value yields `false`.
+ */
 export function booleanTypeNode<const TSize extends NestedTypeNode<NumberTypeNode> = NumberTypeNode<'u8'>>(
     size: TSize = numberTypeNode('u8') as NumberTypeNode<'u8'> as TSize,
 ): BooleanTypeNode<TSize> {

--- a/packages/nodes/src/generated/typeNodes/HiddenPrefixTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/HiddenPrefixTypeNode.ts
@@ -1,6 +1,9 @@
 import type { ConstantValueNode, HiddenPrefixTypeNode, TypeNode } from '@codama/node-types';
 
-/** Prefixes another type with a list of constant values that are written and read but not surfaced as fields to consumers. */
+/**
+ * Prefixes another type with a list of constant values that are written and read but not surfaced as fields to consumers.
+ * When decoding, the prefixed constants are consumed and checked against their expected values before being discarded.
+ */
 export function hiddenPrefixTypeNode<
     const TType extends TypeNode,
     const TPrefix extends Array<ConstantValueNode> | undefined,

--- a/packages/nodes/src/generated/typeNodes/HiddenSuffixTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/HiddenSuffixTypeNode.ts
@@ -1,6 +1,9 @@
 import type { ConstantValueNode, HiddenSuffixTypeNode, TypeNode } from '@codama/node-types';
 
-/** Suffixes another type with a list of constant values that are written and read but not surfaced as fields to consumers. */
+/**
+ * Suffixes another type with a list of constant values that are written and read but not surfaced as fields to consumers.
+ * When decoding, the suffixed constants are consumed and checked against their expected values before being discarded.
+ */
 export function hiddenSuffixTypeNode<
     const TType extends TypeNode,
     const TSuffix extends Array<ConstantValueNode> | undefined,

--- a/packages/nodes/src/generated/typeNodes/MapTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/MapTypeNode.ts
@@ -3,6 +3,7 @@ import type { CountNode, MapTypeNode, TypeNode } from '@codama/node-types';
 /**
  * A keyed map.
  * The key and value types are described by their respective type nodes; the entry count is determined by a count strategy.
+ * Entries are serialised one after the other, each key immediately followed by its value — e.g. key A, value A, key B, value B.
  */
 export function mapTypeNode<const TKey extends TypeNode, const TValue extends TypeNode, const TCount extends CountNode>(
     key: TKey,

--- a/packages/nodes/src/generated/typeNodes/PostOffsetTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/PostOffsetTypeNode.ts
@@ -1,6 +1,73 @@
 import type { PostOffsetStrategy, PostOffsetTypeNode, TypeNode } from '@codama/node-types';
 
-/** After serialising the wrapped type, advance the cursor by `offset` bytes interpreted via the chosen strategy. */
+/**
+ * After serialising the wrapped type, advance the cursor by `offset` bytes interpreted via the chosen strategy.
+ *
+ * Since the offset is applied _after_ the wrapped type runs, this node is useful to move the cursor around once the wrapped type has been processed. See `preOffsetTypeNode` for the opposite behaviour.
+ *
+ * The strategies below are illustrated against the following buffer: the `99` byte represents the encoded value of the wrapped type and the `FF` byte represents the next bytes to be encoded after it, in order to show the _post_ cursor position.
+ *
+ * ```
+ * 0x00000099FF000000;
+ *         | └-- Initial post-offset
+ *         └-- Pre-offset
+ * ```
+ *
+ * **`relative`** — the cursor is moved to the right by the provided offset. A negative offset moves it to the left instead.
+ *
+ * ```
+ * offset = 2
+ * 0x000000990000FF00;
+ *               └-- Post-offset
+ *
+ * offset = -2
+ * 0x0000FF9900000000;
+ *       └-- Post-offset
+ * ```
+ *
+ * **`absolute`** — the cursor is moved to an absolute position in the buffer. A negative offset moves it backwards from the end of the buffer.
+ *
+ * ```
+ * offset = 0
+ * 0xFF00009900000000;
+ *   └-- Post-offset
+ *
+ * offset = -2
+ * 0x000000990000FF00;
+ *               └-- Post-offset
+ * ```
+ *
+ * **`padded`** — the cursor is moved to the right by the provided offset **and the buffer size is increased** by the offset amount, allowing padding bytes to be added. Reciprocally, a negative offset moves the cursor to the left and decreases the buffer size.
+ *
+ * ```
+ * offset = 2
+ * 0x000000990000FF000000; <- Size = 10 (initially 8)
+ *               └-- Post-offset
+ *
+ * offset = -2
+ * 0x0000FF990000; <- Size = 6 (initially 8)
+ *       └-- Post-offset
+ * ```
+ *
+ * **`preOffset`** — the cursor is moved to the right of the pre-offset — i.e. where the wrapped type started — by the provided offset. A negative offset moves it to the left of the pre-offset instead.
+ *
+ * ```
+ * offset = 2
+ * 0x0000009900FF0000;
+ *         |   └-- Post-offset = Pre-offset + 2
+ *         └-- Pre-offset
+ *
+ * offset = -2
+ * 0x00FF009900000000;
+ *     |   └-- Pre-offset
+ *     └-- Post-offset = Pre-offset - 2
+ * ```
+ *
+ * > [!IMPORTANT]
+ * > Some type nodes affect the buffer that is available to us: depending on where we are in the type tree, we may not have access to the entire buffer.
+ * > For instance, inside a `fixedSizeTypeNode`, the buffer is truncated or padded to match the provided fixed size once the wrapped content has been serialised — we are essentially "boxed" into a sub-buffer, and that sub-buffer is the one affected by the `absolute` strategy.
+ * > The type nodes that create sub-buffers are: `fixedSizeTypeNode`, `sentinelTypeNode`, and `sizePrefixTypeNode`.
+ */
 export function postOffsetTypeNode<const TType extends TypeNode>(
     type: TType,
     offset: number,

--- a/packages/nodes/src/generated/typeNodes/PreOffsetTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/PreOffsetTypeNode.ts
@@ -1,6 +1,58 @@
 import type { PreOffsetStrategy, PreOffsetTypeNode, TypeNode } from '@codama/node-types';
 
-/** Before serialising the wrapped type, advance the cursor by `offset` bytes interpreted via the chosen strategy. */
+/**
+ * Before serialising the wrapped type, advance the cursor by `offset` bytes interpreted via the chosen strategy.
+ *
+ * Since the offset is applied _before_ the wrapped type runs, this node is useful to move the encoded value of the wrapped type itself. See `postOffsetTypeNode` for the opposite behaviour.
+ *
+ * The strategies below are illustrated against the following buffer: the `99` byte represents some previously encoded value for reference and the `FF` byte represents the encoded value of the wrapped type, which moves as its pre-offset changes.
+ *
+ * ```
+ * 0x00000099FF000000;
+ *           └-- Initial pre-offset
+ * ```
+ *
+ * **`relative`** — the cursor is moved to the right by the provided offset. A negative offset moves it to the left instead.
+ *
+ * ```
+ * offset = 2
+ * 0x000000990000FF00;
+ *               └-- Pre-offset
+ *
+ * offset = -2
+ * 0x0000FF9900000000;
+ *       └-- Pre-offset
+ * ```
+ *
+ * **`absolute`** — the cursor is moved to an absolute position in the buffer. A negative offset moves it backwards from the end of the buffer.
+ *
+ * ```
+ * offset = 0
+ * 0xFF00009900000000;
+ *   └-- Pre-offset
+ *
+ * offset = -2
+ * 0x000000990000FF00;
+ *               └-- Pre-offset
+ * ```
+ *
+ * **`padded`** — the cursor is moved to the right by the provided offset **and the buffer size is increased** by the offset amount, allowing padding bytes to be added. Reciprocally, a negative offset moves the cursor to the left and decreases the buffer size.
+ *
+ * ```
+ * offset = 2
+ * 0x000000990000FF000000; <- Size = 10 (initially 8)
+ *               └-- Pre-offset
+ *
+ * offset = -2
+ * 0x0000FF990000; <- Size = 6 (initially 8)
+ *       └-- Pre-offset
+ * ```
+ *
+ * > [!IMPORTANT]
+ * > Some type nodes affect the buffer that is available to us: depending on where we are in the type tree, we may not have access to the entire buffer.
+ * > For instance, inside a `fixedSizeTypeNode`, the buffer is truncated or padded to match the provided fixed size once the wrapped content has been serialised — we are essentially "boxed" into a sub-buffer, and that sub-buffer is the one affected by the `absolute` strategy.
+ * > The type nodes that create sub-buffers are: `fixedSizeTypeNode`, `sentinelTypeNode`, and `sizePrefixTypeNode`.
+ */
 export function preOffsetTypeNode<const TType extends TypeNode>(
     type: TType,
     offset: number,

--- a/packages/nodes/src/generated/typeNodes/SentinelTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/SentinelTypeNode.ts
@@ -1,6 +1,13 @@
 import type { ConstantValueNode, SentinelTypeNode, TypeNode } from '@codama/node-types';
 
-/** Wraps another type and delimits it with a constant sentinel value written immediately after the wrapped type. */
+/**
+ * Wraps another type and delimits it with a constant sentinel value written immediately after the wrapped type.
+ *
+ * When decoding, the wrapped type is decoded until the sentinel value is encountered, at which point decoding stops and the sentinel is discarded.
+ *
+ * > [!IMPORTANT]
+ * > For this node to work, the sentinel value must never occur within the encoded bytes of the wrapped type.
+ */
 export function sentinelTypeNode<const TType extends TypeNode, const TSentinel extends ConstantValueNode>(
     type: TType,
     sentinel: TSentinel,

--- a/packages/nodes/src/generated/typeNodes/SizePrefixTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/SizePrefixTypeNode.ts
@@ -1,6 +1,9 @@
 import type { NestedTypeNode, NumberTypeNode, SizePrefixTypeNode, TypeNode } from '@codama/node-types';
 
-/** Wraps another type with a numeric prefix indicating the byte length of the wrapped type. */
+/**
+ * Wraps another type with a numeric prefix indicating the byte length of the wrapped type.
+ * When decoding, the size is read first and determines how many bytes the wrapped type may consume.
+ */
 export function sizePrefixTypeNode<const TType extends TypeNode, const TPrefix extends NestedTypeNode<NumberTypeNode>>(
     type: TType,
     prefix: TPrefix,

--- a/packages/nodes/src/generated/typeNodes/SolAmountTypeNode.ts
+++ b/packages/nodes/src/generated/typeNodes/SolAmountTypeNode.ts
@@ -1,6 +1,9 @@
 import type { NestedTypeNode, NumberTypeNode, SolAmountTypeNode } from '@codama/node-types';
 
-/** A SOL amount expressed in lamports under the wrapped numeric type. */
+/**
+ * A SOL amount expressed in lamports under the wrapped numeric type.
+ * Equivalent to an `amountTypeNode` with 9 decimals and `SOL` as the unit.
+ */
 export function solAmountTypeNode<const TNumber extends NestedTypeNode<NumberTypeNode>>(
     number: TNumber,
 ): SolAmountTypeNode<TNumber> {

--- a/packages/nodes/src/generated/valueNodes/MapEntryValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/MapEntryValueNode.ts
@@ -1,6 +1,9 @@
 import type { MapEntryValueNode, ValueNode } from '@codama/node-types';
 
-/** A single (key, value) pair inside a `mapValueNode`. */
+/**
+ * A single (key, value) pair inside a `mapValueNode`.
+ * For example, the map `{ total: 42 }` has one entry whose key is the string `"total"` and whose value is the number `42`.
+ */
 export function mapEntryValueNode<const TKey extends ValueNode, const TValue extends ValueNode>(
     key: TKey,
     value: TValue,

--- a/packages/nodes/src/generated/valueNodes/NoneValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/NoneValueNode.ts
@@ -1,6 +1,9 @@
 import type { NoneValueNode } from '@codama/node-types';
 
-/** The "absent" value for an optional type. */
+/**
+ * The "absent" value for an optional type.
+ * For instance, this can be set as the default value of a field whose type is an `optionTypeNode`.
+ */
 export function noneValueNode(): NoneValueNode {
     return Object.freeze({
         kind: 'noneValueNode',

--- a/packages/nodes/src/generated/valueNodes/PublicKeyValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/PublicKeyValueNode.ts
@@ -2,7 +2,7 @@ import type { PublicKeyValueNode } from '@codama/node-types';
 
 import { camelCase } from '../../shared';
 
-/** A concrete public key, with an optional symbolic identifier for the address. */
+/** A concrete 32-byte public key, with an optional symbolic identifier for the address. */
 export function publicKeyValueNode(publicKey: string, identifier?: string): PublicKeyValueNode {
     return Object.freeze({
         kind: 'publicKeyValueNode',

--- a/packages/nodes/src/generated/valueNodes/SomeValueNode.ts
+++ b/packages/nodes/src/generated/valueNodes/SomeValueNode.ts
@@ -1,6 +1,9 @@
 import type { SomeValueNode, ValueNode } from '@codama/node-types';
 
-/** The "present" value for an optional type, wrapping a concrete value node. */
+/**
+ * The "present" value for an optional type, wrapping a concrete value node.
+ * For instance, this can be set as the default value of a field whose type is an `optionTypeNode`.
+ */
 export function someValueNode<const TValue extends ValueNode>(value: TValue): SomeValueNode<TValue> {
     return Object.freeze({
         kind: 'someValueNode',

--- a/packages/spec-generators/package.json
+++ b/packages/spec-generators/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@codama/fragments": "workspace:*",
-        "@codama/spec": "1.8.0"
+        "@codama/spec": "1.9.1"
     },
     "devDependencies": {
         "@types/node": "^26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,8 +328,8 @@ importers:
         specifier: workspace:*
         version: link:../fragments
       '@codama/spec':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.9.1
+        version: 1.9.1
     devDependencies:
       '@types/node':
         specifier: ^26
@@ -466,8 +466,8 @@ packages:
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
-  '@codama/spec@1.8.0':
-    resolution: {integrity: sha512-vHuEs0KzCWfpgjALrVywb3WgMfc08PWwIx6yUaB6g5pckv8shcrDBQJA2vyNKfc8BRYdX6fwogLhytpDgyyJ0Q==}
+  '@codama/spec@1.9.1':
+    resolution: {integrity: sha512-6GNKNt6zvxBBvtbokh1VwjTb09Kjc79a44Vt0v7Lk3Hq+ZaI5/uimk9F8bM1IlBuKhBPZmtrAON/X7QPSxqriA==}
     engines: {node: '>=22.12.0'}
 
   '@esbuild/aix-ppc64@0.27.0':
@@ -3393,7 +3393,7 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@codama/spec@1.8.0': {}
+  '@codama/spec@1.9.1': {}
 
   '@esbuild/aix-ppc64@0.27.0':
     optional: true


### PR DESCRIPTION
This PR bumps the pinned `@codama/spec` from 1.8.0 to 1.9.1 in `spec-generators` and regenerates `@codama/node-types` and `@codama/nodes` (`@codama/visitors-core` is untouched, as the 1.9.x spec releases are documentation-focused and do not affect the emitted visitor code). The regenerated output consists of enriched docblocks across the generated files plus the `CodamaVersion` literal moving to `1.9.1`, so new documents created via `rootNode()` are stamped with version `1.9.1`. This is Phase 0a of the v2 migration framework plan.