### PR TITLE
Verify generated output freshness in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Build and run tests
         run: pnpm test
 
+      - name: Regenerate output from the pinned @codama/spec
+        run: pnpm generate
+
       - name: Ensure working directory is clean
         run: |
           git status


### PR DESCRIPTION
This PR makes CI regenerate the spec-derived output before the tests job's existing "working directory is clean" check, so the committed generated files in `node-types`, `nodes`, and `visitors-core` can never silently drift from the pinned `@codama/spec` or from the generator code again. Exactly this drift happened between #1023 and now: the generate pipeline's lint step was broken (#1089) and nothing in CI would have caught it. The step runs after `pnpm test`, so every workspace dist the generator needs is already built, and the repaired pipeline from #1089 is idempotent, so a fresh clone regenerates byte-identical output.