### PR TITLE
Widen CodamaVersion to a major-pinned template literal

### DIFF
--- a/.changeset/social-bats-travel.md
+++ b/.changeset/social-bats-travel.md
@@ -1,0 +1,6 @@
+---
+'@codama/node-types': patch
+'@codama/nodes': patch
+---
+
+Widen the `CodamaVersion` type from the exact pinned literal (`'1.9.1'`) to a major-pinned template literal (`1.${number}.${number}`), so any document of the current spec major type-checks as a `RootNode` rather than only documents carrying the exact pinned version. Add a `getCodamaVersionMajor(version)` helper to `@codama/nodes` that defensively extracts the major from an arbitrary version string, returning `null` when it cannot be parsed.

--- a/packages/node-types/src/generated/shared/codamaVersion.ts
+++ b/packages/node-types/src/generated/shared/codamaVersion.ts
@@ -1,6 +1,6 @@
 /**
- * The Codama spec version this package describes. Pinned to the literal
- * version of the spec at generation time; documents conforming to this
- * version of the spec carry this exact string.
+ * The shape of Codama spec versions this package describes. Pinned to the
+ * spec major at generation time; documents conforming to any minor or patch
+ * of that major carry a string of this shape.
  */
-export type CodamaVersion = '1.9.1';
+export type CodamaVersion = `1.${number}.${number}`;

--- a/packages/nodes/src/shared/index.ts
+++ b/packages/nodes/src/shared/index.ts
@@ -1,2 +1,3 @@
 export * from './docs';
 export * from './stringCases';
+export * from './versions';

--- a/packages/nodes/src/shared/versions.ts
+++ b/packages/nodes/src/shared/versions.ts
@@ -1,0 +1,13 @@
+/**
+ * Extracts the major version from a Codama version string, e.g. `1` from
+ * `'1.9.1'` or `2` from `'2.0.0-rc.4'`.
+ *
+ * Defensive against arbitrary input — documents usually arrive as untrusted
+ * JSON — and returns `null` when no major version can be parsed, so callers
+ * decide how to fail. Useful for cross-major compatibility checks: two Codama
+ * versions are compatible if and only if their majors match.
+ */
+export function getCodamaVersionMajor(version: string): number | null {
+    const match = /^(\d+)\./.exec(version);
+    return match ? Number(match[1]) : null;
+}

--- a/packages/nodes/test/shared/versions.test.ts
+++ b/packages/nodes/test/shared/versions.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+
+import { getCodamaVersionMajor } from '../../src';
+
+describe('getCodamaVersionMajor', () => {
+    test('extracts the major from stable versions', () => {
+        expect(getCodamaVersionMajor('1.9.1')).toBe(1);
+        expect(getCodamaVersionMajor('2.0.0')).toBe(2);
+        expect(getCodamaVersionMajor('10.42.7')).toBe(10);
+        expect(getCodamaVersionMajor('0.21.3')).toBe(0);
+    });
+
+    test('extracts the major from pre-release versions', () => {
+        expect(getCodamaVersionMajor('2.0.0-rc.4')).toBe(2);
+        expect(getCodamaVersionMajor('1.6.0-rc.6')).toBe(1);
+    });
+
+    test('returns null when no major can be parsed', () => {
+        expect(getCodamaVersionMajor('')).toBeNull();
+        expect(getCodamaVersionMajor('not-a-version')).toBeNull();
+        expect(getCodamaVersionMajor('v1.0.0')).toBeNull();
+        expect(getCodamaVersionMajor('1')).toBeNull();
+        expect(getCodamaVersionMajor('.1.0')).toBeNull();
+    });
+});

--- a/packages/spec-generators/src/nodeTypes/fragments/codamaVersion.ts
+++ b/packages/spec-generators/src/nodeTypes/fragments/codamaVersion.ts
@@ -1,13 +1,20 @@
 import { type Fragment, fragment, getDocblockFragment } from '@codama/fragments/javascript';
 
 export function getCodamaVersionFragment(specVersion: string): Fragment {
+    const major = parseMajor(specVersion);
     const docblock = getDocblockFragment(
         [
-            'The Codama spec version this package describes. Pinned to the literal',
-            'version of the spec at generation time; documents conforming to this',
-            'version of the spec carry this exact string.',
+            'The shape of Codama spec versions this package describes. Pinned to the',
+            'spec major at generation time; documents conforming to any minor or patch',
+            'of that major carry a string of this shape.',
         ],
         { withLineJump: true },
     );
-    return fragment`${docblock}export type CodamaVersion = '${specVersion}';`;
+    return fragment`${docblock}export type CodamaVersion = \`${major}.\${number}.\${number}\`;`;
+}
+
+function parseMajor(specVersion: string): number {
+    const match = specVersion.match(/^(\d+)\./);
+    if (!match) throw new Error(`Cannot parse a major version from spec version "${specVersion}".`);
+    return Number(match[1]);
 }

--- a/packages/spec-generators/test/nodeTypes/fragments/codamaVersion.test.ts
+++ b/packages/spec-generators/test/nodeTypes/fragments/codamaVersion.test.ts
@@ -3,17 +3,31 @@ import { describe, expect, it } from 'vitest';
 import { getCodamaVersionFragment } from '../../../src/nodeTypes/fragments/codamaVersion';
 
 describe('getCodamaVersionFragment', () => {
-    it('emits a single-string literal type pinned to the supplied spec version', () => {
-        expect(getCodamaVersionFragment('1.0.0').content).toContain(`export type CodamaVersion = '1.0.0';`);
+    it('emits a major-pinned template-literal type derived from the supplied spec version', () => {
+        expect(getCodamaVersionFragment('1.9.1').content).toContain(
+            'export type CodamaVersion = `1.${number}.${number}`;',
+        );
     });
 
-    it('embeds the version verbatim, even when it is a rc tag', () => {
-        expect(getCodamaVersionFragment('1.0.0-rc.4').content).toContain(`export type CodamaVersion = '1.0.0-rc.4';`);
+    it('pins the major only, ignoring the minor and patch of the supplied version', () => {
+        expect(getCodamaVersionFragment('2.3.4').content).toContain(
+            'export type CodamaVersion = `2.${number}.${number}`;',
+        );
+    });
+
+    it('derives the major from pre-release spec versions too', () => {
+        expect(getCodamaVersionFragment('2.0.0-rc.4').content).toContain(
+            'export type CodamaVersion = `2.${number}.${number}`;',
+        );
+    });
+
+    it('throws when the spec version has no parsable major', () => {
+        expect(() => getCodamaVersionFragment('next')).toThrow('Cannot parse a major version');
     });
 
     it('prepends a JSDoc explaining what the alias means', () => {
         const out = getCodamaVersionFragment('1.0.0').content;
-        expect(out).toContain('The Codama spec version this package describes.');
+        expect(out).toContain('The shape of Codama spec versions this package describes.');
         // Multi-paragraph docs use the block-form `/** … */` with each
         // paragraph on its own ` * ` line.
         expect(out.startsWith('/**\n')).toBe(true);


### PR DESCRIPTION
This PR widens the generated `CodamaVersion` type from the exact pinned spec version (`'1.9.1'`) to a major-pinned template literal, `1.${number}.${number}`, derived from the spec major at generation time. The exact literal was dishonest: real v1 documents carry anything from `1.0.0` to `1.9.x`, yet only the pinned string type-checked as a `RootNode.version`. Pre-release versions are deliberately not covered by the type: if a future spec pin is an rc, the generated `CODAMA_VERSION` assignment fails the type-check loudly at generation time, and the policy is to stamp full release versions anyway. The `nodeTypes` fragment now parses the major defensively and throws on unparsable spec versions, with tests covering stable, pre-release, and malformed inputs. A new hand-written `getCodamaVersionMajor(version)` helper in `@codama/nodes` extracts the major from arbitrary version strings, returning `null` when unparsable, ready for reuse by the upcoming `validateCodamaVersion` fix, `@codama/upgrade`, and the CLI version-check visitor. This is Phase 1a of the v2 migration framework plan.