### PR TITLE
Validate document versions against the spec version, not the package version

### DIFF
--- a/.changeset/fancy-shrimps-exist.md
+++ b/.changeset/fancy-shrimps-exist.md
@@ -1,0 +1,6 @@
+---
+'codama': patch
+'@codama/errors': patch
+---
+
+Fix `validateCodamaVersion` to compare the document's version against the Codama spec version (`CODAMA_VERSION`) instead of the npm package version, which is an unrelated namespace and caused false mismatches whenever the two drifted apart. The function now accepts any string and narrows it to `CodamaVersion` on success, rejects unparsable versions, and no longer special-cases 0.x versions. The `CODAMA_ERROR__VERSION_MISMATCH` message is reworded accordingly.

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -125,7 +125,7 @@ export const CodamaErrorMessages: Readonly<{
     [CODAMA_ERROR__UNRECOGNIZED_NODE_KIND]: 'Unrecognized node kind [$kind].',
     [CODAMA_ERROR__UNRECOGNIZED_NUMBER_FORMAT]: 'Unrecognized number format [$format].',
     [CODAMA_ERROR__VERSION_MISMATCH]:
-        'The provided RootNode version [$rootVersion] is not compatible with the installed Codama version [$codamaVersion].',
+        'The provided RootNode version [$rootVersion] is not compatible with the Codama spec version [$codamaVersion] supported by the installed packages.',
     [CODAMA_ERROR__VISITORS__ACCOUNT_FIELD_NOT_FOUND]: 'Account [$name] does not have a field named [$missingField].',
     [CODAMA_ERROR__VISITORS__CANNOT_ADD_DUPLICATED_PDA_NAMES]:
         'Cannot add PDAs to program [$programName] because the following PDA names already exist [$duplicatedPdaNames].',

--- a/packages/library/src/codama.ts
+++ b/packages/library/src/codama.ts
@@ -1,6 +1,6 @@
 import { CODAMA_ERROR__VERSION_MISMATCH } from '@codama/errors';
 import { CodamaError } from '@codama/errors';
-import { assertIsNode, CodamaVersion, Node, RootNode } from '@codama/nodes';
+import { assertIsNode, CODAMA_VERSION, CodamaVersion, getCodamaVersionMajor, Node, RootNode } from '@codama/nodes';
 import { visit, Visitor } from '@codama/visitors';
 
 export interface Codama {
@@ -39,13 +39,19 @@ export function createFromJson(json: string): Codama {
     return createFromRoot(JSON.parse(json) as RootNode);
 }
 
-export function validateCodamaVersion(rootVersion: CodamaVersion): void {
-    const codamaVersion = __VERSION__;
-    if (rootVersion === codamaVersion) return;
-    const [rootMajor, rootMinor] = rootVersion.split('.').map(Number);
-    const [CodamaMajor, CodamaMinor] = codamaVersion.split('.').map(Number);
-    const isZeroMajor = rootMajor === 0 && CodamaMajor === 0;
-    if (isZeroMajor && rootMinor === CodamaMinor) return;
-    if (rootMajor === CodamaMajor) return;
+/**
+ * Asserts that a document version is compatible with the Codama spec version
+ * supported by the installed packages — i.e. that both share the same major —
+ * and narrows it to `CodamaVersion` accordingly.
+ *
+ * The document version is compared against the generated `CODAMA_VERSION`
+ * spec constant, not the npm package version: the two are unrelated
+ * namespaces. Accepts any string since documents usually arrive as
+ * untrusted JSON; unparsable versions are rejected.
+ */
+export function validateCodamaVersion(rootVersion: string): asserts rootVersion is CodamaVersion {
+    const codamaVersion = CODAMA_VERSION;
+    const rootMajor = getCodamaVersionMajor(rootVersion);
+    if (rootMajor !== null && rootMajor === getCodamaVersionMajor(codamaVersion)) return;
     throw new CodamaError(CODAMA_ERROR__VERSION_MISMATCH, { codamaVersion, rootVersion });
 }

--- a/packages/library/src/types/global.d.ts
+++ b/packages/library/src/types/global.d.ts
@@ -3,4 +3,3 @@ declare const __ESM__: boolean;
 declare const __NODEJS__: boolean;
 declare const __REACTNATIVE__: boolean;
 declare const __TEST__: boolean;
-declare const __VERSION__: string;

--- a/packages/library/test/index.test.ts
+++ b/packages/library/test/index.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from 'vitest';
 
 import {
+    CODAMA_ERROR__VERSION_MISMATCH,
     CODAMA_VERSION,
+    CodamaError,
     createFromJson,
     createFromRoot,
     getAllInstructions,
@@ -9,6 +11,7 @@ import {
     programNode,
     rootNode,
     rootNodeVisitor,
+    validateCodamaVersion,
     voidVisitor,
 } from '../src';
 
@@ -63,4 +66,40 @@ test('it reads an IDL that omits every array attribute without throwing (skip-wh
     expect(reserialised).toEqual(JSON.parse(json) as unknown);
     expect('accounts' in reserialised.program).toBe(false);
     expect('instructions' in reserialised.program).toBe(false);
+});
+
+test('it accepts document versions sharing the spec major, regardless of minor and patch', () => {
+    expect(() => validateCodamaVersion(CODAMA_VERSION)).not.toThrow();
+    expect(() => validateCodamaVersion('1.0.0')).not.toThrow();
+    expect(() => validateCodamaVersion('1.42.7')).not.toThrow();
+    expect(() => validateCodamaVersion('1.6.0-rc.6')).not.toThrow();
+});
+
+test('it rejects document versions from another spec major', () => {
+    expect(() => validateCodamaVersion('2.0.0')).toThrow(
+        new CodamaError(CODAMA_ERROR__VERSION_MISMATCH, { codamaVersion: CODAMA_VERSION, rootVersion: '2.0.0' }),
+    );
+    expect(() => validateCodamaVersion('0.21.3')).toThrow(
+        new CodamaError(CODAMA_ERROR__VERSION_MISMATCH, { codamaVersion: CODAMA_VERSION, rootVersion: '0.21.3' }),
+    );
+});
+
+test('it rejects unparsable document versions', () => {
+    expect(() => validateCodamaVersion('')).toThrow(
+        new CodamaError(CODAMA_ERROR__VERSION_MISMATCH, { codamaVersion: CODAMA_VERSION, rootVersion: '' }),
+    );
+    expect(() => validateCodamaVersion('not-a-version')).toThrow(
+        new CodamaError(CODAMA_ERROR__VERSION_MISMATCH, {
+            codamaVersion: CODAMA_VERSION,
+            rootVersion: 'not-a-version',
+        }),
+    );
+});
+
+test('it validates the document version when creating a Codama instance', () => {
+    const program = programNode({ name: 'myProgram', publicKey: '1111' });
+    expect(() => createFromRoot(rootNode(program))).not.toThrow();
+    expect(() => createFromRoot({ ...rootNode(program), version: '99.0.0' as typeof CODAMA_VERSION })).toThrow(
+        new CodamaError(CODAMA_ERROR__VERSION_MISMATCH, { codamaVersion: CODAMA_VERSION, rootVersion: '99.0.0' }),
+    );
 });


### PR DESCRIPTION
This PR fixes `validateCodamaVersion` in the `codama` library to compare the document's `RootNode.version` major against the generated `CODAMA_VERSION` spec constant from `@codama/nodes`, instead of `__VERSION__` (the npm package version, an unrelated namespace that happened to share majors so far). The function now accepts any string, since documents arrive as untrusted JSON, rejects unparsable versions via the `getCodamaVersionMajor` helper from #1093, and is an assertion function narrowing the input to `CodamaVersion` on success. The 0.x minor-as-major special case is dropped: the installed spec is 1.x, so any 0.x document throws exactly as before. The now-unused `__VERSION__` global declaration is removed from the library package, the `CODAMA_ERROR__VERSION_MISMATCH` message is reworded to name the spec version, and tests cover same-major acceptance (including historical rc stamps like `1.6.0-rc.6`), cross-major rejection, unparsable rejection, and the `createFromRoot` construction path. Pointing the error message at `@codama/upgrade` is deliberately deferred to Phase 2, when that package actually exists. This is Phase 1b of the v2 migration framework plan.