### PR TITLE
Add checkCodamaVersionVisitor and document the CLI upgrade pattern

### DIFF
--- a/.changeset/slow-doodles-carry.md
+++ b/.changeset/slow-doodles-carry.md
@@ -1,0 +1,5 @@
+---
+'@codama/visitors': minor
+---
+
+Add `checkCodamaVersionVisitor`. It checks the version of the visited Codama IDL against the Codama spec version supported by the installed packages, throwing a `CODAMA_ERROR__VERSION_MISMATCH` error when the majors differ. It is mainly useful at IDL-ingestion boundaries that bypass `createFromRoot`, such as a `before` visitor in a Codama CLI config.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -162,6 +162,19 @@ There are plenty of existing visitors that you can use in your Codama scripts. T
 
 The examples below show how to use some of these visitors in your configuration file. They make heavy use of the [`@codama/visitors`](https://github.com/codama-idl/codama/tree/main/packages/visitors/README.md) package which provides a large number of utility visitors.
 
+### Checking the IDL version
+
+Throws an error if the IDL's major version does not match the Codama spec version supported by your installed packages. The CLI otherwise accepts IDLs verbatim without any version checking, so this is best used as a `before` visitor to fail fast on incompatible IDLs.
+
+See [`checkCodamaVersionVisitor`](https://github.com/codama-idl/codama/tree/main/packages/visitors#checkcodamaversionvisitor)
+
+```json
+{
+    "idl": "program/idl.json",
+    "before": ["@codama/visitors#checkCodamaVersionVisitor"]
+}
+```
+
 ### Deleting nodes
 
 Returns a new IDL with the specified nodes removed.
@@ -236,5 +249,18 @@ In the example below, we rename the `vault` account to `safe` and update the `au
             }
         }
     ]
+}
+```
+
+### Upgrading legacy IDLs
+
+Returns a new IDL upgraded to the latest major version of the Codama standard. Since renderers and other visitors expect the latest version, this is best used as a `before` visitor so any older IDL is upgraded before everything else runs.
+
+See [`@codama/upgrade`](https://github.com/codama-idl/codama/tree/main/packages/upgrade)
+
+```json
+{
+    "idl": "program/idl.json",
+    "before": ["@codama/upgrade"]
 }
 ```

--- a/packages/visitors/README.md
+++ b/packages/visitors/README.md
@@ -72,6 +72,21 @@ codama.update(
 );
 ```
 
+### `checkCodamaVersionVisitor`
+
+This visitor checks that the version of the visited Codama IDL shares its major with the Codama spec version supported by the installed packages — mirroring the check performed by `createFromRoot` — and throws a `CODAMA_ERROR__VERSION_MISMATCH` error otherwise. The IDL is returned unchanged when the check passes.
+
+It is mainly useful at IDL-ingestion boundaries that bypass `createFromRoot`, such as the [Codama CLI](../cli) which otherwise accepts IDLs verbatim without any version checking. For instance, it can be used as a `before` visitor to fail fast on incompatible IDLs:
+
+```json
+{
+    "idl": "program/idl.json",
+    "before": ["@codama/visitors#checkCodamaVersionVisitor"]
+}
+```
+
+Note that older IDLs can be upgraded instead of rejected by using the [`@codama/upgrade`](../upgrade) package as a `before` visitor.
+
 ### `createSubInstructionsFromEnumArgsVisitor`
 
 This visitor splits an instruction into multiple sub-instructions by using an enum argument such that each of its variants creates a different sub-instruction. It accepts an object where the keys are the instruction names and the values are the enum argument names that will be used to split the instruction.

--- a/packages/visitors/src/checkCodamaVersionVisitor.ts
+++ b/packages/visitors/src/checkCodamaVersionVisitor.ts
@@ -1,0 +1,29 @@
+import { CODAMA_ERROR__VERSION_MISMATCH, CodamaError } from '@codama/errors';
+import { CODAMA_VERSION, getCodamaVersionMajor, type RootNode } from '@codama/nodes';
+import { rootNodeVisitor, type Visitor } from '@codama/visitors-core';
+
+/**
+ * A visitor that checks the visited IDL's `version` against the Codama
+ * spec version supported by the installed packages, mirroring the check
+ * performed by `createFromRoot`. It throws a
+ * {@link CODAMA_ERROR__VERSION_MISMATCH} error when the majors differ or the
+ * version cannot be parsed, and returns the IDL unchanged otherwise.
+ *
+ * Mainly useful at IDL-ingestion boundaries that bypass `createFromRoot` —
+ * e.g. as a `before` visitor in a Codama CLI config to fail fast on
+ * incompatible IDLs:
+ *
+ * ```json
+ * { "idl": "program/idl.json", "before": ["@codama/visitors#checkCodamaVersionVisitor"] }
+ * ```
+ */
+export function checkCodamaVersionVisitor(): Visitor<RootNode, 'rootNode'> {
+    return rootNodeVisitor(root => {
+        const rootMajor = getCodamaVersionMajor(root.version);
+        if (rootMajor !== null && rootMajor === getCodamaVersionMajor(CODAMA_VERSION)) return root;
+        throw new CodamaError(CODAMA_ERROR__VERSION_MISMATCH, {
+            codamaVersion: CODAMA_VERSION,
+            rootVersion: root.version,
+        });
+    });
+}

--- a/packages/visitors/src/index.ts
+++ b/packages/visitors/src/index.ts
@@ -1,6 +1,7 @@
 export * from '@codama/visitors-core';
 
 export * from './addPdasVisitor';
+export * from './checkCodamaVersionVisitor';
 export * from './createSubInstructionsFromEnumArgsVisitor';
 export * from './deduplicateIdenticalDefinedTypesVisitor';
 export * from './fillDefaultPdaSeedValuesVisitor';

--- a/packages/visitors/test/checkCodamaVersionVisitor.test.ts
+++ b/packages/visitors/test/checkCodamaVersionVisitor.test.ts
@@ -1,0 +1,46 @@
+import { CODAMA_ERROR__VERSION_MISMATCH, CodamaError } from '@codama/errors';
+import { CODAMA_VERSION, CodamaVersion, programNode, rootNode } from '@codama/nodes';
+import { visit } from '@codama/visitors-core';
+import { expect, test } from 'vitest';
+
+import { checkCodamaVersionVisitor } from '../src';
+
+test('it accepts IDLs sharing the spec major and returns them unchanged', () => {
+    // Given IDLs whose versions share the spec major.
+    const program = programNode({ name: 'myProgram', publicKey: '1111' });
+    const latest = rootNode(program);
+    const oldest = { ...rootNode(program), version: '1.0.0' as CodamaVersion };
+
+    // When we visit them with the check visitor, then they are returned unchanged.
+    expect(visit(latest, checkCodamaVersionVisitor())).toBe(latest);
+    expect(visit(oldest, checkCodamaVersionVisitor())).toBe(oldest);
+});
+
+test('it rejects IDLs from another spec major', () => {
+    // Given IDLs whose versions belong to other spec majors.
+    const program = programNode({ name: 'myProgram', publicKey: '1111' });
+    const newer = { ...rootNode(program), version: '99.0.0' as CodamaVersion };
+    const older = { ...rootNode(program), version: '0.21.3' as CodamaVersion };
+
+    // When we visit them with the check visitor, then we expect version mismatch errors.
+    expect(() => visit(newer, checkCodamaVersionVisitor())).toThrow(
+        new CodamaError(CODAMA_ERROR__VERSION_MISMATCH, { codamaVersion: CODAMA_VERSION, rootVersion: '99.0.0' }),
+    );
+    expect(() => visit(older, checkCodamaVersionVisitor())).toThrow(
+        new CodamaError(CODAMA_ERROR__VERSION_MISMATCH, { codamaVersion: CODAMA_VERSION, rootVersion: '0.21.3' }),
+    );
+});
+
+test('it rejects IDLs with unparsable versions', () => {
+    // Given an IDL whose version cannot be parsed.
+    const program = programNode({ name: 'myProgram', publicKey: '1111' });
+    const root = { ...rootNode(program), version: 'not-a-version' as CodamaVersion };
+
+    // When we visit it with the check visitor, then we expect a version mismatch error.
+    expect(() => visit(root, checkCodamaVersionVisitor())).toThrow(
+        new CodamaError(CODAMA_ERROR__VERSION_MISMATCH, {
+            codamaVersion: CODAMA_VERSION,
+            rootVersion: 'not-a-version',
+        }),
+    );
+});


### PR DESCRIPTION
This PR adds a lightweight `checkCodamaVersionVisitor` to `@codama/visitors`, filling the gap where the CLI accepts any Codama-standard JSON verbatim with zero version checking. The visitor mirrors the check performed by `createFromRoot`: it compares the visited IDL's major against the supported `CODAMA_VERSION` via `getCodamaVersionMajor` and throws the existing `CODAMA_ERROR__VERSION_MISMATCH` on mismatch or unparsable versions, returning the document unchanged otherwise. Following the no-implicit-auto-upgrade policy, nothing is wired into the CLI automatically; instead, the CLI README gains two recipes documenting the `before` visitor pattern: upgrading legacy IDLs via `@codama/upgrade` and failing fast on incompatible ones via `@codama/visitors#checkCodamaVersionVisitor`. The visitors README documents the new visitor alongside the existing ones. This is Phase 3 of the v2 migration framework plan.
