### PR TITLE
Bump the spec pins to 1.9.2

### DIFF
--- a/.changeset/sweet-pianos-glow.md
+++ b/.changeset/sweet-pianos-glow.md
@@ -1,0 +1,6 @@
+---
+'@codama/node-types': patch
+'@codama/nodes': patch
+---
+
+Bump the generated `CODAMA_VERSION` to 1.9.2 and refresh the generated documentation from the latest spec.

--- a/packages/node-types/src/generated/RootNode.ts
+++ b/packages/node-types/src/generated/RootNode.ts
@@ -2,8 +2,8 @@ import type { ProgramNode } from './ProgramNode';
 import type { CodamaVersion } from './shared/codamaVersion';
 
 /**
- * The root of a Codama IDL document.
- * Pairs a primary program with any number of additional programs and tags the document with the spec version.
+ * The root of a Codama IDL.
+ * Pairs a primary program with any number of additional programs and tags the IDL with the spec version.
  *
  * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/96c43c75-5925-4b6b-a1e0-8b8c61317cfe)
  */
@@ -15,15 +15,15 @@ export interface RootNode<
 
     // Data.
     /**
-     * A literal marker identifying the document as a Codama IDL.
+     * A literal marker identifying the JSON object as a Codama IDL.
      * This allows other communities to fork the Codama standard under a different marker.
      */
     readonly standard: 'codama';
-    /** The Codama spec version this document conforms to. */
+    /** The Codama spec version this IDL conforms to. */
     readonly version: CodamaVersion;
 
     // Children.
-    /** The primary program described by the document. */
+    /** The primary program described by the IDL. */
     readonly program: TProgram;
     /** Additional programs referenced by the primary program. */
     readonly additionalPrograms?: TAdditionalPrograms;

--- a/packages/nodes/src/generated/RootNode.ts
+++ b/packages/nodes/src/generated/RootNode.ts
@@ -3,8 +3,8 @@ import type { ProgramNode, RootNode } from '@codama/node-types';
 import { CODAMA_VERSION } from './codamaVersion';
 
 /**
- * The root of a Codama IDL document.
- * Pairs a primary program with any number of additional programs and tags the document with the spec version.
+ * The root of a Codama IDL.
+ * Pairs a primary program with any number of additional programs and tags the IDL with the spec version.
  *
  * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/96c43c75-5925-4b6b-a1e0-8b8c61317cfe)
  */

--- a/packages/nodes/src/generated/codamaVersion.ts
+++ b/packages/nodes/src/generated/codamaVersion.ts
@@ -8,4 +8,4 @@ import type { CodamaVersion } from '@codama/node-types';
  * that need to compare an IDL's `version` against the spec
  * shape `@codama/nodes` understands.
  */
-export const CODAMA_VERSION: CodamaVersion = '1.9.1';
+export const CODAMA_VERSION: CodamaVersion = '1.9.2';

--- a/packages/spec-generators/package.json
+++ b/packages/spec-generators/package.json
@@ -13,8 +13,8 @@
     },
     "dependencies": {
         "@codama/fragments": "workspace:*",
-        "@codama/spec": "1.9.1",
-        "@codama/spec-v1": "npm:@codama/spec@1.9.1"
+        "@codama/spec": "1.9.2",
+        "@codama/spec-v1": "npm:@codama/spec@1.9.2"
     },
     "devDependencies": {
         "@types/node": "^26",

--- a/packages/upgrade/README.md
+++ b/packages/upgrade/README.md
@@ -75,4 +75,4 @@ function inspectLegacyIdl(root: v1.RootNode) {
 
 Upgrade functions are pure JSON-tree-in, JSON-tree-out transforms with no environment access, which keeps the upgrade chain portable to other implementations of the Codama standard.
 
-Maintainers: the playbook for releasing a new major of the Codama standard lives in the repository-root [CONTRIBUTING](../../CONTRIBUTING.md).
+Maintainers: the playbook for releasing a new major of the Codama standard lives in the repository-root [CONTRIBUTING](https://github.com/codama-idl/codama/blob/main/CONTRIBUTING.md).

--- a/packages/upgrade/src/v1/generated/RootNode.ts
+++ b/packages/upgrade/src/v1/generated/RootNode.ts
@@ -2,8 +2,8 @@ import type { ProgramNode } from './ProgramNode';
 import type { CodamaVersion } from './shared/codamaVersion';
 
 /**
- * The root of a Codama IDL document.
- * Pairs a primary program with any number of additional programs and tags the document with the spec version.
+ * The root of a Codama IDL.
+ * Pairs a primary program with any number of additional programs and tags the IDL with the spec version.
  *
  * ![Diagram](https://github.com/codama-idl/codama/assets/3642397/96c43c75-5925-4b6b-a1e0-8b8c61317cfe)
  */
@@ -15,15 +15,15 @@ export interface RootNode<
 
     // Data.
     /**
-     * A literal marker identifying the document as a Codama IDL.
+     * A literal marker identifying the JSON object as a Codama IDL.
      * This allows other communities to fork the Codama standard under a different marker.
      */
     readonly standard: 'codama';
-    /** The Codama spec version this document conforms to. */
+    /** The Codama spec version this IDL conforms to. */
     readonly version: CodamaVersion;
 
     // Children.
-    /** The primary program described by the document. */
+    /** The primary program described by the IDL. */
     readonly program: TProgram;
     /** Additional programs referenced by the primary program. */
     readonly additionalPrograms?: TAdditionalPrograms;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,11 +328,11 @@ importers:
         specifier: workspace:*
         version: link:../fragments
       '@codama/spec':
-        specifier: 1.9.1
-        version: 1.9.1
+        specifier: 1.9.2
+        version: 1.9.2
       '@codama/spec-v1':
-        specifier: npm:@codama/spec@1.9.1
-        version: '@codama/spec@1.9.1'
+        specifier: npm:@codama/spec@1.9.2
+        version: '@codama/spec@1.9.2'
     devDependencies:
       '@types/node':
         specifier: ^26
@@ -485,8 +485,8 @@ packages:
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
-  '@codama/spec@1.9.1':
-    resolution: {integrity: sha512-6GNKNt6zvxBBvtbokh1VwjTb09Kjc79a44Vt0v7Lk3Hq+ZaI5/uimk9F8bM1IlBuKhBPZmtrAON/X7QPSxqriA==}
+  '@codama/spec@1.9.2':
+    resolution: {integrity: sha512-QcNSRZNp13AardSMiip+Ef38+X30TbARS6vYriZwxXla1y/TLTJxj1FNdJ014kWUPpR7IvkR2Gc7cse0KEbuiw==}
     engines: {node: '>=22.12.0'}
 
   '@esbuild/aix-ppc64@0.27.0':
@@ -3412,7 +3412,7 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@codama/spec@1.9.1': {}
+  '@codama/spec@1.9.2': {}
 
   '@esbuild/aix-ppc64@0.27.0':
     optional: true


### PR DESCRIPTION
This PR bumps both spec pins in `spec-generators` to `1.9.2` — the living `@codama/spec` pin and the `@codama/spec-v1` freeze alias — and regenerates. The 1.9.2 release only rewords documentation ("IDL" instead of "document"), so the diff is docblock updates across `@codama/node-types`, `@codama/nodes` and the frozen v1 snapshot in `@codama/upgrade`, plus the generated `CODAMA_VERSION` moving to `1.9.2`. The `@codama/upgrade` README's maintainer pointer also becomes an absolute link so it resolves on the npm package page.