### PR TITLE
Promote all pre-1.0 packages to 1.0.0

### DIFF
--- a/.changeset/wise-areas-see.md
+++ b/.changeset/wise-areas-see.md
@@ -1,0 +1,8 @@
+---
+'@codama/dynamic-address-resolution': major
+'@codama/dynamic-instructions': major
+'@codama/dynamic-client': major
+'@codama/fragments': major
+---
+
+Promote the package to its first stable major. No API changes are included; this aligns every published package in the monorepo with the 1.x line of the Codama standard ahead of the v2 work.


### PR DESCRIPTION
This PR adds a changeset promoting the four remaining pre-1.0 packages — `@codama/fragments`, `@codama/dynamic-client`, `@codama/dynamic-address-resolution` and `@codama/dynamic-instructions` — to 1.0.0. No API changes are included; the goal is that every published package in the monorepo sits on the 1.x line, keeping package majors and spec majors mentally aligned ahead of any v2 work.