### PR TITLE
Align branch config with the mainless release model

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,7 +17,7 @@
     ],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "1.x",
   "privatePackages": {
         "version": false,
         "tag": false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Main
 
 on:
   push:
-    branches: [main, '*.x']
+    branches: ['*.x']
   pull_request:
-    branches: [main, '*.x']
+    branches: ['*.x']
 
 concurrency:
   group: main-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR aligns the branch's configuration with the mainless release model defined in [RELEASING.md](https://github.com/codama-idl/spec/blob/1.x/RELEASING.md): `.changeset/config.json` now declares this branch as its own `baseBranch`, and the workflow triggers drop the no-longer-existing `main` branch.