### PR TITLE
Restore main as the bleeding-edge branch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,7 +17,7 @@
     ],
   "linked": [],
   "access": "public",
-  "baseBranch": "1.x",
+  "baseBranch": "main",
   "privatePackages": {
         "version": false,
         "tag": false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Main
 
 on:
   push:
-    branches: ['[0-9]+.x']
+    branches: [main, '[0-9]+.x']
   pull_request:
-    branches: ['[0-9]+.x']
+    branches: [main, '[0-9]+.x']
 
 concurrency:
   group: main-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR follows the `1.x` → `main` rename, reverting the mainless experiment in favour of a permanent `main` branch: `.changeset/config.json` points back at `main` and the workflow triggers accept `main` alongside the numeric major-branch pattern.