### PR TITLE
Adopt the release-tools automation

### DIFF
--- a/.github/workflows/cut.yml
+++ b/.github/workflows/cut.yml
@@ -1,0 +1,25 @@
+name: Cut
+
+on:
+  workflow_dispatch:
+    inputs:
+      tracking-issue:
+        description: 'Open a transition tracking issue'
+        type: boolean
+        default: false
+      announce:
+        description: 'Open the announcement thread in the ecosystem hub Discussions'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  cut:
+    uses: codama-idl/release-tools/.github/workflows/cut.yml@v1
+    with:
+      tracking-issue: ${{ inputs.tracking-issue }}
+      announce: ${{ inputs.announce }}
+    secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,6 +116,7 @@ jobs:
         uses: changesets/action@v2.1.1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
+          version-script: pnpm release:version
           commit-message: '[${{ env.RELEASE_VERSION }}] Publish packages'
           pr-title: '[${{ env.RELEASE_VERSION }}] Publish packages'
           publish-script: pnpm publish-packages

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,11 @@
+name: Promote
+
+on: workflow_dispatch
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    uses: codama-idl/release-tools/.github/workflows/promote.yml@v1
+    secrets: inherit

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
         "lint": "oxlint && oxfmt --check",
         "lint:fix": "oxlint --fix && oxfmt",
         "test": "turbo run test --log-order grouped",
-        "publish-packages": "pnpm build && changeset publish"
+        "publish-packages": "pnpm build && changeset publish",
+        "release:version": "changeset version && release-tools postversion"
     },
     "devDependencies": {
         "@changesets/changelog-github": "^1.0.0",
         "@changesets/cli": "^3.0.1",
+        "@codama/release-tools": "github:codama-idl/release-tools#v1.0.0",
         "@solana-config/oxc": "^0.1.1",
         "@types/node": "^26",
         "agadoo": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@changesets/cli':
         specifier: ^3.0.1
         version: 3.0.1
+      '@codama/release-tools':
+        specifier: github:codama-idl/release-tools#v1.0.0
+        version: https://codeload.github.com/codama-idl/release-tools/tar.gz/60c0f05d093d7c307ba80c20cd78e50e9dd1eb3e
       '@solana-config/oxc':
         specifier: ^0.1.1
         version: 0.1.1(oxfmt@0.65.0)(oxlint@1.80.0(oxlint-tsgolint@7.0.2001))
@@ -484,6 +487,12 @@ packages:
   '@clack/prompts@1.7.0':
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
+
+  '@codama/release-tools@https://codeload.github.com/codama-idl/release-tools/tar.gz/60c0f05d093d7c307ba80c20cd78e50e9dd1eb3e':
+    resolution: {tarball: https://codeload.github.com/codama-idl/release-tools/tar.gz/60c0f05d093d7c307ba80c20cd78e50e9dd1eb3e}
+    version: 1.0.0
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@codama/spec@1.9.2':
     resolution: {integrity: sha512-QcNSRZNp13AardSMiip+Ef38+X30TbARS6vYriZwxXla1y/TLTJxj1FNdJ014kWUPpR7IvkR2Gc7cse0KEbuiw==}
@@ -3398,6 +3407,8 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@codama/release-tools@https://codeload.github.com/codama-idl/release-tools/tar.gz/60c0f05d093d7c307ba80c20cd78e50e9dd1eb3e': {}
 
   '@codama/spec@1.9.2': {}
 


### PR DESCRIPTION
This PR adopts [codama-idl/release-tools](https://github.com/codama-idl/release-tools) `v1.0.0` per [RELEASING.md](https://github.com/codama-idl/spec/blob/HEAD/RELEASING.md): the `postversion` guard chains after `changeset version` (blocking illegal major crossings and same-major-invariant violations in release PRs), and the `cut`/`promote` dispatch wrappers call the reusable workflows at `@v1`. Note: the guard will pass on the regenerated release PR because `changeset version` takes all public packages to major 1 (#1100's promotions); the current unversioned tree intentionally fails it until #1119 merges.