### PR TITLE
Fix byte-array PDA seeds deriving with a Borsh length prefix

### DIFF
--- a/.changeset/bright-toes-wave.md
+++ b/.changeset/bright-toes-wave.md
@@ -1,0 +1,5 @@
+---
+'@codama/nodes-from-anchor': patch
+---
+
+Fix `Vec<u8>` instruction arguments used as PDA seeds to derive from their raw bytes instead of the Borsh size-prefixed encoding. Anchor derives byte-array seeds from the unprefixed bytes, so the generated seed type previously produced a different PDA than the on-chain program for any program using a `Vec<u8>` seed.

--- a/packages/nodes-from-anchor/src/v01/PdaSeedNode.ts
+++ b/packages/nodes-from-anchor/src/v01/PdaSeedNode.ts
@@ -6,6 +6,7 @@ import {
 import {
     accountValueNode,
     argumentValueNode,
+    bytesTypeNode,
     camelCase,
     constantPdaSeedNodeFromBytes,
     InstructionArgumentNode,
@@ -51,16 +52,26 @@ export function pdaSeedNodeFromAnchorV01(
                 throw new CodamaError(CODAMA_ERROR__ANCHOR__ARGUMENT_TYPE_MISSING, { name: originalArgumentName });
             }
 
-            // Anchor uses unprefixed strings for PDA seeds even though the
-            // argument itself uses a Borsh size-prefixed string. Thus, we
-            // must recognize this case and convert the type accordingly.
+            // Anchor uses unprefixed strings and byte arrays for PDA seeds
+            // even though the arguments themselves use Borsh size-prefixed
+            // types. Thus, we must recognize both cases and convert the
+            // types accordingly.
             const isBorshString =
                 isNode(argumentNode.type, 'sizePrefixTypeNode') &&
                 isNode(argumentNode.type.type, 'stringTypeNode') &&
                 argumentNode.type.type.encoding === 'utf8' &&
                 isNode(argumentNode.type.prefix, 'numberTypeNode') &&
                 argumentNode.type.prefix.format === 'u32';
-            const argumentType = isBorshString ? stringTypeNode('utf8') : argumentNode.type;
+            const isBorshBytes =
+                isNode(argumentNode.type, 'sizePrefixTypeNode') &&
+                isNode(argumentNode.type.type, 'bytesTypeNode') &&
+                isNode(argumentNode.type.prefix, 'numberTypeNode') &&
+                argumentNode.type.prefix.format === 'u32';
+            const argumentType = isBorshString
+                ? stringTypeNode('utf8')
+                : isBorshBytes
+                  ? bytesTypeNode()
+                  : argumentNode.type;
 
             return {
                 definition: variablePdaSeedNode(argumentNode.name, argumentType),

--- a/packages/nodes-from-anchor/test/v01/pdaSeedNode.test.ts
+++ b/packages/nodes-from-anchor/test/v01/pdaSeedNode.test.ts
@@ -1,6 +1,7 @@
 import {
     accountValueNode,
     argumentValueNode,
+    bytesTypeNode,
     constantPdaSeedNodeFromBytes,
     instructionArgumentNode,
     numberTypeNode,
@@ -47,4 +48,16 @@ test('it removes the string prefix from arg Anchor seeds', () => {
 
     expect(nodes.definition).toEqual(variablePdaSeedNode('identifier', stringTypeNode('utf8')));
     expect(nodes.value).toEqual(pdaSeedValueNode('identifier', argumentValueNode('identifier')));
+});
+
+test('it removes the bytes prefix from arg Anchor seeds', () => {
+    const nodes = pdaSeedNodeFromAnchorV01({ kind: 'arg', path: 'seed_data' }, [
+        instructionArgumentNode({
+            name: 'seed_data',
+            type: sizePrefixTypeNode(bytesTypeNode(), numberTypeNode('u32')),
+        }),
+    ]);
+
+    expect(nodes.definition).toEqual(variablePdaSeedNode('seed_data', bytesTypeNode()));
+    expect(nodes.value).toEqual(pdaSeedValueNode('seed_data', argumentValueNode('seed_data')));
 });


### PR DESCRIPTION
This PR resurrects #1101 by @latent-9, which I accidentally closed whilst cleaning up stale branches (sorry again! 🙏). The original commit is cherry-picked verbatim from the PR ref, so authorship is preserved and it already has an approving review on the original thread.

In short: a `Vec<u8>` instruction argument used as a PDA seed kept its Borsh `sizePrefixTypeNode(u32, bytesTypeNode())` type when converted from an Anchor IDL, whereas Anchor derives byte-array seeds from the raw bytes. This meant generated clients computed a different PDA than the on-chain program. The fix mirrors the existing `isBorshString` special case with an `isBorshBytes` counterpart that emits a raw `bytesTypeNode()` seed.